### PR TITLE
Toon voortgangsicoon tijdens contact zoeken

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/common/contactmatcher.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/common/contactmatcher.blade.php
@@ -139,13 +139,47 @@
             <label class="block font-semibold mb-1">Contactpersoon zoeken</label>
 
             <!-- Zoekveld -->
-            <input
-                v-model="search"
-                @input="onSearch"
-                placeholder="Zoek op naam, e-mail, telefoon..."
-                class="input w-full mb-2"
-                autocomplete="off"
-            />
+            <div class="relative">
+                <input
+                    v-model="search"
+                    @input="onSearch"
+                    placeholder="Zoek op naam, e-mail, telefoon..."
+                    class="input w-full mb-2"
+                    autocomplete="off"
+                />
+                <!-- Loading spinner -->
+                <div v-if="isSearching" class="absolute right-3 top-1/2 transform -translate-y-1/2 -mb-1">
+                    <svg
+                        class="h-4 w-4 animate-spin text-gray-500"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                    >
+                        <circle
+                            class="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            stroke-width="4"
+                        ></circle>
+                        <path
+                            class="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        ></path>
+                    </svg>
+                </div>
+            </div>
+
+            <!-- Zoek status indicator -->
+            <div v-if="isSearching" class="text-xs text-gray-500 mb-2 flex items-center gap-1">
+                <svg class="h-3 w-3 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                Zoeken naar contactpersonen...
+            </div>
 
             <!-- Suggesties -->
             <ul v-if="suggestions.length" class="border rounded bg-white shadow mb-2">
@@ -267,6 +301,7 @@
                     currentPersonMatchScore: null,
                     searchTimeout: null,
                     isCreatingPerson: false,
+                    isSearching: false,
                 };
             },
 
@@ -291,7 +326,7 @@
 
                     if (!terms) return;
 
-                    this.fetchSuggestionsByLead( this.lead.id);
+                    this.fetchSuggestionsByLead(this.lead.id);
                 },
 
                 onSearch() {
@@ -299,21 +334,26 @@
 
                     if (!this.search) {
                         this.suggestions = [];
+                        this.isSearching = false;
                         return;
                     }
 
+                    this.isSearching = true;
                     this.searchTimeout = setTimeout(() => {
                         this.fetchSuggestions(this.search);
                     }, 300);
                 },
 
                 async fetchSuggestionsByLead(leadId) {
+                    this.isSearching = true;
                     try {
                         const response = await axios.get('/admin/contacts/persons/searchByLead/' + leadId);
                         this.suggestions = response.data.data || [];
                     } catch (e) {
                         console.warn('Zoekopdracht mislukt:', e);
                         this.suggestions = [];
+                    } finally {
+                        this.isSearching = false;
                     }
                 },
 
@@ -334,6 +374,8 @@
                     } catch (e) {
                         console.warn('Zoekopdracht mislukt:', e);
                         this.suggestions = [];
+                    } finally {
+                        this.isSearching = false;
                     }
                 },
 
@@ -341,6 +383,7 @@
                     this.selectedPerson = person;
                     this.search = '';
                     this.suggestions = [];
+                    this.isSearching = false;
                 },
 
                 async createPersonFromLead() {

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -510,13 +510,46 @@
                 <!-- Search Input -->
                 <div class="max-w-md">
                     <label class="block font-semibold mb-2">Zoek contactpersoon</label>
-                    <input
-                        v-model="search"
-                        @input="onSearch"
-                        placeholder="Zoek op naam, e-mail, telefoon..."
-                        class="input w-full"
-                        autocomplete="off"
-                    />
+                    <div class="relative">
+                        <input
+                            v-model="search"
+                            @input="onSearch"
+                            placeholder="Zoek op naam, e-mail, telefoon..."
+                            class="input w-full"
+                            autocomplete="off"
+                        />
+                        <!-- Loading spinner -->
+                        <div v-if="isSearching" class="absolute right-3 top-1/2 transform -translate-y-1/2">
+                            <svg
+                                class="h-4 w-4 animate-spin text-gray-500"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                            >
+                                <circle
+                                    class="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    stroke-width="4"
+                                ></circle>
+                                <path
+                                    class="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                ></path>
+                            </svg>
+                        </div>
+                    </div>
+                    <!-- Search status indicator -->
+                    <div v-if="isSearching" class="text-xs text-gray-500 mt-1 flex items-center gap-1">
+                        <svg class="h-3 w-3 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        Zoeken naar contactpersonen...
+                    </div>
                 </div>
 
                 <!-- Search Results -->
@@ -636,6 +669,7 @@
                         selectedPerson: null,
                         searchTimeout: null,
                         hasSearched: false,
+                        isSearching: false,
                     };
                 },
 
@@ -646,9 +680,11 @@
 
                         if (!this.search) {
                             this.suggestions = [];
+                            this.isSearching = false;
                             return;
                         }
 
+                        this.isSearching = true;
                         this.searchTimeout = setTimeout(() => {
                             this.fetchSuggestions(this.search);
                         }, 300);
@@ -666,12 +702,15 @@
                             console.warn('Zoekopdracht mislukt:', e);
                             this.suggestions = [];
                             this.hasSearched = true;
+                        } finally {
+                            this.isSearching = false;
                         }
                     },
 
                     selectPerson(person) {
                         this.selectedPersonId = person.id;
                         this.selectedPerson = person;
+                        this.isSearching = false;
                         this.$emit('person-selected', person);
                     },
 


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces visual feedback for the "Contactpersoon zoeken" functionality. A spinner and text indicator now display during search operations to inform users that the system is actively searching, preventing confusion during long queries. This applies to both the main contact matcher and the step-one contact matcher components.

## How To Test This?
1.  Navigate to a page using the "Contactpersoon zoeken" component (e.g., lead creation/editing).
2.  Start typing in the "Zoek op naam, e-mail, telefoon..." field.
3.  Observe a small spinner appearing inside the input field and "Zoeken naar contactpersonen..." text with a spinner below the input while the search is active.
4.  Verify that these indicators disappear once search results are displayed or the search field is cleared.
5.  Test the automatic search on lead creation (if applicable) to ensure the indicators show there too.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
- [ ] Please make sure all the Tailwind classes are reordered.

---

[Open in Web](https://cursor.com/agents?id=bc-eed31644-bf7b-4a33-b4ac-ded51cf3bdcb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eed31644-bf7b-4a33-b4ac-ded51cf3bdcb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)