### PR TITLE
Zorg dat nieuwe lead bovenaan komt

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -133,7 +133,7 @@ class LeadController extends Controller
                     'pipeline.stages',
                     'stage',
                     'attribute_values',
-                ])->paginate(10)),
+                ])->orderBy('leads.created_at', 'desc')->paginate(10)),
 
                 'meta' => [
                     'current_page' => $paginator->currentPage(),


### PR DESCRIPTION
## Issue Reference
N/A - Addresses an issue where newly created leads were not appearing at the top of the Kanban board.

## Description
This pull request ensures that new leads are displayed at the top of their respective stages on the Lead Kanban board. Previously, leads were not explicitly ordered, causing new entries to appear inconsistently. By adding an `orderBy('leads.created_at', 'desc')` clause, the most recently created leads will now always be prioritized and shown first.

## How To Test This?
1. Create a new lead through the application.
2. Navigate to the Lead Kanban board.
3. Verify that the newly created lead appears at the top of its respective stage column.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---

[Open in Web](https://cursor.com/agents?id=bc-365bd55f-1f83-4446-8980-6d55249bd84c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-365bd55f-1f83-4446-8980-6d55249bd84c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)