### PR TITLE
Update anamnesis with BMI and clearer labels

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/anamnesis/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/anamnesis/edit.blade.php
@@ -155,9 +155,9 @@
                         </div>
                     </div>
 
-                    <!-- Medical Conditions -->
+                    <!-- Contra-indicaties -->
                     <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Medische condities</h2>
+                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Contra-indicaties</h2>
                         
                         <div class="space-y-6">
                             <!-- Metalen -->
@@ -297,7 +297,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Dormicum
+                                        Dormicum (kalmeringsmiddel)
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -316,17 +316,7 @@
                                     </div>
                                 </x-admin::form.control-group>
                             </div>
-                        </div>
-                    </div>
-                </div>
 
-                <!-- Right Panel -->
-                <div class="flex flex-1 flex-col gap-4 max-lg:flex-auto">
-                    <!-- Medical History -->
-                    <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Medische geschiedenis</h2>
-                        
-                        <div class="space-y-6">
                             <!-- Hart operatie -->
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
@@ -431,12 +421,155 @@
                                     />
                                 </div>
                             </div>
+
+                            <!-- Hartproblemen -->
+                            <div class="space-y-2">
+                                <x-admin::form.control-group>
+                                    <x-admin::form.control-group.label class="required">
+                                        Hartproblemen
+                                    </x-admin::form.control-group.label>
+                                    
+                                    <div class="flex gap-4">
+                                        <label class="flex items-center">
+                                            <input type="radio" name="heart_problems" value="1" 
+                                                   {{ $anamnesis->heart_problems == 1 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('heart_problems', this.checked)"
+                                                   class="mr-2">
+                                            Ja
+                                        </label>
+                                        <label class="flex items-center">
+                                            <input type="radio" name="heart_problems" value="0" 
+                                                   {{ $anamnesis->heart_problems == 0 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('heart_problems', false)"
+                                                   class="mr-2">
+                                            Nee
+                                        </label>
+                                    </div>
+                                </x-admin::form.control-group>
+                                
+                                <div id="heart_problems_comment" class="mt-2" style="display: {{ $anamnesis->heart_problems == 1 ? 'block' : 'none' }}">
+                                    <x-admin::form.control-group.control
+                                        type="text"
+                                        name="heart_problems_notes"
+                                        :value="$anamnesis->heart_problems_notes"
+                                        placeholder="Toelichting hartklachten"
+                                    />
+                                </div>
+                            </div>
+
+                            <!-- Rugklachten -->
+                            <div class="space-y-2">
+                                <x-admin::form.control-group>
+                                    <x-admin::form.control-group.label class="required">
+                                        Rugklachten
+                                    </x-admin::form.control-group.label>
+                                    
+                                    <div class="flex gap-4">
+                                        <label class="flex items-center">
+                                            <input type="radio" name="back_problems" value="1" 
+                                                   {{ $anamnesis->back_problems == 1 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('back_problems', this.checked)"
+                                                   class="mr-2">
+                                            Ja
+                                        </label>
+                                        <label class="flex items-center">
+                                            <input type="radio" name="back_problems" value="0" 
+                                                   {{ $anamnesis->back_problems == 0 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('back_problems', false)"
+                                                   class="mr-2">
+                                            Nee
+                                        </label>
+                                    </div>
+                                </x-admin::form.control-group>
+                                
+                                <div id="back_problems_comment" class="mt-2" style="display: {{ $anamnesis->back_problems == 1 ? 'block' : 'none' }}">
+                                    <x-admin::form.control-group.control
+                                        type="text"
+                                        name="back_problems_notes"
+                                        :value="$anamnesis->back_problems_notes"
+                                        placeholder="Toelichting rugklachten"
+                                    />
+                                </div>
+                            </div>
+
+                            <!-- Allergie -->
+                            <div class="space-y-2">
+                                <x-admin::form.control-group>
+                                    <x-admin::form.control-group.label class="required">
+                                        Heeft u allergieën?
+                                    </x-admin::form.control-group.label>
+                                    
+                                    <div class="flex gap-4">
+                                        <label class="flex items-center">
+                                            <input type="radio" name="allergies" value="1" 
+                                                   {{ $anamnesis->allergies == 1 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('allergies', this.checked)"
+                                                   class="mr-2">
+                                            Ja
+                                        </label>
+                                        <label class="flex items-center">
+                                            <input type="radio" name="allergies" value="0" 
+                                                   {{ $anamnesis->allergies == 0 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('allergies', false)"
+                                                   class="mr-2">
+                                            Nee
+                                        </label>
+                                    </div>
+                                </x-admin::form.control-group>
+                                
+                                <div id="allergies_comment" class="mt-2" style="display: {{ $anamnesis->allergies == 1 ? 'block' : 'none' }}">
+                                    <x-admin::form.control-group.control
+                                        type="text"
+                                        name="allergies_notes"
+                                        :value="$anamnesis->allergies_notes"
+                                        placeholder="Toelichting allergie"
+                                    />
+                                </div>
+                            </div>
+
+                            <!-- Spijsverteringsklachten -->
+                            <div class="space-y-2">
+                                <x-admin::form.control-group>
+                                    <x-admin::form.control-group.label class="required">
+                                        Spijsverteringsklachten
+                                    </x-admin::form.control-group.label>
+                                    
+                                    <div class="flex gap-4">
+                                        <label class="flex items-center">
+                                            <input type="radio" name="digestive_problems" value="1" 
+                                                   {{ $anamnesis->digestive_problems == 1 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('digestive_problems', this.checked)"
+                                                   class="mr-2">
+                                            Ja
+                                        </label>
+                                        <label class="flex items-center">
+                                            <input type="radio" name="digestive_problems" value="0" 
+                                                   {{ $anamnesis->digestive_problems == 0 ? 'checked' : '' }}
+                                                   onchange="toggleCommentField('digestive_problems', false)"
+                                                   class="mr-2">
+                                            Nee
+                                        </label>
+                                    </div>
+                                </x-admin::form.control-group>
+                                
+                                <div id="digestive_problems_comment" class="mt-2" style="display: {{ $anamnesis->digestive_problems == 1 ? 'block' : 'none' }}">
+                                    <x-admin::form.control-group.control
+                                        type="text"
+                                        name="digestive_problems_notes"
+                                        :value="$anamnesis->digestive_problems_notes"
+                                        placeholder="Toelichting spijsvertering"
+                                    />
+                                </div>
+                            </div>
                         </div>
                     </div>
+                </div>
 
-                    <!-- Hereditary Conditions -->
+                <!-- Right Panel -->
+                <div class="flex flex-1 flex-col gap-4 max-lg:flex-auto">
+                    <!-- Gezondheid & Erfelijkheden -->
                     <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Erfelijke aandoeningen</h2>
+                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Gezondheid & Erfelijkheden</h2>
                         
                         <div class="space-y-6">
                             <!-- Hart erfelijk -->
@@ -543,19 +676,12 @@
                                     />
                                 </div>
                             </div>
-                        </div>
-                    </div>
 
-                                        <!-- Lifestyle -->
-                    <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-                        <h2 class="mb-4 text-lg font-semibold dark:text-white">Levensstijl</h2>
-                        
-                        <div class="space-y-6">
                             <!-- Roken -->
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Roken
+                                        Rookt u?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -590,7 +716,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Diabetes
+                                        Heeft u diabetes?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -625,7 +751,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Actief
+                                        Bent u lichamelijk actief?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -645,146 +771,6 @@
                                 </x-admin::form.control-group>
                             </div>
 
-                            <!-- Spijsverteringsklachten -->
-                            <div class="space-y-2">
-                                <x-admin::form.control-group>
-                                    <x-admin::form.control-group.label class="required">
-                                        Spijsverteringsklachten
-                                    </x-admin::form.control-group.label>
-                                    
-                                    <div class="flex gap-4">
-                                        <label class="flex items-center">
-                                            <input type="radio" name="digestive_problems" value="1" 
-                                                   {{ $anamnesis->digestive_problems == 1 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('digestive_problems', this.checked)"
-                                                   class="mr-2">
-                                            Ja
-                                        </label>
-                                        <label class="flex items-center">
-                                            <input type="radio" name="digestive_problems" value="0" 
-                                                   {{ $anamnesis->digestive_problems == 0 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('digestive_problems', false)"
-                                                   class="mr-2">
-                                            Nee
-                                        </label>
-                                    </div>
-                                </x-admin::form.control-group>
-                                
-                                <div id="digestive_problems_comment" class="mt-2" style="display: {{ $anamnesis->digestive_problems == 1 ? 'block' : 'none' }}">
-                                    <x-admin::form.control-group.control
-                                        type="text"
-                                        name="digestive_problems_notes"
-                                        :value="$anamnesis->digestive_problems_notes"
-                                        placeholder="Toelichting spijsvertering"
-                                    />
-                                </div>
-                            </div>
-
-                            <!-- Allergie -->
-                            <div class="space-y-2">
-                                <x-admin::form.control-group>
-                                    <x-admin::form.control-group.label class="required">
-                                        Allergie
-                                    </x-admin::form.control-group.label>
-                                    
-                                    <div class="flex gap-4">
-                                        <label class="flex items-center">
-                                            <input type="radio" name="allergies" value="1" 
-                                                   {{ $anamnesis->allergies == 1 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('allergies', this.checked)"
-                                                   class="mr-2">
-                                            Ja
-                                        </label>
-                                        <label class="flex items-center">
-                                            <input type="radio" name="allergies" value="0" 
-                                                   {{ $anamnesis->allergies == 0 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('allergies', false)"
-                                                   class="mr-2">
-                                            Nee
-                                        </label>
-                                    </div>
-                                </x-admin::form.control-group>
-                                
-                                <div id="allergies_comment" class="mt-2" style="display: {{ $anamnesis->allergies == 1 ? 'block' : 'none' }}">
-                                    <x-admin::form.control-group.control
-                                        type="text"
-                                        name="allergies_notes"
-                                        :value="$anamnesis->allergies_notes"
-                                        placeholder="Toelichting allergie"
-                                    />
-                                </div>
-                            </div>
-
-                            <!-- Rugklachten -->
-                            <div class="space-y-2">
-                                <x-admin::form.control-group>
-                                    <x-admin::form.control-group.label class="required">
-                                        Rugklachten
-                                    </x-admin::form.control-group.label>
-                                    
-                                    <div class="flex gap-4">
-                                        <label class="flex items-center">
-                                            <input type="radio" name="back_problems" value="1" 
-                                                   {{ $anamnesis->back_problems == 1 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('back_problems', this.checked)"
-                                                   class="mr-2">
-                                            Ja
-                                        </label>
-                                        <label class="flex items-center">
-                                            <input type="radio" name="back_problems" value="0" 
-                                                   {{ $anamnesis->back_problems == 0 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('back_problems', false)"
-                                                   class="mr-2">
-                                            Nee
-                                        </label>
-                                    </div>
-                                </x-admin::form.control-group>
-                                
-                                <div id="back_problems_comment" class="mt-2" style="display: {{ $anamnesis->back_problems == 1 ? 'block' : 'none' }}">
-                                    <x-admin::form.control-group.control
-                                        type="text"
-                                        name="back_problems_notes"
-                                        :value="$anamnesis->back_problems_notes"
-                                        placeholder="Toelichting rugklachten"
-                                    />
-                                </div>
-                            </div>
-
-                            <!-- Hartproblemen -->
-                            <div class="space-y-2">
-                                <x-admin::form.control-group>
-                                    <x-admin::form.control-group.label class="required">
-                                        Hartproblemen
-                                    </x-admin::form.control-group.label>
-                                    
-                                    <div class="flex gap-4">
-                                        <label class="flex items-center">
-                                            <input type="radio" name="heart_problems" value="1" 
-                                                   {{ $anamnesis->heart_problems == 1 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('heart_problems', this.checked)"
-                                                   class="mr-2">
-                                            Ja
-                                        </label>
-                                        <label class="flex items-center">
-                                            <input type="radio" name="heart_problems" value="0" 
-                                                   {{ $anamnesis->heart_problems == 0 ? 'checked' : '' }}
-                                                   onchange="toggleCommentField('heart_problems', false)"
-                                                   class="mr-2">
-                                            Nee
-                                        </label>
-                                    </div>
-                                </x-admin::form.control-group>
-                                
-                                <div id="heart_problems_comment" class="mt-2" style="display: {{ $anamnesis->heart_problems == 1 ? 'block' : 'none' }}">
-                                    <x-admin::form.control-group.control
-                                        type="text"
-                                        name="heart_problems_notes"
-                                        :value="$anamnesis->heart_problems_notes"
-                                        placeholder="Toelichting hartklachten"
-                                    />
-                                </div>
-                            </div>
-
                             <!-- Risico hartinfarct -->
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
@@ -802,6 +788,8 @@
                             </div>
                         </div>
                     </div>
+
+
 
                     <!-- Final Notes -->
                     <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">

--- a/packages/Webkul/Admin/src/Resources/views/anamnesis/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/anamnesis/edit.blade.php
@@ -443,7 +443,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Hart erfelijk
+                                        Hartafwijking?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -478,7 +478,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Vaat erfelijk
+                                        Komt / kwam er in naaste familie hart- en/of vaatziekten voor?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">
@@ -513,7 +513,7 @@
                             <div class="space-y-2">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
-                                        Tumoren erfelijk
+                                        Komt / kwam er in de naaste familie kanker voor?
                                     </x-admin::form.control-group.label>
                                     
                                     <div class="flex gap-4">

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/anamnesis.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/anamnesis.blade.php
@@ -136,13 +136,13 @@
                     'hereditary_heart' => 'Hartafwijking',
                     'hereditary_vascular' => 'Hart-/vaatziekten familie',
                     'hereditary_tumors' => 'Kanker familie',
-                    'allergies' => 'Allergie',
+                    'allergies' => 'Allergieën',
                     'back_problems' => 'Rugklachten',
                     'heart_problems' => 'Hartproblemen',
-                    'smoking' => 'Roken',
+                    'smoking' => 'Rookt',
                     'diabetes' => 'Diabetes',
                     'digestive_problems' => 'Spijsverteringsklachten',
-                    'active' => 'Actief'
+                    'active' => 'Lichamelijk actief'
                 ])->filter(function($label, $field) use ($lead) {
                     return $lead->anamnesis->{$field} == 1;
                 });

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/anamnesis.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/anamnesis.blade.php
@@ -51,6 +51,74 @@
                             <span class="font-medium dark:text-white">{{ $lead->anamnesis->weight }} kg</span>
                         </div>
                     @endif
+                    
+                    <!-- BMI Calculation and Display -->
+                    @if($lead->anamnesis->height && $lead->anamnesis->weight)
+                        @php
+                            $heightInMeters = $lead->anamnesis->height / 100;
+                            $bmi = round($lead->anamnesis->weight / ($heightInMeters * $heightInMeters), 1);
+                            
+                            // BMI categories and colors
+                            if ($bmi < 18.5) {
+                                $bmiCategory = 'Ondergewicht';
+                                $bmiColor = 'bg-blue-500';
+                                $bmiTextColor = 'text-blue-700';
+                                $bmiBgColor = 'bg-blue-50';
+                            } elseif ($bmi < 25) {
+                                $bmiCategory = 'Normaal gewicht';
+                                $bmiColor = 'bg-green-500';
+                                $bmiTextColor = 'text-green-700';
+                                $bmiBgColor = 'bg-green-50';
+                            } elseif ($bmi < 30) {
+                                $bmiCategory = 'Overgewicht';
+                                $bmiColor = 'bg-yellow-500';
+                                $bmiTextColor = 'text-yellow-700';
+                                $bmiBgColor = 'bg-yellow-50';
+                            } else {
+                                $bmiCategory = 'Obesitas';
+                                $bmiColor = 'bg-red-500';
+                                $bmiTextColor = 'text-red-700';
+                                $bmiBgColor = 'bg-red-50';
+                            }
+                            
+                            // Calculate position for BMI indicator (BMI scale from 15 to 40)
+                            $bmiPosition = min(max(($bmi - 15) / 25 * 100, 0), 100);
+                        @endphp
+                        
+                        <div class="mt-4 p-3 {{ $bmiBgColor }} rounded-lg border">
+                            <div class="flex justify-between items-center mb-2">
+                                <span class="text-gray-600 dark:text-gray-400">BMI:</span>
+                                <span class="font-bold {{ $bmiTextColor }}">{{ $bmi }} - {{ $bmiCategory }}</span>
+                            </div>
+                            
+                            <!-- BMI Visual Bar -->
+                            <div class="relative">
+                                <div class="w-full h-6 bg-gray-200 rounded-full overflow-hidden">
+                                    <!-- BMI scale background -->
+                                    <div class="h-full flex">
+                                        <div class="bg-blue-300 flex-1"></div>      <!-- Underweight -->
+                                        <div class="bg-green-300 flex-1"></div>    <!-- Normal -->
+                                        <div class="bg-yellow-300 flex-1"></div>   <!-- Overweight -->
+                                        <div class="bg-red-300 flex-1"></div>      <!-- Obese -->
+                                    </div>
+                                </div>
+                                
+                                <!-- BMI indicator -->
+                                <div class="absolute top-0 h-6 w-1 {{ $bmiColor }} rounded-full transform -translate-x-1/2" 
+                                     style="left: {{ $bmiPosition }}%;">
+                                </div>
+                            </div>
+                            
+                            <!-- BMI scale labels -->
+                            <div class="flex justify-between text-xs text-gray-500 mt-1">
+                                <span>15</span>
+                                <span>18.5</span>
+                                <span>25</span>
+                                <span>30</span>
+                                <span>40</span>
+                            </div>
+                        </div>
+                    @endif
                 </div>
             @endif
 
@@ -65,9 +133,9 @@
                     'heart_surgery' => 'Hart operatie',
                     'implant' => 'Implantaat',
                     'surgeries' => 'Operaties',
-                    'hereditary_heart' => 'Hart erfelijk',
-                    'hereditary_vascular' => 'Vaat erfelijk',
-                    'hereditary_tumors' => 'Tumoren erfelijk',
+                    'hereditary_heart' => 'Hartafwijking',
+                    'hereditary_vascular' => 'Hart-/vaatziekten familie',
+                    'hereditary_tumors' => 'Kanker familie',
                     'allergies' => 'Allergie',
                     'back_problems' => 'Rugklachten',
                     'heart_problems' => 'Hartproblemen',


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
This pull request enhances the clarity and usability of anamnesis data by:
*   **Adding a visual BMI indicator** to the lead view, providing a quick and clear overview of a client's BMI status.
*   **Improving the clarity of various anamnesis field labels** by replacing cryptic descriptions with more descriptive and user-friendly text.
*   **Reorganizing the anamnesis edit form** into two logical categories, 'Contra-indicaties' and 'Gezondheid & Erfelijkheden', to enhance data entry and readability.

## How To Test This?
1.  **Verify BMI display:**
    *   Navigate to `/admin/leads/view/[id]` for a lead with both height and weight recorded in their anamnesis.
    *   Confirm that the BMI is calculated and displayed with a color-coded bar and category.
2.  **Verify updated labels and categories:**
    *   Navigate to `/admin/anamnesis/edit/[id]`.
    *   Check that the form fields are now organized under 'Contra-indicaties' and 'Gezondheid & Erfelijkheden'.
    *   Confirm that labels such as "Hart erfelijk", "Vaat erfelijk", "Tumoren erfelijk", "Dormicum", "Actief", "Allergie", "Roken", and "Diabetes" have been updated to their new, clearer versions.
    *   Ensure that the comment fields still toggle correctly for relevant questions.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-638e2a3e-3ed7-4f82-af12-b8910cd0b866">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-638e2a3e-3ed7-4f82-af12-b8910cd0b866">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>