### PR TITLE
Update lead and kanban card

### DIFF
--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -69,7 +69,7 @@ class LeadFactory extends Factory
             'lead_type_id'           => $type->id,
             'lead_pipeline_id'       => $pipeline->id,
             'lead_pipeline_stage_id' => $stage->id,
-            'combine_order'          => false, // Default false for simplicity
+            'combine_order'          => true, // Default true
             // Personal fields - minimal defaults, can be overridden
             'first_name'             => $this->faker->firstName(),
             'last_name'              => $this->faker->lastName(),

--- a/database/migrations/2025_08_22_000006_modify_leads_table_remove_title_add_combine_order.php
+++ b/database/migrations/2025_08_22_000006_modify_leads_table_remove_title_add_combine_order.php
@@ -12,8 +12,8 @@ return new class extends Migration
             // Remove title column
             $table->dropColumn('title');
 
-            // Add combine_order boolean column (NOT NULL, default false)
-            $table->boolean('combine_order')->default(false)->after('organization_id');
+            // Add combine_order boolean column (NOT NULL, default true)
+            $table->boolean('combine_order')->default(true)->after('organization_id');
         });
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -489,7 +489,7 @@
                         lead_channel_id: '',
                         lead_source_id: '',
                         department_id: '',
-                        combine_order: 0,
+                        combine_order: 1,
                             lead_type_id: '',
                             // Personal fields for matching
                             first_name: '',

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -126,7 +126,13 @@
                                                                         <!-- Header -->
                                     <div class="flex items-start justify-between gap-2">
                                        <div class="flex items-center gap-1 min-w-0 flex-1">
-                                           <div v-if="element.persons && element.persons.length > 0" class="flex-shrink-0">
+                                           <!-- Show group icon if multiple persons, otherwise show avatar -->
+                                           <div v-if="element.persons && element.persons.length > 1" class="flex-shrink-0">
+                                               <div class="flex h-6 w-6 items-center justify-center rounded-full bg-blue-200 text-blue-900">
+                                                   <i class="icon-users text-xs"></i>
+                                               </div>
+                                           </div>
+                                           <div v-else-if="element.persons && element.persons.length === 1" class="flex-shrink-0">
                                                <x-admin::avatar ::name="element.persons[0]?.name" class="w-6 h-6" />
                                            </div>
                                            <div v-else-if="element.first_name">


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
This PR addresses two user requests:
1.  Sets the default value of the "combine order" field to `true` for both new lead creation and in the database migration. This ensures new leads default to combining orders.
2.  Updates the lead kanban card to display a group icon (`icon-users`) when a lead is associated with multiple people, providing a clearer visual distinction.

## How To Test This?
1.  **Verify "Combine Order" Default:**
    *   Navigate to the "Create Lead" page.
    *   Observe that the "Orders combineren" (Combine Order) field is pre-selected to "Ja" (Yes).
    *   Create a new lead and verify in the database or lead details that `combine_order` is `true`.
2.  **Verify Kanban Card Icon:**
    *   Create a lead and link it to **one** person. Verify the kanban card shows the person's initials.
    *   Create a lead and link it to **multiple** people. Verify the kanban card now displays a group icon (`icon-users`) instead of initials.
    *   Create a lead with **no** linked people. Verify the kanban card shows the lead's first name initial if available.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-210c42e9-f7df-404d-adcd-0301db60543b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-210c42e9-f7df-404d-adcd-0301db60543b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

