### PR TITLE
Fix missing combine_order column in leads table

### DIFF
--- a/database/migrations/2025_08_22_000006_modify_leads_table_remove_title_add_combine_order.php
+++ b/database/migrations/2025_08_22_000006_modify_leads_table_remove_title_add_combine_order.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->dropColumn('title');
 
             // Add combine_order boolean column (NOT NULL, default true)
-            $table->boolean('combine_order')->default(true)->after('organization_id');
+            $table->boolean('combine_order')->default(true);
         });
     }
 


### PR DESCRIPTION
## Issue Reference
Fixes a CI test failure related to a missing database column.

## Description
This PR resolves a `QueryException` occurring in CI tests where the `leads` table was reported to have no `combine_order` column. The issue stemmed from the migration `2025_08_22_000006_modify_leads_table_remove_title_add_combine_order.php` attempting to add the `combine_order` column `after('organization_id')`. This positional reference was causing the migration to fail during test database creation (using SQLite in-memory with `RefreshDatabase`).

By removing the `->after('organization_id')` clause, the `combine_order` column will now be added at the end of the table, ensuring it is correctly created without positional dependencies and resolving the test failure.

## How To Test This?
1.  Run the CI tests (e.g., `php artisan test`).
2.  Observe that the `Tests\Feature\LeadAddressMergeTest` (and potentially other tests relying on the `combine_order` column) now pass without a `QueryException` for the `combine_order` column.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-f540f1dd-0f7c-417e-af6f-769269077ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f540f1dd-0f7c-417e-af6f-769269077ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

