### PR TITLE
Optimaliseer lead status weergave

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -46,6 +46,11 @@ class LeadController extends Controller
     const SUPPORTED_TYPES = 'pdf,bmp,jpeg,jpg,png,webp';
 
     /**
+     * Const variable for won/lost stage codes.
+     */
+    const WON_LOST_STAGE_CODES = ['won', 'lost', 'won-hernia', 'lost-hernia'];
+
+    /**
      * Create a new controller instance.
      *
      * @return void
@@ -110,10 +115,20 @@ class LeadController extends Controller
                 ], 500);
             }
 
+        // Check if we should exclude won/lost stages for performance optimization
+        $excludeWonLost = filter_var(request()->query('exclude_won_lost', false), FILTER_VALIDATE_BOOLEAN);
+        
         if ($stageId = request()->query('pipeline_stage_id')) {
             $stages = $pipeline->stages->where('id', request()->query('pipeline_stage_id'));
         } else {
             $stages = $pipeline->stages;
+            
+            // Filter out won/lost stages if requested to improve performance
+            if ($excludeWonLost) {
+                $stages = $stages->filter(function ($stage) {
+                    return !in_array($stage->code, self::WON_LOST_STAGE_CODES);
+                });
+            }
         }
 
         foreach ($stages as $stage) {
@@ -167,7 +182,8 @@ class LeadController extends Controller
             Log::error('Error in leads.get endpoint', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
-                'request_params' => request()->all()
+                'request_params' => request()->all(),
+                'exclude_won_lost' => $excludeWonLost ?? null
             ]);
 
             return response()->json([

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -32,7 +32,6 @@
                     <div
                         class="flex min-w-[275px] max-w-[275px] flex-col gap-1 rounded-lg border border-gray-200 dark:border-gray-800"
                         v-for="(stage, index) in stageLeads"
-                        v-show="!(hideWonLost && (stage.code === 'won' || stage.code === 'lost' || stage.code === 'won-hernia' || stage.code === 'lost-hernia'))"
                     >
                         {!! view_render_event('admin.leads.index.kanban.content.stage.header.before') !!}
 
@@ -402,6 +401,7 @@
                         searchFields: '',
                         pipeline_id: "{{ request('pipeline_id') }}",
                         limit: 10,
+                        exclude_won_lost: this.hideWonLost, // Performance optimization: exclude won/lost stages when hidden
                     };
 
                     this.applied.filters.columns.forEach((column) => {
@@ -443,12 +443,13 @@
                             return response;
                         })
                         .catch(error => {
-                            console.log(error)
+                            console.error('Error fetching leads:', error);
                         });
                 },
 
                 /**
                  * Filters the leads based on the applied filters.
+                 * Clears existing data and refetches with new filters and current exclude_won_lost state.
                  *
                  * @param {object} filters - The filters to be applied.
                  * @returns {void}
@@ -459,16 +460,22 @@
                         ...filters.columns,
                     ];
 
+                    // Clear existing data before applying new filters
+                    this.stageLeads = {};
                     this.get()
                         .then(response => {
                             for (let [sortOrder, data] of Object.entries(response.data)) {
                                 this.stageLeads[sortOrder] = data;
                             }
+                        })
+                        .catch(error => {
+                            console.error('Error applying filters:', error);
                         });
                 },
 
                 /**
                  * Searches the leads based on the applied filters.
+                 * Clears existing data and refetches with new search criteria and current exclude_won_lost state.
                  *
                  * @param {object} filters - The filters to be applied.
                  * @returns {void}
@@ -479,22 +486,34 @@
                         ...filters.columns,
                     ];
 
+                    // Clear existing data before applying new search
+                    this.stageLeads = {};
                     this.get()
                         .then(response => {
                             for (let [sortOrder, data] of Object.entries(response.data)) {
                                 this.stageLeads[sortOrder] = data;
                             }
+                        })
+                        .catch(error => {
+                            console.error('Error applying search:', error);
                         });
                 },
 
                 /**
                  * Appends the leads to the stage.
+                 * Ensures the exclude_won_lost parameter is included for performance optimization.
                  *
                  * @param {object} params - The parameters to be appended.
                  * @returns {void}
                  */
                 append(params) {
-                    this.get(params)
+                    // Ensure exclude_won_lost parameter is included for performance optimization
+                    const paramsWithExclude = {
+                        ...params,
+                        exclude_won_lost: this.hideWonLost,
+                    };
+                    
+                    this.get(paramsWithExclude)
                         .then(response => {
                             for (let [sortOrder, data] of Object.entries(response.data)) {
                                 if (! this.stageLeads[sortOrder]) {
@@ -660,18 +679,40 @@
                 },
 
                 /**
-                 * Toggle the visibility of won/lost stages
+                 * Toggle the visibility of won/lost stages and refetch data accordingly
+                 * This method optimizes performance by only fetching data for visible stages
                  */
-                                                                                                                   toggleWonLost() {
-                this.hideWonLost = !this.hideWonLost;
-                this.updateKanbans();
-                
-                // Update button text
-                const buttonText = document.getElementById('toggle-won-lost-text');
-                if (buttonText) {
-                    buttonText.textContent = this.hideWonLost ? 'Toon gewonnen/verloren' : 'Verberg gewonnen/verloren';
-                }
-            },
+                toggleWonLost() {
+                    this.hideWonLost = !this.hideWonLost;
+                    this.updateKanbans();
+                    
+                    // Update button text
+                    const buttonText = document.getElementById('toggle-won-lost-text');
+                    if (buttonText) {
+                        buttonText.textContent = this.hideWonLost ? 'Toon gewonnen/verloren' : 'Verberg gewonnen/verloren';
+                    }
+                    
+                    // Clear existing data and refetch with new exclude_won_lost parameter
+                    this.stageLeads = {};
+                    this.get()
+                        .then(response => {
+                            for (let [sortOrder, data] of Object.entries(response.data)) {
+                                this.stageLeads[sortOrder] = data;
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Error toggling won/lost stages:', error);
+                            // Revert the toggle if there's an error
+                            this.hideWonLost = !this.hideWonLost;
+                            this.updateKanbans();
+                            
+                            // Update button text back
+                            const buttonText = document.getElementById('toggle-won-lost-text');
+                            if (buttonText) {
+                                buttonText.textContent = this.hideWonLost ? 'Toon gewonnen/verloren' : 'Verberg gewonnen/verloren';
+                            }
+                        });
+                },
             }
         });
         });

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/toolbar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/toolbar.blade.php
@@ -22,7 +22,7 @@
             class="secondary-button whitespace-nowrap"
             onclick="window.toggleWonLost && window.toggleWonLost()"
         >
-            <span id="toggle-won-lost-text">Verberg gewonnen/verloren</span>
+            <span id="toggle-won-lost-text">Toon gewonnen/verloren</span>
         </button>
 
         <div class="z-10 hidden w-full divide-y divide-gray-100 rounded bg-white shadow dark:bg-gray-900"></div>


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR optimizes the lead kanban board to prevent fetching unnecessary data for 'won' and 'lost' lead stages when they are hidden.

Previously, all lead data was fetched regardless of the visibility of 'won' and 'lost' stages, leading to inefficient data transfer. This change introduces server-side filtering based on a new `exclude_won_lost` parameter. The frontend now dynamically passes this parameter to API calls, ensuring only data for visible stages is retrieved.

This significantly improves performance and reduces network load, especially for large datasets.

## How To Test This?
1.  Navigate to the Leads Kanban board.
2.  Observe the "Toon gewonnen/verloren" button. By default, 'won' and 'lost' stages should be hidden, and network requests for leads should not include data for these stages.
3.  Click the "Toon gewonnen/verloren" button. The 'won' and 'lost' stages should become visible, and new network requests should now include data for these stages.
4.  Click the button again ("Verberg gewonnen/verloren"). The 'won' and 'lost' stages should hide, and subsequent network requests should again exclude data for these stages.
5.  Verify that filtering, searching, and infinite scrolling also respect the current "hide won/lost" state, only fetching data for the visible stages.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-9c6ab9c6-ea6e-474e-8ffb-636d3cb643ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c6ab9c6-ea6e-474e-8ffb-636d3cb643ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

