### PR TITLE
Temporarily disable webhooks during import

### DIFF
--- a/app/Console/Commands/AbstractSugarCRMImport.php
+++ b/app/Console/Commands/AbstractSugarCRMImport.php
@@ -119,15 +119,15 @@ abstract class AbstractSugarCRMImport extends Command
 
     /**
      * Execute import with automatic webhook management
-     * 
-     * @param bool $dryRun Whether this is a dry run
-     * @param callable $importLogic The import logic to execute
+     *
+     * @param  bool  $dryRun  Whether this is a dry run
+     * @param  callable  $importLogic  The import logic to execute
      * @return mixed The result of the import logic
      */
     protected function executeImport(bool $dryRun, callable $importLogic)
     {
         // Disable webhooks during import to prevent external notifications
-        if (!$dryRun) {
+        if (! $dryRun) {
             $this->disableWebhooks();
         }
 
@@ -135,7 +135,7 @@ abstract class AbstractSugarCRMImport extends Command
             return $importLogic();
         } finally {
             // Always re-enable webhooks after import, even if an error occurred
-            if (!$dryRun) {
+            if (! $dryRun) {
                 $this->enableWebhooks();
             }
         }
@@ -148,9 +148,9 @@ abstract class AbstractSugarCRMImport extends Command
     {
         $originalState = config('webhook.enabled', true);
         Config::set('webhook.enabled', false);
-        
+
         $this->info('🔕 Webhooks disabled for import operation');
-        $this->info('   Original state: ' . ($originalState ? 'enabled' : 'disabled'));
+        $this->info('   Original state: '.($originalState ? 'enabled' : 'disabled'));
     }
 
     /**

--- a/app/Console/Commands/AbstractSugarCRMImport.php
+++ b/app/Console/Commands/AbstractSugarCRMImport.php
@@ -118,9 +118,33 @@ abstract class AbstractSugarCRMImport extends Command
     }
 
     /**
+     * Execute import with automatic webhook management
+     * 
+     * @param bool $dryRun Whether this is a dry run
+     * @param callable $importLogic The import logic to execute
+     * @return mixed The result of the import logic
+     */
+    protected function executeImport(bool $dryRun, callable $importLogic)
+    {
+        // Disable webhooks during import to prevent external notifications
+        if (!$dryRun) {
+            $this->disableWebhooks();
+        }
+
+        try {
+            return $importLogic();
+        } finally {
+            // Always re-enable webhooks after import, even if an error occurred
+            if (!$dryRun) {
+                $this->enableWebhooks();
+            }
+        }
+    }
+
+    /**
      * Disable webhooks during import operations
      */
-    protected function disableWebhooks(): void
+    private function disableWebhooks(): void
     {
         $originalState = config('webhook.enabled', true);
         Config::set('webhook.enabled', false);
@@ -132,7 +156,7 @@ abstract class AbstractSugarCRMImport extends Command
     /**
      * Re-enable webhooks after import operations
      */
-    protected function enableWebhooks(): void
+    private function enableWebhooks(): void
     {
         Config::set('webhook.enabled', true);
         $this->info('🔔 Webhooks re-enabled after import operation');

--- a/app/Console/Commands/AbstractSugarCRMImport.php
+++ b/app/Console/Commands/AbstractSugarCRMImport.php
@@ -6,6 +6,7 @@ use App\Enums\PersonGender;
 use App\Enums\PersonSalutation;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -114,5 +115,26 @@ abstract class AbstractSugarCRMImport extends Command
             PersonGender::Female => PersonSalutation::Mevr,
             default              => null,
         };
+    }
+
+    /**
+     * Disable webhooks during import operations
+     */
+    protected function disableWebhooks(): void
+    {
+        $originalState = config('webhook.enabled', true);
+        Config::set('webhook.enabled', false);
+        
+        $this->info('🔕 Webhooks disabled for import operation');
+        $this->info('   Original state: ' . ($originalState ? 'enabled' : 'disabled'));
+    }
+
+    /**
+     * Re-enable webhooks after import operations
+     */
+    protected function enableWebhooks(): void
+    {
+        Config::set('webhook.enabled', true);
+        $this->info('🔔 Webhooks re-enabled after import operation');
     }
 }

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -61,114 +61,115 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
-        return $this->executeImport($dryRun, function() use ($connection, $limit, $leadIds, $dryRun) {
+        return $this->executeImport($dryRun, function () use ($connection, $limit, $leadIds, $dryRun) {
             // Test connection
             $this->testConnection($connection);
 
             // Get records from SugarCRM
             $sql = DB::connection($connection)
-            ->table('leads as l')
-            ->join('leads_cstm as lc', 'l.id', '=', 'lc.id_c')
-            ->leftJoin('email_addr_bean_rel as eabr', function ($join) {
-                $join->on('eabr.bean_id', '=', 'l.id')
-                    ->where('eabr.bean_module', '=', 'Leads')
-                    ->where('eabr.deleted', '=', 0);
-            })
-            ->leftJoin('email_addresses as ea', function ($join) {
-                $join->on('ea.id', '=', 'eabr.email_address_id')
-                    ->where('ea.deleted', '=', 0);
-            })
-            ->select([
-                'l.*',
-                DB::raw('MAX(l.date_entered) as lead_date_entered'),
-                DB::raw('MAX(l.date_modified) as lead_date_modified'),
-                'lc.gender_c',
-                'lc.workflow_status_c',
-                'lc.kanaal_c',
-                'lc.soort_aanvraag_c',
-                'lc.meisjesnaam_c',
-                'lc.aang_tussenv_c',
-                'lc.partner_birthdate_c',
-                'lc.partner_gender_c',
-                'lc.lengte_c',
-                'lc.gewicht_c',
-                'lc.op_een_factuur_c',
-                'lc.anamnese_c',
-                'lc.partner_anamnese_c',
-                'lc.metalen_c',
-                'lc.medicijnen_c',
-                'lc.glaucoom_c',
-                'lc.claustrofobie_c',
-                'lc.opmerking_c',
-                'lc.partner_medicijnen_c',
-                'lc.partner_smoking_c',
-                'lc.partner_diabetes_c',
-                'lc.partner_vaat_erfelijk_c',
-                'lc.partner_gewicht_c',
-                'lc.partner_metalen_c',
-                'lc.partner_tumoren_erfelijk_c',
-                'lc.partner_glaucoom_c',
-                'lc.partner_meisjesnaam_c',
-                'lc.partner_lengte_c',
-                'lc.partner_first_name_c',
-                'lc.partner_heart_problems_c',
-                'lc.partner_rugklachten_c',
-                'lc.partner_last_name_c',
-                'lc.partner_dormicum_c',
-                'lc.partner_claustrofobie_c',
-                'lc.partner_spijsverteringsklach_c',
-                'lc.partner_hart_erfelijk_c',
-                'lc.partner_salutation_c',
-                'lc.partner_opmerking_c',
-                'lc.partner_risico_hartinfarct_c',
-                'lc.ms_sinds_c',
-                'lc.ms_type_c',
-                'lc.spreektalen_c',
-                'lc.straat_c',
-                'lc.primary_huisnr_c',
-                'lc.primary_huisnr_toevoeging_c',
-                'lc.reden_afvoeren_c',
-                'lc.nieuwsbrief_vraag_c',
-                'lc.reset_wfl_status_c',
-                'lc.particulier_c',
-                'lc.roepnaam_c',
-                'lc.voorletters_c',
-                'lc.leeftijd_c',
-                'lc.allergie_c',
-                'lc.opm_allergie_c',
-                'lc.hart_operatie_c',
-                'lc.opm_hart_operatie_c',
-                'lc.implantaat_c',
-                'lc.opm_implantaat_c',
-                'lc.tussenvoegsel_c',
-                'lc.interes_info_c',
-                'lc.operaties_c',
-                'lc.reden_afvoeren_c',
-                'lc.opm_erf_tumoren_c',
-                DB::raw('MAX(CASE WHEN eabr.primary_address = 1 THEN ea.email_address END) as email_primary'),
-                DB::raw('MIN(CASE WHEN eabr.primary_address = 0 THEN ea.email_address END) as email_any'),
-            ])
-            ->where('l.deleted', 0)
-            ->where('soort_aanvraag_c', '!=', 'ccsvi'); // Exclude 'ccsvi'
+                ->table('leads as l')
+                ->join('leads_cstm as lc', 'l.id', '=', 'lc.id_c')
+                ->leftJoin('email_addr_bean_rel as eabr', function ($join) {
+                    $join->on('eabr.bean_id', '=', 'l.id')
+                        ->where('eabr.bean_module', '=', 'Leads')
+                        ->where('eabr.deleted', '=', 0);
+                })
+                ->leftJoin('email_addresses as ea', function ($join) {
+                    $join->on('ea.id', '=', 'eabr.email_address_id')
+                        ->where('ea.deleted', '=', 0);
+                })
+                ->select([
+                    'l.*',
+                    DB::raw('MAX(l.date_entered) as lead_date_entered'),
+                    DB::raw('MAX(l.date_modified) as lead_date_modified'),
+                    'lc.gender_c',
+                    'lc.workflow_status_c',
+                    'lc.kanaal_c',
+                    'lc.soort_aanvraag_c',
+                    'lc.meisjesnaam_c',
+                    'lc.aang_tussenv_c',
+                    'lc.partner_birthdate_c',
+                    'lc.partner_gender_c',
+                    'lc.lengte_c',
+                    'lc.gewicht_c',
+                    'lc.op_een_factuur_c',
+                    'lc.anamnese_c',
+                    'lc.partner_anamnese_c',
+                    'lc.metalen_c',
+                    'lc.medicijnen_c',
+                    'lc.glaucoom_c',
+                    'lc.claustrofobie_c',
+                    'lc.opmerking_c',
+                    'lc.partner_medicijnen_c',
+                    'lc.partner_smoking_c',
+                    'lc.partner_diabetes_c',
+                    'lc.partner_vaat_erfelijk_c',
+                    'lc.partner_gewicht_c',
+                    'lc.partner_metalen_c',
+                    'lc.partner_tumoren_erfelijk_c',
+                    'lc.partner_glaucoom_c',
+                    'lc.partner_meisjesnaam_c',
+                    'lc.partner_lengte_c',
+                    'lc.partner_first_name_c',
+                    'lc.partner_heart_problems_c',
+                    'lc.partner_rugklachten_c',
+                    'lc.partner_last_name_c',
+                    'lc.partner_dormicum_c',
+                    'lc.partner_claustrofobie_c',
+                    'lc.partner_spijsverteringsklach_c',
+                    'lc.partner_hart_erfelijk_c',
+                    'lc.partner_salutation_c',
+                    'lc.partner_opmerking_c',
+                    'lc.partner_risico_hartinfarct_c',
+                    'lc.ms_sinds_c',
+                    'lc.ms_type_c',
+                    'lc.spreektalen_c',
+                    'lc.straat_c',
+                    'lc.primary_huisnr_c',
+                    'lc.primary_huisnr_toevoeging_c',
+                    'lc.reden_afvoeren_c',
+                    'lc.nieuwsbrief_vraag_c',
+                    'lc.reset_wfl_status_c',
+                    'lc.particulier_c',
+                    'lc.roepnaam_c',
+                    'lc.voorletters_c',
+                    'lc.leeftijd_c',
+                    'lc.allergie_c',
+                    'lc.opm_allergie_c',
+                    'lc.hart_operatie_c',
+                    'lc.opm_hart_operatie_c',
+                    'lc.implantaat_c',
+                    'lc.opm_implantaat_c',
+                    'lc.tussenvoegsel_c',
+                    'lc.interes_info_c',
+                    'lc.operaties_c',
+                    'lc.reden_afvoeren_c',
+                    'lc.opm_erf_tumoren_c',
+                    DB::raw('MAX(CASE WHEN eabr.primary_address = 1 THEN ea.email_address END) as email_primary'),
+                    DB::raw('MIN(CASE WHEN eabr.primary_address = 0 THEN ea.email_address END) as email_any'),
+                ])
+                ->where('l.deleted', 0)
+                ->where('soort_aanvraag_c', '!=', 'ccsvi'); // Exclude 'ccsvi'
 
-        // If specific lead IDs are provided, filter by them and ignore limit
-        if (! empty($leadIds)) {
-            $sql->whereIn('l.id', $leadIds);
-        } else {
-            $sql->groupBy('l.id')
-                ->orderBy('l.date_entered', 'desc') // Nieuwste eerst
-                ->limit($limit);
-        }
+            // If specific lead IDs are provided, filter by them and ignore limit
+            if (! empty($leadIds)) {
+                $sql->whereIn('l.id', $leadIds);
+            } else {
+                $sql->groupBy('l.id')
+                    ->orderBy('l.date_entered', 'desc') // Nieuwste eerst
+                    ->limit($limit);
+            }
 
-        $this->info($sql->toRawSql());
-        $records = $sql->get();
+            $this->info($sql->toRawSql());
+            $records = $sql->get();
 
-        $this->info('Found '.$records->count().' records to import');
+            $this->info('Found '.$records->count().' records to import');
 
             $leadByPersons = $this->extractPerson($records);
             $leadByPersonsByAnamnesis = $this->extractAnamenesis($leadByPersons);
             if ($dryRun) {
                 $this->showDryRunResults($records, $leadByPersonsByAnamnesis);
+
                 return;
             }
 

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -61,11 +61,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
-        // Disable webhooks during import to prevent external notifications
-        if (!$dryRun) {
-            $this->disableWebhooks();
-        }
-
+        return $this->executeImport($dryRun, function() use ($connection, $limit, $leadIds, $dryRun) {
             // Test connection
             $this->testConnection($connection);
 
@@ -177,13 +173,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
             }
 
             $this->importRecords($records, $leadByPersonsByAnamnesis);
-
-        } finally {
-            // Always re-enable webhooks after import, even if an error occurred
-            if (!$dryRun) {
-                $this->enableWebhooks();
-            }
-        }
+        });
     }
 
     /**

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -61,11 +61,16 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
-        // Test connection
-        $this->testConnection($connection);
+        // Disable webhooks during import to prevent external notifications
+        if (!$dryRun) {
+            $this->disableWebhooks();
+        }
 
-        // Get records from SugarCRM
-        $sql = DB::connection($connection)
+            // Test connection
+            $this->testConnection($connection);
+
+            // Get records from SugarCRM
+            $sql = DB::connection($connection)
             ->table('leads as l')
             ->join('leads_cstm as lc', 'l.id', '=', 'lc.id_c')
             ->leftJoin('email_addr_bean_rel as eabr', function ($join) {
@@ -164,16 +169,21 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
         $this->info('Found '.$records->count().' records to import');
 
-        $leadByPersons = $this->extractPerson($records);
-        $leadByPersonsByAnamnesis = $this->extractAnamenesis($leadByPersons);
-        if ($dryRun) {
-            $this->showDryRunResults($records, $leadByPersonsByAnamnesis);
+            $leadByPersons = $this->extractPerson($records);
+            $leadByPersonsByAnamnesis = $this->extractAnamenesis($leadByPersons);
+            if ($dryRun) {
+                $this->showDryRunResults($records, $leadByPersonsByAnamnesis);
+                return;
+            }
 
-            return;
+            $this->importRecords($records, $leadByPersonsByAnamnesis);
+
+        } finally {
+            // Always re-enable webhooks after import, even if an error occurred
+            if (!$dryRun) {
+                $this->enableWebhooks();
+            }
         }
-
-        $this->importRecords($records, $leadByPersonsByAnamnesis);
-
     }
 
     /**

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -51,75 +51,75 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
-        return $this->executeImport($dryRun, function() use ($connection, $table, $limit, $personIds, $dryRun) {
-            // Test connection
-            $this->testConnection($connection);
+        try {
+            return $this->executeImport($dryRun, function() use ($connection, $table, $limit, $personIds, $dryRun) {
+                // Test connection
+                $this->testConnection($connection);
 
-            // Get records from SugarCRM
-            $sql = DB::connection($connection)
-                ->table($table.' as c')
-                ->join('contacts_cstm as cm', 'c.id', '=', 'cm.id_c')
-                ->leftJoin('email_addr_bean_rel as eabr', function ($join) {
-                    $join->on('eabr.bean_id', '=', 'c.id')
-                        ->where('eabr.bean_module', '=', 'Contacts')
-                        ->where('eabr.deleted', '=', 0);
-                })
-                ->leftJoin('email_addresses as ea', function ($join) {
-                    $join->on('ea.id', '=', 'eabr.email_address_id')
-                        ->where('ea.deleted', '=', 0);
-                })
-                ->select([
-                    'c.id',
-                    'c.first_name',
-                    'c.last_name',
-                    'c.phone_work',
-                    'c.phone_mobile',
-                    'c.phone_home',
-                    'c.phone_other',
-                    'c.birthdate',
-                    'c.date_entered',
-                    'c.date_modified',
-                    // Primary address fields from contacts
-                    'c.primary_address_street',
-                    'c.primary_address_city',
-                    'c.primary_address_state',
-                    'c.primary_address_postalcode',
-                    'c.primary_address_country',
-                    'cm.gender_c',
-                    'cm.meisjesnaam_c',
-                    'cm.roepnaam_c',
-                    'cm.voorletters_c',
-                    'cm.tussenvoegsel_c',
-                    'cm.aang_tussenv_c',
-                    'cm.primary_huisnr_c',
-                    'cm.primary_huisnr_toevoeging_c',
-                    DB::raw('MAX(CASE WHEN eabr.primary_address = 1 THEN ea.email_address END) as email_primary'),
-                    DB::raw('MIN(CASE WHEN eabr.primary_address = 0 THEN ea.email_address END) as email_any'),
-                ])
-                ->where('c.deleted', 0)
-                ->whereNotNull('c.id')
-                ->where('c.id', '!=', '');
+                // Get records from SugarCRM
+                $sql = DB::connection($connection)
+                    ->table($table.' as c')
+                    ->join('contacts_cstm as cm', 'c.id', '=', 'cm.id_c')
+                    ->leftJoin('email_addr_bean_rel as eabr', function ($join) {
+                        $join->on('eabr.bean_id', '=', 'c.id')
+                            ->where('eabr.bean_module', '=', 'Contacts')
+                            ->where('eabr.deleted', '=', 0);
+                    })
+                    ->leftJoin('email_addresses as ea', function ($join) {
+                        $join->on('ea.id', '=', 'eabr.email_address_id')
+                            ->where('ea.deleted', '=', 0);
+                    })
+                    ->select([
+                        'c.id',
+                        'c.first_name',
+                        'c.last_name',
+                        'c.phone_work',
+                        'c.phone_mobile',
+                        'c.phone_home',
+                        'c.phone_other',
+                        'c.birthdate',
+                        'c.date_entered',
+                        'c.date_modified',
+                        // Primary address fields from contacts
+                        'c.primary_address_street',
+                        'c.primary_address_city',
+                        'c.primary_address_state',
+                        'c.primary_address_postalcode',
+                        'c.primary_address_country',
+                        'cm.gender_c',
+                        'cm.meisjesnaam_c',
+                        'cm.roepnaam_c',
+                        'cm.voorletters_c',
+                        'cm.tussenvoegsel_c',
+                        'cm.aang_tussenv_c',
+                        'cm.primary_huisnr_c',
+                        'cm.primary_huisnr_toevoeging_c',
+                        DB::raw('MAX(CASE WHEN eabr.primary_address = 1 THEN ea.email_address END) as email_primary'),
+                        DB::raw('MIN(CASE WHEN eabr.primary_address = 0 THEN ea.email_address END) as email_any'),
+                    ])
+                    ->where('c.deleted', 0)
+                    ->whereNotNull('c.id')
+                    ->where('c.id', '!=', '');
 
-            // If specific person IDs are provided, filter by them and ignore limit
-            if (! empty($personIds)) {
-                $sql->whereIn('c.id', $personIds);
-            } else {
-                $sql->groupBy('c.id')
-                    ->orderBy('c.date_entered', 'desc') // Nieuwste eerst
-                    ->limit($limit);
-            }
-            $records = $sql->get();
+                // If specific person IDs are provided, filter by them and ignore limit
+                if (! empty($personIds)) {
+                    $sql->whereIn('c.id', $personIds);
+                } else {
+                    $sql->groupBy('c.id')
+                        ->orderBy('c.date_entered', 'desc') // Nieuwste eerst
+                        ->limit($limit);
+                }
+                $records = $sql->get();
 
-            $this->info('Found '.$records->count().' records to import');
+                $this->info('Found '.$records->count().' records to import');
 
-            if ($dryRun) {
-                $this->showDryRunResults($records);
+                if ($dryRun) {
+                    $this->showDryRunResults($records);
+                    return;
+                }
 
-                return;
-            }
-
-            $this->importRecords($records);
-
+                $this->importRecords($records);
+            });
         } catch (Exception $e) {
             $this->error('Error: '.$e->getMessage());
             Log::error('SugarCRM import failed', [
@@ -129,9 +129,7 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
             ]);
 
             return 1;
-        });
-        
-        return 0;
+        }
     }
 
     /**

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -51,6 +51,11 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
+        // Disable webhooks during import to prevent external notifications
+        if (!$dryRun) {
+            $this->disableWebhooks();
+        }
+
         try {
             // Test connection
             $this->testConnection($connection);
@@ -129,6 +134,11 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
             ]);
 
             return 1;
+        } finally {
+            // Always re-enable webhooks after import, even if an error occurred
+            if (!$dryRun) {
+                $this->enableWebhooks();
+            }
         }
     }
 

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -51,12 +51,7 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
         }
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
-        // Disable webhooks during import to prevent external notifications
-        if (!$dryRun) {
-            $this->disableWebhooks();
-        }
-
-        try {
+        return $this->executeImport($dryRun, function() use ($connection, $table, $limit, $personIds, $dryRun) {
             // Test connection
             $this->testConnection($connection);
 
@@ -134,12 +129,9 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
             ]);
 
             return 1;
-        } finally {
-            // Always re-enable webhooks after import, even if an error occurred
-            if (!$dryRun) {
-                $this->enableWebhooks();
-            }
-        }
+        });
+        
+        return 0;
     }
 
     /**

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -52,7 +52,7 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
         $this->info('Dry run: '.($dryRun ? 'Yes' : 'No'));
 
         try {
-            return $this->executeImport($dryRun, function() use ($connection, $table, $limit, $personIds, $dryRun) {
+            return $this->executeImport($dryRun, function () use ($connection, $table, $limit, $personIds, $dryRun) {
                 // Test connection
                 $this->testConnection($connection);
 
@@ -115,6 +115,7 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
 
                 if ($dryRun) {
                     $this->showDryRunResults($records);
+
                     return;
                 }
 

--- a/app/Console/Commands/ManageLeadDuplicateCache.php
+++ b/app/Console/Commands/ManageLeadDuplicateCache.php
@@ -52,7 +52,7 @@ class ManageLeadDuplicateCache extends Command
     private function showStats(): int
     {
         $this->info('🔍 Lead Duplicate Cache Statistics');
-        $this->line('=' . str_repeat('=', 40));
+        $this->line('='.str_repeat('=', 40));
 
         $stats = $this->cacheService->getCacheStats();
 
@@ -61,7 +61,7 @@ class ManageLeadDuplicateCache extends Command
             [
                 ['Total Leads', number_format($stats['total_leads'])],
                 ['Cache Backend', $stats['cache_backend']],
-                ['Cache TTL', $stats['cache_ttl_hours'] . ' hours'],
+                ['Cache TTL', $stats['cache_ttl_hours'].' hours'],
             ]
         );
 

--- a/app/Observers/LeadWorkflowListener.php
+++ b/app/Observers/LeadWorkflowListener.php
@@ -16,6 +16,14 @@ class LeadWorkflowListener
      */
     public function handle(Lead $lead): void
     {
+        // Skip workflow processing if webhooks are disabled (e.g., during imports)
+        if (!config('webhook.enabled', true)) {
+            Log::info('LeadWorkflowListener: Skipping - webhooks are disabled (likely during import)', [
+                'lead_id' => $lead->id,
+            ]);
+            return;
+        }
+
         // Refresh the lead to get the latest data from database
         $lead->refresh();
 

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -14,6 +14,12 @@ class WebhookService
      */
     public function sendWebhook(array $data, WebhookType $webhookType, string $caller = 'unknown'): bool
     {
+        // Check if webhooks are globally disabled
+        if (!config('webhook.enabled', true)) {
+            Log::info('Webhooks are disabled - skipping webhook: '.$webhookType->value.'; from: '.$caller, $data);
+            return true; // Return true to indicate "successful" skip
+        }
+
         $url = '';
         $body = '';
         $hasN8nApiKey = false;

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -15,8 +15,9 @@ class WebhookService
     public function sendWebhook(array $data, WebhookType $webhookType, string $caller = 'unknown'): bool
     {
         // Check if webhooks are globally disabled
-        if (!config('webhook.enabled', true)) {
+        if (! config('webhook.enabled', true)) {
             Log::info('Webhooks are disabled - skipping webhook: '.$webhookType->value.'; from: '.$caller, $data);
+
             return true; // Return true to indicate "successful" skip
         }
 

--- a/config/webhook.php
+++ b/config/webhook.php
@@ -13,6 +13,17 @@ return [
     'base_url'    => env('WEBHOOK_BASE_URL', 'http://n8n:5678'),
     'n8n_api_key' => env('N8N_API_KEY', ''),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook Enable/Disable
+    |--------------------------------------------------------------------------
+    |
+    | This setting allows you to globally disable all webhooks.
+    | Useful during import operations or maintenance.
+    |
+    */
+    'enabled' => env('WEBHOOKS_ENABLED', true),
+
     'endpoints' => [
         'lead_pipeline_change'  => env('WEBHOOK_LEAD_PIPELINE_ENDPOINT', '/webhook-test/0de7745d-64c8-410b-9d23-f98f4b9c3787'),
         'lead_activity_is_done' => env('WEBHOOK_LEAD_ACTIVITY_ENDPOINT', ''),

--- a/packages/Webkul/Email/src/Providers/EmailServiceProvider.php
+++ b/packages/Webkul/Email/src/Providers/EmailServiceProvider.php
@@ -21,7 +21,6 @@ class EmailServiceProvider extends ServiceProvider
 
         $this->app->bind(InboundEmailProcessor::class, function ($app) {
             $driver = config('mail-receiver.default');
-            logger()->info('Mail receiver driver: '.$driver);
 
             if ($driver === 'sendgrid') {
                 return $app->make(SendgridEmailProcessor::class);


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
This PR implements a mechanism to temporarily disable webhooks during the execution of `import:leads` and `import:persons` commands. This prevents a flood of unwanted external notifications during large-scale bulk import operations.

Webhooks are disabled at the start of the import and automatically re-enabled at the end, even if errors occur, using a `try...finally` block. Dry-run imports are not affected and will still trigger webhooks.

## How To Test This?
1.  **Verify Webhook Disablement during Import:**
    *   Run `php artisan import:leads --limit=1` (or `import:persons`).
    *   Check the application logs (`storage/logs/laravel.log`) for messages like "🔕 Webhooks disabled for import operation" and "🔔 Webhooks re-enabled after import operation".
    *   Confirm that no actual webhooks were sent to external services during the import.
2.  **Verify Webhook Functionality outside Import:**
    *   Perform an action that normally triggers a webhook (e.g., create a new lead/person manually).
    *   Confirm that the webhook is sent as expected.
3.  **Verify Dry Run Behavior:**
    *   Run `php artisan import:leads --dry-run --limit=1`.
    *   Check the application logs and confirm that webhooks were *not* disabled and re-enabled (i.e., the "Webhooks disabled" log message should not appear).

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-b51f5052-5308-42a6-831e-ac0dacc81487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b51f5052-5308-42a6-831e-ac0dacc81487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

