### PR TITLE
Fix participant field user display

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -165,7 +165,7 @@ class ActivityController extends Controller
      */
     public function edit(int $id): View
     {
-        $activity = $this->activityRepository->findOrFail($id);
+        $activity = $this->activityRepository->with(['participants.user'])->findOrFail($id);
 
         $groups = app(GroupRepository::class)->all();
 


### PR DESCRIPTION
## Issue Reference
Resolves reported issue with "Deelnemers" field in activity edit form.

## Description
Previously, the "Deelnemers" (Participants) field in the activity edit form did not display user names because the `participants.user` relationship was not eager loaded. This PR modifies the `ActivityController` to eager load this relationship, ensuring user names are correctly displayed.

## How To Test This?
1. Navigate to `admin/activities/edit/{activity_id}` for an activity that has participants.
2. Observe the "Deelnemers" field.
3. Verify that the names of the participants are now correctly displayed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering

---
<a href="https://cursor.com/background-agent?bcId=bc-e4aa89d7-6511-49cc-ab0c-0e489e0724c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4aa89d7-6511-49cc-ab0c-0e489e0724c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

