### PR TITLE
Make group id mandatory for activities

### DIFF
--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -1138,6 +1138,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                         'is_done'       => $this->mapCallStatus($callData->status),
                         'user_id'       => $this->mapAssignedUser($callData->assigned_user_id),
                         'lead_id'       => $lead->id,
+                        'group_id'      => Department::getGroupIdForLead($lead) ?? \Webkul\User\Models\Group::first()?->id,
                     ];
 
                     $timestamps = [

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -6,6 +6,7 @@ use App\Enums\Departments;
 use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Webkul\User\Models\Group;
 
 class Department extends Model
 {
@@ -70,5 +71,48 @@ class Department extends Model
             }
         }
         throw new Exception('Group not found');
+    }
+
+    /**
+     * Map department to group ID based on Department enum.
+     * This creates the reverse mapping from department to group.
+     *
+     * @param int $departmentId The department ID
+     * @return int|null The corresponding group ID
+     */
+    public static function mapDepartmentToGroupId(int $departmentId): ?int
+    {
+        $department = self::find($departmentId);
+        
+        if (!$department) {
+            return null;
+        }
+
+        // Map department names to group names (they should match)
+        $departmentToGroupMap = [
+            Departments::HERNIA->value => 'Hernia',
+            Departments::PRIVATESCAN->value => 'Privatescan',
+        ];
+
+        $groupName = $departmentToGroupMap[$department->name] ?? $department->name;
+
+        $group = Group::where('name', $groupName)->first();
+        
+        return $group?->id;
+    }
+
+    /**
+     * Get the group ID for a lead based on its department.
+     *
+     * @param \Webkul\Lead\Models\Lead $lead
+     * @return int|null
+     */
+    public static function getGroupIdForLead($lead): ?int
+    {
+        if (!$lead->department_id) {
+            return null;
+        }
+
+        return self::mapDepartmentToGroupId($lead->department_id);
     }
 }

--- a/database/migrations/2025_12_19_000000_make_group_id_required_in_activities_table.php
+++ b/database/migrations/2025_12_19_000000_make_group_id_required_in_activities_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // First, ensure all activities have a group_id by setting a default for null values
+        // We'll use the first available group as default
+        $defaultGroupId = DB::table('groups')->first()?->id;
+        
+        if ($defaultGroupId) {
+            DB::table('activities')
+                ->whereNull('group_id')
+                ->update(['group_id' => $defaultGroupId]);
+        }
+
+        // Now make the column required (not nullable)
+        Schema::table('activities', function (Blueprint $table) {
+            $table->unsignedInteger('group_id')->nullable(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->unsignedInteger('group_id')->nullable()->change();
+        });
+    }
+};

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -3,6 +3,7 @@
 namespace Webkul\Admin\Http\Controllers\Activity;
 
 use App\Enums\WebhookType;
+use App\Models\Department;
 use App\Services\WebhookService;
 use Carbon\Carbon;
 use Exception;
@@ -102,6 +103,7 @@ class ActivityController extends Controller
             'schedule_from' => 'required_unless:type,note,file',
             'schedule_to'   => 'required_unless:type,note,file',
             'file'          => 'required_if:type,file',
+            'group_id'      => 'required|exists:groups,id',
         ]);
 
         if (request('type') === 'meeting') {
@@ -130,22 +132,44 @@ class ActivityController extends Controller
 
         Event::dispatch('activity.create.before');
 
-        // Auto-assign group if not specified but user has a group
         $data = request()->all();
         
         // Convert empty strings to null for foreign key constraints
-        foreach (['lead_id', 'group_id', 'user_id'] as $field) {
+        foreach (['lead_id', 'user_id'] as $field) {
             if (isset($data[$field]) && ($data[$field] === '' || $data[$field] === null)) {
                 $data[$field] = null;
             }
         }
         
+        // Ensure group_id is always set - it's now required
         if (!isset($data['group_id']) || !$data['group_id']) {
-            $userId = $data['user_id'] ?? auth()->guard('user')->id();
-            if ($userId) {
-                $user = \Webkul\User\Models\User::find($userId);
-                if ($user && $user->groups()->count() > 0) {
-                    $data['group_id'] = $user->groups()->first()->id;
+            // First try to get group from lead's department
+            if (isset($data['lead_id']) && $data['lead_id']) {
+                $lead = \Webkul\Lead\Models\Lead::find($data['lead_id']);
+                if ($lead) {
+                    $groupId = Department::getGroupIdForLead($lead);
+                    if ($groupId) {
+                        $data['group_id'] = $groupId;
+                    }
+                }
+            }
+            
+            // If still no group, try to get from user's groups
+            if (!isset($data['group_id']) || !$data['group_id']) {
+                $userId = $data['user_id'] ?? auth()->guard('user')->id();
+                if ($userId) {
+                    $user = \Webkul\User\Models\User::find($userId);
+                    if ($user && $user->groups()->count() > 0) {
+                        $data['group_id'] = $user->groups()->first()->id;
+                    }
+                }
+            }
+            
+            // If still no group, get the first available group as fallback
+            if (!isset($data['group_id']) || !$data['group_id']) {
+                $firstGroup = \Webkul\User\Models\Group::first();
+                if ($firstGroup) {
+                    $data['group_id'] = $firstGroup->id;
                 }
             }
         }
@@ -210,6 +234,10 @@ class ActivityController extends Controller
      */
     public function update($id): RedirectResponse|JsonResponse
     {
+        $this->validate(request(), [
+            'group_id' => 'required|exists:groups,id',
+        ]);
+
         // Get the current activity to check permissions
         $activity = $this->activityRepository->findOrFail($id);
         
@@ -236,8 +264,8 @@ class ActivityController extends Controller
 
         $data = request()->all();
         
-        // Convert empty strings to null for foreign key constraints
-        foreach (['lead_id', 'group_id', 'user_id'] as $field) {
+        // Convert empty strings to null for foreign key constraints (except group_id which is now required)
+        foreach (['lead_id', 'user_id'] as $field) {
             if (isset($data[$field]) && ($data[$field] === '' || $data[$field] === null)) {
                 $data[$field] = null;
             }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Controllers\Lead;
 
+use App\Models\Department;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Webkul\Activity\Repositories\ActivityRepository;
@@ -38,27 +39,44 @@ class ActivityController extends Controller
             'comment' => 'required_if:type,note',
             'description' => 'nullable|string',
             'user_id' => 'nullable|exists:users,id',
-            'group_id' => 'nullable|exists:groups,id',
+            'group_id' => 'required|exists:groups,id',
             'schedule_from' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'schedule_to' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'file' => 'required_if:type,file',
         ]);
         $request['comment'] = $request->description;
 
-        // Convert empty strings to null for foreign key constraints
+        // Convert empty strings to null for foreign key constraints (except group_id which is now required)
         $data = $request->all();
-        foreach (['user_id', 'group_id'] as $field) {
+        foreach (['user_id'] as $field) {
             if (isset($data[$field]) && ($data[$field] === '' || $data[$field] === null)) {
                 $data[$field] = null;
             }
         }
 
-        // Auto-assign group if not specified but user has a group
+        // Ensure group_id is always set - it's now required
         $groupId = $data['group_id'] ?? null;
-        if (!$groupId && isset($data['user_id']) && $data['user_id']) {
-            $user = User::find($data['user_id']);
-            if ($user && $user->groups()->count() > 0) {
-                $groupId = $user->groups()->first()->id;
+        if (!$groupId) {
+            // First try to get group from lead's department
+            $lead = $this->leadRepository->findOrFail($id);
+            if ($lead) {
+                $groupId = Department::getGroupIdForLead($lead);
+            }
+            
+            // If still no group, try to get from user's groups
+            if (!$groupId && isset($data['user_id']) && $data['user_id']) {
+                $user = User::find($data['user_id']);
+                if ($user && $user->groups()->count() > 0) {
+                    $groupId = $user->groups()->first()->id;
+                }
+            }
+            
+            // If still no group, get the first available group as fallback
+            if (!$groupId) {
+                $firstGroup = \Webkul\User\Models\Group::first();
+                if ($firstGroup) {
+                    $groupId = $firstGroup->id;
+                }
             }
         }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/GroupController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/GroupController.php
@@ -138,4 +138,32 @@ class GroupController extends Controller
             ], 404);
         }
     }
+
+    /**
+     * Find group by department ID.
+     */
+    public function findByDepartmentId(int $departmentId): JsonResponse
+    {
+        $groupId = \App\Models\Department::mapDepartmentToGroupId($departmentId);
+        
+        if ($groupId) {
+            $group = Group::find($groupId);
+            if ($group) {
+                return response()->json($group);
+            }
+        }
+        
+        return response()->json([
+            'message' => 'Group not found for department ID ' . $departmentId,
+        ], 404);
+    }
+
+    /**
+     * Get all groups.
+     */
+    public function apiIndex(): JsonResponse
+    {
+        $groups = $this->groupRepository->all();
+        return response()->json($groups);
+    }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
@@ -257,4 +257,13 @@ class UserController extends Controller
             'message' => trans('admin::app.settings.users.index.mass-delete-success'),
         ]);
     }
+
+    /**
+     * Get user's groups.
+     */
+    public function getUserGroups(int $id): JsonResponse
+    {
+        $user = $this->userRepository->with('groups')->findOrFail($id);
+        return response()->json($user->groups);
+    }
 }

--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -145,7 +145,7 @@
 
                     <!-- Group -->
                     <x-admin::form.control-group>
-                        <x-admin::form.control-group.label>
+                        <x-admin::form.control-group.label class="required">
                             {{ __('admin::app.activities.group') }}
                         </x-admin::form.control-group.label>
 
@@ -153,6 +153,7 @@
                             type="select"
                             name="group_id"
                             :value="old('group_id', $activity->group_id)"
+                            rules="required"
                         >
                             <option value="">{{ __('admin::app.activities.select-group') }}</option>
                             @foreach ($groups as $group)
@@ -161,6 +162,8 @@
                                 </option>
                             @endforeach
                         </x-admin::form.control-group.control>
+
+                        <x-admin::form.control-group.error control-name="group_id" />
                     </x-admin::form.control-group>
 
                     <!-- Related Entity Information -->

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/activity.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/activity.blade.php
@@ -153,7 +153,7 @@
 
                             <!-- Group -->
                             <x-admin::form.control-group>
-                                <x-admin::form.control-group.label>
+                                <x-admin::form.control-group.label class="required">
                                     @lang('admin::app.activities.group')
                                 </x-admin::form.control-group.label>
 
@@ -161,12 +161,16 @@
                                     type="select"
                                     name="group_id"
                                     :value="old('group_id')"
+                                    rules="required"
+                                    v-model="selectedGroupId"
                                 >
                                     <option value="">{{ __('admin::app.activities.select-group') }}</option>
                                     @foreach (app(Webkul\User\Repositories\GroupRepository::class)->all() as $group)
                                         <option value="{{ $group->id }}">{{ $group->name }}</option>
                                     @endforeach
                                 </x-admin::form.control-group.control>
+
+                                <x-admin::form.control-group.error control-name="group_id" />
                             </x-admin::form.control-group>
 
                             <!-- Schedule Date -->
@@ -268,6 +272,8 @@
                         value: 'call'
                     },
 
+                    selectedGroupId: null,
+
                     availableTypes: [
                         {
                             label: "{{ trans('admin::app.components.activities.actions.activity.call') }}",
@@ -280,13 +286,63 @@
                 }
             },
 
+            mounted() {
+                this.setDefaultGroupId();
+            },
+
             methods: {
                 openModal(type) {
                     this.$refs.activityModal.open();
                 },
 
+                setDefaultGroupId() {
+                    // If entity is a lead with department_id, try to map to group
+                    if (this.entity && this.entity.department_id) {
+                        // Make an API call to get the group for this department
+                        this.$axios.get(`/admin/settings/groups/api/by-department-id/${this.entity.department_id}`)
+                            .then(response => {
+                                if (response.data && response.data.id) {
+                                    this.selectedGroupId = response.data.id;
+                                }
+                            })
+                            .catch(() => {
+                                // Fallback to user's first group
+                                this.setUserDefaultGroup();
+                            });
+                    } else {
+                        this.setUserDefaultGroup();
+                    }
+                },
+
+                setUserDefaultGroup() {
+                    // Fallback: get current user's first group
+                    const currentUserId = {{ auth()->guard('user')->id() ?? 'null' }};
+                    if (currentUserId) {
+                        this.$axios.get(`/admin/settings/users/api/${currentUserId}/groups`)
+                            .then(response => {
+                                if (response.data && response.data.length > 0) {
+                                    this.selectedGroupId = response.data[0].id;
+                                }
+                            })
+                            .catch(() => {
+                                // Final fallback: get first available group
+                                this.$axios.get('/admin/settings/groups/api')
+                                    .then(response => {
+                                        if (response.data && response.data.length > 0) {
+                                            this.selectedGroupId = response.data[0].id;
+                                        }
+                                    });
+                            });
+                    }
+                },
+
                 save(params) {
                     this.isStoring = true;
+
+                    // Ensure group_id is included in params
+                    if (this.selectedGroupId) {
+                        params.group_id = this.selectedGroupId;
+                    }
 
                     this.$axios.post("{{ route('admin.activities.store') }}", params)
                         .then (response => {

--- a/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
@@ -44,6 +44,10 @@ Route::prefix('settings')->group(function () {
         Route::put('edit/{id}', 'update')->name('admin.settings.groups.update');
 
         Route::delete('{id}', 'destroy')->name('admin.settings.groups.delete');
+        
+        // API routes for groups
+        Route::get('api', 'apiIndex')->name('admin.api.groups.index');
+        Route::get('api/by-department-id/{departmentId}', 'findByDepartmentId')->name('admin.api.groups.by_department_id');
     });
 
     /**
@@ -169,6 +173,9 @@ Route::prefix('settings')->group(function () {
         Route::post('mass-update', 'massUpdate')->name('admin.settings.users.mass_update');
 
         Route::post('mass-destroy', 'massDestroy')->name('admin.settings.users.mass_delete');
+        
+        // API routes for users
+        Route::get('api/{id}/groups', 'getUserGroups')->name('admin.api.users.groups');
     });
 
     /**


### PR DESCRIPTION
## Issue Reference

## Description
This PR makes the `group_id` field mandatory for all `Activity` records to ensure consistent data.

The changes include:
*   **Database**: `group_id` is now non-nullable, with a migration to backfill existing `NULL` values to a default group.
*   **Validation**: `group_id` is required in all relevant backend controllers (`ActivityController`, `Lead ActivityController`) and frontend forms (edit and creation components).
*   **Default Assignment**: `group_id` is automatically assigned when creating an activity, prioritizing the associated lead's department, then the current user's group, and finally a system-wide default.
*   **Mapping**: The `Department` model has been updated with methods (`mapDepartmentToGroupId`, `getGroupIdForLead`) to facilitate mapping departments to groups.
*   **Import**: The `ImportLeadsFromSugarCRM` command now correctly assigns a `group_id` to new activities based on the lead's department.
*   **API**: New API endpoints have been added to retrieve groups by department ID and user-specific groups, supporting the frontend default logic.

## How To Test This?
1.  **Run Migration**: Execute `php artisan migrate` to ensure the `group_id` column is non-nullable and existing activities have a default group.
2.  **Create Activity**:
    *   Navigate to a lead's detail page and try creating a new activity. Verify that the `Group` field is pre-selected based on the lead's department (if available) or the current user's group.
    *   Attempt to create an activity without a `group_id` (if default logic doesn't apply) and confirm validation errors.
3.  **Edit Activity**:
    *   Edit an existing activity. Verify that the `Group` field is marked as required.
    *   Attempt to save an activity with an empty `group_id` and confirm validation errors.
4.  **SugarCRM Import**: If possible, run the `ImportLeadsFromSugarCRM` command and verify that newly imported activities have a `group_id` assigned based on the lead's department.

## Documentation
- [x] My pull request requires an update on the documentation repository.
The documentation for activity creation and editing, especially regarding the `group_id` field and its default assignment logic, needs to be updated.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-fbe915d1-4770-483b-ae88-9b61a380e0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbe915d1-4770-483b-ae88-9b61a380e0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

