### PR TITLE
Import emails for leads script

### DIFF
--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -17,15 +17,16 @@ use Webkul\Lead\Models\Lead;
 use Webkul\User\Models\User;
 
 /**
- * Import leads from SugarCRM database with anamnesis data and call activities
+ * Import leads from SugarCRM database with anamnesis data, call activities and email activities
  *
  * This command imports leads and their associated anamnesis data from SugarCRM,
- * as well as call activities related to those leads.
+ * as well as call activities and email activities related to those leads.
  * It uses the following relationships:
  * - leads_contacts_c: Links leads to persons
  * - leads_pcrm_anamnesepreventie_1_c: Links leads to anamnesis
  * - pcrm_anamnetie_contacts_c: Links anamnesis to persons
  * - calls table: Contains call activities where parent_type = 'Leads'
+ * - emails, emails_text, emails_beans: Contains email activities linked to leads via bean_module = 'Leads'
  */
 class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 {
@@ -45,7 +46,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
      *
      * @var string
      */
-    protected $description = 'Import leads from SugarCRM database with anamnesis data and call activities';
+    protected $description = 'Import leads from SugarCRM database with anamnesis data, call activities and email activities';
 
     /**
      * Execute the console command.
@@ -178,21 +179,24 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
             // Extract call activities for the leads
             $callActivities = $this->extractCallActivities($records);
+            
+            // Extract email activities for the leads
+            $emailActivities = $this->extractEmailActivities($records);
 
             if ($dryRun) {
-                $this->showDryRunResults($records, $leadByPersonsByAnamnesis, $callActivities);
+                $this->showDryRunResults($records, $leadByPersonsByAnamnesis, $callActivities, $emailActivities);
 
                 return;
             }
 
-            $this->importRecords($records, $leadByPersonsByAnamnesis, $callActivities);
+            $this->importRecords($records, $leadByPersonsByAnamnesis, $callActivities, $emailActivities);
         });
     }
 
     /**
      * Show dry run results
      */
-    private function showDryRunResults($records, $leadByPersonsByAnamnesis, $callActivities = []): void
+    private function showDryRunResults($records, $leadByPersonsByAnamnesis, $callActivities = [], $emailActivities = []): void
     {
         $this->info("\n=== DRY RUN RESULTS ===");
 
@@ -215,6 +219,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
             'Rel Anamnesis IDs',
             'Rel Anamnesis Count',
             'Call Activities',
+            'Email Activities',
         ];
         $rows = [];
 
@@ -243,6 +248,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
             // Get call activities for this lead
             $leadCallActivities = $callActivities[$record->id] ?? [];
             $callActivitiesInfo = empty($leadCallActivities) ? '—' : count($leadCallActivities).' calls';
+            
+            // Get email activities for this lead
+            $leadEmailActivities = $emailActivities[$record->id] ?? [];
+            $emailActivitiesInfo = empty($leadEmailActivities) ? '—' : count($leadEmailActivities).' emails';
 
             $rows[] = [
                 $record->id ?? 'N/A',
@@ -263,6 +272,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                 empty($relatedAnamnesisIds) ? '—' : implode(',', $relatedAnamnesisIds),
                 $relatedAnamnesisCount,
                 $callActivitiesInfo,
+                $emailActivitiesInfo,
             ];
         }
 
@@ -288,12 +298,32 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
             $this->line('');
             $this->info('Call Activities Summary: No call activities found or calls table not available');
         }
+        
+        // Show email activities summary
+        if (! empty($emailActivities)) {
+            $totalEmailActivities = array_sum(array_map('count', $emailActivities));
+            $this->line('');
+            $this->info('Email Activities Summary:');
+            $this->info("Total email activities found: {$totalEmailActivities}");
+
+            if ($totalEmailActivities > 0) {
+                $this->info('Email activities per lead:');
+                foreach ($emailActivities as $leadId => $emails) {
+                    $leadRecord = collect($records)->firstWhere('id', $leadId);
+                    $leadName = $leadRecord ? "{$leadRecord->first_name} {$leadRecord->last_name}" : "Lead {$leadId}";
+                    $this->info("  - {$leadName}: ".count($emails).' emails');
+                }
+            }
+        } else {
+            $this->line('');
+            $this->info('Email Activities Summary: No email activities found or emails table not available');
+        }
     }
 
     /**
      * Import records
      */
-    private function importRecords($records, $leadByPersonsByAnamnesis, $callActivities = []): void
+    private function importRecords($records, $leadByPersonsByAnamnesis, $callActivities = [], $emailActivities = []): void
     {
         $bar = $this->output->createProgressBar($records->count());
         $bar->start();
@@ -307,6 +337,8 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         $skippedNotAllPersonsFound = 0;
         $callActivitiesImported = 0;
         $callActivitiesSkipped = 0;
+        $emailActivitiesImported = 0;
+        $emailActivitiesSkipped = 0;
 
         foreach ($records as $record) {
             try {
@@ -431,6 +463,16 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                     $this->error("Failed to import call activities for lead {$lead->external_id}: ".$e->getMessage());
                     // Continue with next lead
                 }
+                
+                // Import email activities for this lead (outside main transaction)
+                try {
+                    $emailStats = $this->importEmailActivities($lead, $emailActivities);
+                    $emailActivitiesImported += $emailStats['imported'];
+                    $emailActivitiesSkipped += $emailStats['skipped'];
+                } catch (Exception $e) {
+                    $this->error("Failed to import email activities for lead {$lead->external_id}: ".$e->getMessage());
+                    // Continue with next lead
+                }
 
                 $imported++;
                 $bar->advance();
@@ -458,6 +500,11 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         $this->info('Call Activities:');
         $this->info("✓ Call activities imported: {$callActivitiesImported}");
         $this->info("⚠ Call activities skipped: {$callActivitiesSkipped}");
+        
+        $this->line('');
+        $this->info('Email Activities:');
+        $this->info("✓ Email activities imported: {$emailActivitiesImported}");
+        $this->info("⚠ Email activities skipped: {$emailActivitiesSkipped}");
 
         // Detailed skip breakdown
         $this->line('');
@@ -1091,6 +1138,97 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
     }
 
     /**
+     * Extract email activities from SugarCRM for the given leads
+     *
+     * @param  mixed  $records  The lead records
+     * @return array [lead_id => [email_data1, email_data2, ...]]
+     */
+    private function extractEmailActivities($records): array
+    {
+        $leadIds = collect($records)->pluck('id')->all();
+
+        if (empty($leadIds)) {
+            return [];
+        }
+
+        $connection = $this->option('connection');
+
+        try {
+            // Check if email tables exist
+            if (! Schema::connection($connection)->hasTable('emails')) {
+                $this->info('Emails table does not exist in SugarCRM database, skipping email activities import');
+
+                return [];
+            }
+            if (! Schema::connection($connection)->hasTable('emails_text')) {
+                $this->info('Emails_text table does not exist in SugarCRM database, skipping email activities import');
+
+                return [];
+            }
+            if (! Schema::connection($connection)->hasTable('emails_beans')) {
+                $this->info('Emails_beans table does not exist in SugarCRM database, skipping email activities import');
+
+                return [];
+            }
+
+            $sql = DB::connection($connection)
+                ->table('emails as e')
+                ->join('emails_text as et', 'e.id', '=', 'et.email_id')
+                ->join('emails_beans as eb', 'e.id', '=', 'eb.email_id')
+                ->select([
+                    'e.id',
+                    'e.name as subject',
+                    'e.date_entered',
+                    'e.date_modified',
+                    'e.assigned_user_id',
+                    'e.created_by',
+                    'e.deleted',
+                    'e.date_sent',
+                    'e.message_id',
+                    'e.type',
+                    'e.status',
+                    'e.flagged',
+                    'e.reply_to_status',
+                    'e.intent',
+                    'e.mailbox_id',
+                    'e.parent_type',
+                    'e.parent_id',
+                    'et.description',
+                    'et.description_html',
+                    'et.raw_source',
+                    'eb.bean_id',
+                    'eb.bean_module',
+                ])
+                ->whereIn('eb.bean_id', $leadIds)
+                ->where('eb.bean_module', '=', 'Leads')
+                ->where('e.deleted', '=', 0)
+                ->where('eb.deleted', '=', 0)
+                ->orderBy('e.date_sent', 'asc');
+
+            $this->info('Extracting email activities: '.$sql->toRawSql());
+            $emails = $sql->get();
+
+            $this->info('Found '.$emails->count().' email activities');
+
+            // Group emails by bean_id (lead_id)
+            $result = [];
+            foreach ($emails as $email) {
+                if (! isset($result[$email->bean_id])) {
+                    $result[$email->bean_id] = [];
+                }
+                $result[$email->bean_id][] = $email;
+            }
+
+            return $result;
+        } catch (Exception $e) {
+            $this->error('Failed to extract email activities: '.$e->getMessage());
+            $this->info('Continuing import without email activities');
+
+            return [];
+        }
+    }
+
+    /**
      * Import call activities for a lead
      *
      * @param  Lead  $lead  The lead to import activities for
@@ -1163,6 +1301,128 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         return ['imported' => $imported, 'skipped' => $skipped];
+    }
+
+    /**
+     * Import email activities for a lead
+     *
+     * @param  Lead  $lead  The lead to import activities for
+     * @param  array  $emailActivities  All email activities grouped by lead ID
+     * @return array Statistics about imported and skipped activities
+     */
+    private function importEmailActivities(Lead $lead, array $emailActivities): array
+    {
+        $imported = 0;
+        $skipped = 0;
+
+        try {
+            $leadEmailActivities = $emailActivities[$lead->external_id] ?? [];
+
+            if (empty($leadEmailActivities)) {
+                return ['imported' => $imported, 'skipped' => $skipped];
+            }
+
+            $this->info('Importing '.count($leadEmailActivities)." email activities for lead {$lead->external_id}");
+
+            foreach ($leadEmailActivities as $emailData) {
+                try {
+                    // Check if activity already exists by external reference
+                    $existingActivity = Activity::where('external_id', $emailData->id)->first();
+                    if ($existingActivity) {
+                        $this->info("Skipping existing email activity with external_id={$emailData->id}");
+                        $skipped++;
+
+                        continue;
+                    }
+
+                    // Get group_id from lead's department (will throw exception if invalid)
+                    $groupId = Department::getGroupIdForLead($lead);
+
+                    // Create the activity
+                    $activityData = [
+                        'title'       => $emailData->subject ?? 'Email activiteit',
+                        'type'        => 'email',
+                        'comment'     => $this->formatEmailContent($emailData),
+                        'external_id' => $emailData->id,
+                        'additional'  => [
+                            'message_id'       => $emailData->message_id,
+                            'email_type'       => $emailData->type,
+                            'status'           => $emailData->status,
+                            'flagged'          => (bool) $emailData->flagged,
+                            'reply_to_status'  => $emailData->reply_to_status,
+                            'intent'           => $emailData->intent,
+                            'mailbox_id'       => $emailData->mailbox_id,
+                            'parent_type'      => $emailData->parent_type,
+                            'parent_id'        => $emailData->parent_id,
+                        ],
+                        'schedule_from' => $this->parseSugarDate($emailData->date_sent),
+                        'schedule_to'   => $this->parseSugarDate($emailData->date_sent),
+                        'is_done'       => $this->mapEmailStatus($emailData->status),
+                        'user_id'       => $this->mapAssignedUser($emailData->assigned_user_id),
+                        'lead_id'       => $lead->id,
+                        'group_id'      => $groupId,
+                    ];
+
+                    $timestamps = [
+                        'created_at' => $this->parseSugarDate($emailData->date_entered),
+                        'updated_at' => $this->parseSugarDate($emailData->date_modified),
+                    ];
+
+                    $activity = $this->createEntityWithTimestamps(Activity::class, $activityData, $timestamps);
+
+                    $this->info("✓ Imported email activity: {$emailData->subject} for lead {$lead->external_id}");
+                    $imported++;
+                } catch (Exception $e) {
+                    $this->error("Failed to import email activity {$emailData->id}: ".$e->getMessage());
+                    // Continue with next email activity
+                }
+            }
+        } catch (Exception $e) {
+            $this->error("Failed to import email activities for lead {$lead->external_id}: ".$e->getMessage());
+        }
+
+        return ['imported' => $imported, 'skipped' => $skipped];
+    }
+
+    /**
+     * Format email content for activity comment
+     */
+    private function formatEmailContent($emailData): string
+    {
+        $content = [];
+        
+        if (!empty($emailData->subject)) {
+            $content[] = "Subject: {$emailData->subject}";
+        }
+        
+        // Prefer HTML content, fallback to plain text
+        $body = $emailData->description_html ?? $emailData->description ?? '';
+        if (!empty($body)) {
+            // Strip HTML tags for plain text storage in comment
+            $plainBody = strip_tags($body);
+            // Limit length to prevent extremely long comments
+            if (strlen($plainBody) > 1000) {
+                $plainBody = substr($plainBody, 0, 1000) . '...';
+            }
+            $content[] = "Body: {$plainBody}";
+        }
+        
+        return implode("\n\n", $content);
+    }
+
+    /**
+     * Map email status to is_done boolean
+     */
+    private function mapEmailStatus(?string $status): bool
+    {
+        if (! $status) {
+            return false;
+        }
+
+        // Email is considered "done" if it's sent or archived
+        $completedStatuses = ['sent', 'archived', 'delivered'];
+
+        return in_array(strtolower(trim($status)), $completedStatuses);
     }
 
     /**

--- a/tests/Feature/ImportLeadsFromSugarCRMTest.php
+++ b/tests/Feature/ImportLeadsFromSugarCRMTest.php
@@ -28,6 +28,7 @@ beforeEach(function () {
     foreach ([
         'email_addr_bean_rel', 'email_addresses', 'leads_cstm', 'leads', 'leads_contacts_c',
         'leads_pcrm_anamnesepreventie_1_c', 'pcrm_anamnetie_contacts_c', 'pcrm_anamnesepreventie', 'pcrm_anamnesepreventie_cstm', 'calls', 'calls_cstm',
+        'emails', 'emails_text', 'emails_beans',
     ] as $tbl) {
         if (Schema::connection('sugarcrm')->hasTable($tbl)) {
             Schema::connection('sugarcrm')->drop($tbl);
@@ -237,6 +238,46 @@ beforeEach(function () {
     Schema::connection('sugarcrm')->create('calls_cstm', function (Blueprint $table) {
         $table->string('id_c')->primary();
         $table->string('belgroep_c')->nullable();
+    });
+
+    // Create emails table
+    Schema::connection('sugarcrm')->create('emails', function (Blueprint $table) {
+        $table->string('id')->primary();
+        $table->string('name')->nullable(); // subject
+        $table->dateTime('date_entered')->nullable();
+        $table->dateTime('date_modified')->nullable();
+        $table->string('assigned_user_id')->nullable();
+        $table->string('created_by')->nullable();
+        $table->boolean('deleted')->default(0);
+        $table->dateTime('date_sent')->nullable();
+        $table->string('message_id')->nullable();
+        $table->string('type')->nullable();
+        $table->string('status')->nullable();
+        $table->boolean('flagged')->default(0);
+        $table->string('reply_to_status')->nullable();
+        $table->string('intent')->nullable();
+        $table->string('mailbox_id')->nullable();
+        $table->string('parent_type')->nullable();
+        $table->string('parent_id')->nullable();
+    });
+
+    // Create emails_text table
+    Schema::connection('sugarcrm')->create('emails_text', function (Blueprint $table) {
+        $table->string('email_id')->primary();
+        $table->text('description')->nullable(); // plain text body
+        $table->text('description_html')->nullable(); // html body
+        $table->text('raw_source')->nullable();
+    });
+
+    // Create emails_beans table (junction table)
+    Schema::connection('sugarcrm')->create('emails_beans', function (Blueprint $table) {
+        $table->string('id')->primary();
+        $table->string('email_id');
+        $table->string('bean_id');
+        $table->string('bean_module');
+        $table->text('campaign_data')->nullable();
+        $table->dateTime('date_modified')->nullable();
+        $table->boolean('deleted')->default(0);
     });
 });
 
@@ -651,4 +692,217 @@ test('imports call activities from sugarcrm', function () {
         ->and($activity2->additional['direction'])->toBe('outbound')
         ->and($activity2->additional['status'])->toBe('planned')
         ->and($activity2->additional['belgroep'])->toBe('follow-up');
+});
+
+test('imports email activities from sugarcrm', function () {
+    // Create user with external_id (required for import)
+    $user = User::factory()->create(['external_id' => 'user-001']);
+
+    // Create app person that will be linked to lead via anamnesis relation
+    $person = Person::factory()->create([
+        'external_id' => 'person-001',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+    ]);
+
+    // Insert lead data in SugarCRM
+    $leadId = 'lead-001';
+    $personId = 'person-001';
+    $anamnesisId = 'anamnesis-001';
+
+    DB::connection('sugarcrm')->table('leads')->insert([
+        'id' => $leadId,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'status' => 'New',
+        'date_entered' => '2024-01-01 10:00:00',
+        'date_modified' => '2024-01-01 11:00:00',
+        'deleted' => 0,
+    ]);
+
+    DB::connection('sugarcrm')->table('leads_cstm')->insert([
+        'id_c' => $leadId,
+        'workflow_status_c' => 'nieuweaanvraag',
+        'kanaal_c' => 'website',
+        'soort_aanvraag_c' => 'preventie',
+        'gender_c' => 'male',
+    ]);
+
+    // Insert person-lead relation
+    DB::connection('sugarcrm')->table('leads_contacts_c')->insert([
+        'id' => 'rel-001',
+        'leads_c7104eads_ida' => $leadId,
+        'leads_cbb5dacts_idb' => $personId,
+        'deleted' => 0,
+    ]);
+
+    // Insert anamnesis data
+    DB::connection('sugarcrm')->table('pcrm_anamnesepreventie')->insert([
+        'id' => $anamnesisId,
+        'name' => 'Test Anamnesis',
+        'status' => 'active',
+        'date_entered' => '2024-01-01 09:00:00',
+        'date_modified' => '2024-01-01 09:30:00',
+        'anamnese' => 'Test anamnesis data',
+        'lengte' => 180,
+        'gewicht' => 75,
+        'metalen' => 1,
+        'medicijnen' => 0,
+        'glaucoom' => 0,
+        'claustrofobie' => 1,
+        'deleted' => 0,
+    ]);
+
+    DB::connection('sugarcrm')->table('pcrm_anamnesepreventie_cstm')->insert([
+        'id_c' => $anamnesisId,
+        'opm_metalen_c' => 'Heeft metalen implantaat',
+        'hart_operatie_c' => 0,
+        'allergie_c' => 1,
+        'opm_allergie_c' => 'Allergisch voor pinda\'s',
+    ]);
+
+    // Insert anamnesis relations
+    DB::connection('sugarcrm')->table('leads_pcrm_anamnesepreventie_1_c')->insert([
+        'id' => 'lead-anam-001',
+        'leads_pcrm_anamnesepreventie_1leads_ida' => $leadId,
+        'leads_pcrm_anamnesepreventie_1pcrm_anamnesepreventie_idb' => $anamnesisId,
+        'deleted' => 0,
+    ]);
+
+    DB::connection('sugarcrm')->table('pcrm_anamnetie_contacts_c')->insert([
+        'id' => 'anam-person-001',
+        'pcrm_anamn171deventie_idb' => $anamnesisId,
+        'pcrm_anamn0b6eontacts_ida' => $personId,
+        'deleted' => 0,
+    ]);
+
+    // Insert email data
+    $emailId1 = 'email-001';
+    $emailId2 = 'email-002';
+
+    DB::connection('sugarcrm')->table('emails')->insert([
+        [
+            'id' => $emailId1,
+            'name' => 'Welkom bij onze diensten',
+            'date_entered' => '2024-01-01 12:00:00',
+            'date_modified' => '2024-01-01 12:00:00',
+            'assigned_user_id' => 'user-001',
+            'created_by' => 'user-001',
+            'deleted' => 0,
+            'date_sent' => '2024-01-01 12:00:00',
+            'message_id' => 'msg-001@example.com',
+            'type' => 'out',
+            'status' => 'sent',
+            'flagged' => 0,
+            'reply_to_status' => null,
+            'intent' => 'welcome',
+            'mailbox_id' => 'mailbox-001',
+            'parent_type' => 'Leads',
+            'parent_id' => $leadId,
+        ],
+        [
+            'id' => $emailId2,
+            'name' => 'Opvolging afspraak',
+            'date_entered' => '2024-01-02 14:00:00',
+            'date_modified' => '2024-01-02 14:00:00',
+            'assigned_user_id' => 'user-001',
+            'created_by' => 'user-001',
+            'deleted' => 0,
+            'date_sent' => '2024-01-02 14:00:00',
+            'message_id' => 'msg-002@example.com',
+            'type' => 'out',
+            'status' => 'sent',
+            'flagged' => 1,
+            'reply_to_status' => null,
+            'intent' => 'follow_up',
+            'mailbox_id' => 'mailbox-001',
+            'parent_type' => 'Leads',
+            'parent_id' => $leadId,
+        ],
+    ]);
+
+    // Insert email text content
+    DB::connection('sugarcrm')->table('emails_text')->insert([
+        [
+            'email_id' => $emailId1,
+            'description' => 'Welkom bij onze diensten. We kijken ernaar uit om u te helpen.',
+            'description_html' => '<p>Welkom bij onze diensten. We kijken ernaar uit om u te helpen.</p>',
+            'raw_source' => 'Raw email content here...',
+        ],
+        [
+            'email_id' => $emailId2,
+            'description' => 'Dit is een opvolging van uw afspraak.',
+            'description_html' => '<p>Dit is een <strong>opvolging</strong> van uw afspraak.</p>',
+            'raw_source' => 'Raw follow-up email content...',
+        ],
+    ]);
+
+    // Insert email-bean relations
+    DB::connection('sugarcrm')->table('emails_beans')->insert([
+        [
+            'id' => 'email-bean-001',
+            'email_id' => $emailId1,
+            'bean_id' => $leadId,
+            'bean_module' => 'Leads',
+            'campaign_data' => null,
+            'date_modified' => '2024-01-01 12:00:00',
+            'deleted' => 0,
+        ],
+        [
+            'id' => 'email-bean-002',
+            'email_id' => $emailId2,
+            'bean_id' => $leadId,
+            'bean_module' => 'Leads',
+            'campaign_data' => null,
+            'date_modified' => '2024-01-02 14:00:00',
+            'deleted' => 0,
+        ],
+    ]);
+
+    // Run import
+    Artisan::call('import:leads', [
+        '--connection' => 'sugarcrm',
+        '--limit' => 10,
+        '--lead-ids' => [$leadId],
+    ]);
+
+    // Verify lead was imported
+    $lead = Lead::where('external_id', $leadId)->first();
+    expect($lead)->not->toBeNull();
+
+    // Verify email activities were imported
+    $emailActivities = Activity::where('lead_id', $lead->id)
+        ->where('type', 'email')
+        ->orderBy('created_at')
+        ->get();
+
+    expect($emailActivities)->toHaveCount(2);
+
+    // Check first email activity
+    $activity1 = $emailActivities[0];
+    expect($activity1->title)->toBe('Welkom bij onze diensten')
+        ->and($activity1->type)->toBe('email')
+        ->and($activity1->external_id)->toBe($emailId1)
+        ->and($activity1->comment)->toContain('Subject: Welkom bij onze diensten')
+        ->and($activity1->comment)->toContain('Body: Welkom bij onze diensten. We kijken ernaar uit om u te helpen.')
+        ->and($activity1->is_done)->toBe(true) // 'sent' status should map to done
+        ->and($activity1->additional['message_id'])->toBe('msg-001@example.com')
+        ->and($activity1->additional['email_type'])->toBe('out')
+        ->and($activity1->additional['status'])->toBe('sent')
+        ->and($activity1->additional['flagged'])->toBe(false)
+        ->and($activity1->additional['intent'])->toBe('welcome');
+
+    // Check second email activity
+    $activity2 = $emailActivities[1];
+    expect($activity2->title)->toBe('Opvolging afspraak')
+        ->and($activity2->type)->toBe('email')
+        ->and($activity2->external_id)->toBe($emailId2)
+        ->and($activity2->comment)->toContain('Subject: Opvolging afspraak')
+        ->and($activity2->comment)->toContain('Body: Dit is een opvolging van uw afspraak.')
+        ->and($activity2->is_done)->toBe(true) // 'sent' status should map to done
+        ->and($activity2->additional['message_id'])->toBe('msg-002@example.com')
+        ->and($activity2->additional['email_type'])->toBe('out')
+        ->and($activity2->additional['status'])->toBe('sent')
+        ->and($activity2->additional['flagged'])->toBe(true)
+        ->and($activity2->additional['intent'])->toBe('follow_up');
 });


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
This pull request extends the `import:leads` command to include the import of email activities associated with leads from SugarCRM. This provides a more comprehensive activity history for each lead in the application.

Key changes include:
- **Email Extraction**: A new method `extractEmailActivities` fetches emails, their content, and their relationship to leads from SugarCRM's `emails`, `emails_text`, and `emails_beans` tables.
- **Email Import**: A new method `importEmailActivities` creates `Activity` records of type 'email' for each extracted email.
    - Email subject and a formatted body (HTML stripped, length limited) are stored in `title` and `comment` fields.
    - All relevant email metadata (e.g., `message_id`, `type`, `status`, `flagged`) is stored in the `additional` JSON field.
    - The `is_done` status of the activity is mapped based on the email's status (e.g., 'sent', 'archived', 'delivered' are considered done).
- **Command Output**: The dry-run results and final import statistics now include details about imported and skipped email activities.
- **Command Description**: The command description has been updated to reflect the new email import functionality.

## How To Test This?
1.  **Run the dedicated feature test:**
    ```bash
    php artisan test tests/Feature/ImportLeadsFromSugarCRMTest.php --filter=imports\ email\ activities\ from\ sugarcrm
    ```
    This test verifies the correct extraction, formatting, and import of email activities, including metadata and content.

2.  **Perform a dry run with the command:**
    ```bash
    php artisan import:leads --connection=sugarcrm --limit=10 --dry-run
    ```
    Observe the "Email Activities" column in the dry run table and the "Email Activities Summary" section for the imported leads.

3.  **Run a full import:**
    ```bash
    php artisan import:leads --connection=sugarcrm --limit=10
    ```
    Verify that `Activity` records of type 'email' are created for the imported leads, containing the correct subject, formatted comment, and additional metadata.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-a3c82009-1918-4cd6-a3a3-b22293b96c60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3c82009-1918-4cd6-a3a3-b22293b96c60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

