### PR TITLE
Remember last selected pipeline with cookie

### DIFF
--- a/app/Services/PipelineCookieService.php
+++ b/app/Services/PipelineCookieService.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cookie;
+use Webkul\Lead\Repositories\PipelineRepository;
+
+class PipelineCookieService
+{
+    const COOKIE_NAME = 'last_selected_pipeline_id';
+    const COOKIE_DURATION = 60 * 24 * 30; // 30 days in minutes
+
+    public function __construct(
+        protected PipelineRepository $pipelineRepository
+    ) {}
+
+    /**
+     * Get the last selected pipeline ID from cookie
+     *
+     * @return int|null
+     */
+    public function getLastSelectedPipelineId(): ?int
+    {
+        $pipelineId = request()->cookie(self::COOKIE_NAME);
+        
+        if (!$pipelineId) {
+            return null;
+        }
+
+        // Validate that the pipeline still exists
+        $pipeline = $this->pipelineRepository->find($pipelineId);
+        
+        return $pipeline ? (int) $pipelineId : null;
+    }
+
+    /**
+     * Set the last selected pipeline ID in cookie
+     *
+     * @param int $pipelineId
+     * @return \Illuminate\Cookie\CookieJar
+     */
+    public function setLastSelectedPipelineId(int $pipelineId)
+    {
+        // Validate that the pipeline exists before setting cookie
+        $pipeline = $this->pipelineRepository->find($pipelineId);
+        
+        if (!$pipeline) {
+            return null;
+        }
+
+        return Cookie::queue(
+            Cookie::make(
+                self::COOKIE_NAME,
+                $pipelineId,
+                self::COOKIE_DURATION,
+                '/',
+                null,
+                false, // secure (set to true for HTTPS)
+                true   // httpOnly
+            )
+        );
+    }
+
+    /**
+     * Get the effective pipeline ID considering URL parameter and cookie
+     *
+     * @param int|null $requestPipelineId Pipeline ID from request parameter
+     * @return int|null
+     */
+    public function getEffectivePipelineId(?int $requestPipelineId = null): ?int
+    {
+        // URL parameter takes precedence over cookie
+        if ($requestPipelineId) {
+            // Set cookie to remember this choice
+            $this->setLastSelectedPipelineId($requestPipelineId);
+            return $requestPipelineId;
+        }
+
+        // Fall back to cookie value
+        return $this->getLastSelectedPipelineId();
+    }
+
+    /**
+     * Clear the pipeline cookie
+     *
+     * @return void
+     */
+    public function clearPipelineCookie(): void
+    {
+        Cookie::queue(Cookie::forget(self::COOKIE_NAME));
+    }
+}

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -38,6 +38,7 @@ use Webkul\Tag\Repositories\TagRepository;
 use Webkul\User\Repositories\UserRepository;
 use InvalidArgumentException;
 use App\Services\LeadValidationService;
+use App\Services\PipelineCookieService;
 
 class LeadController extends Controller
 {
@@ -65,7 +66,8 @@ class LeadController extends Controller
         protected StageRepository     $stageRepository,
         protected LeadRepository      $leadRepository,
         protected ProductRepository   $productRepository,
-        protected PersonRepository    $personRepository
+        protected PersonRepository    $personRepository,
+        protected PipelineCookieService $pipelineCookieService
     )
     {
         request()->request->add(['entity_type' => 'leads']);
@@ -80,10 +82,20 @@ class LeadController extends Controller
             return datagrid(LeadDataGrid::class)->process();
         }
 
-        if (request('pipeline_id')) {
-            $pipeline = $this->pipelineRepository->find(request('pipeline_id'));
-        } else {
+        // Get effective pipeline ID (URL parameter takes precedence over cookie)
+        $effectivePipelineId = $this->pipelineCookieService->getEffectivePipelineId(request('pipeline_id'));
+        
+        if ($effectivePipelineId) {
+            $pipeline = $this->pipelineRepository->find($effectivePipelineId);
+        }
+        
+        // Fall back to default pipeline if no valid pipeline found
+        if (!isset($pipeline) || !$pipeline) {
             $pipeline = $this->pipelineRepository->getDefaultPipeline();
+            // Set cookie for default pipeline
+            if ($pipeline) {
+                $this->pipelineCookieService->setLastSelectedPipelineId($pipeline->id);
+            }
         }
 
         return view('admin::leads.index', [
@@ -98,9 +110,15 @@ class LeadController extends Controller
     public function get(): JsonResponse
     {
         try {
-            if (request()->query('pipeline_id')) {
-                $pipeline = $this->pipelineRepository->find(request()->query('pipeline_id'));
-            } else {
+            // Get effective pipeline ID (URL parameter takes precedence over cookie)
+            $effectivePipelineId = $this->pipelineCookieService->getEffectivePipelineId(request()->query('pipeline_id'));
+            
+            if ($effectivePipelineId) {
+                $pipeline = $this->pipelineRepository->find($effectivePipelineId);
+            }
+            
+            // Fall back to default pipeline if no valid pipeline found
+            if (!isset($pipeline) || !$pipeline) {
                 $pipeline = $this->pipelineRepository->getDefaultPipeline();
             }
 
@@ -219,9 +237,12 @@ class LeadController extends Controller
         $userGroupNames = $user->groups->pluck('name')->toArray();
         $defaultDepartmentId = Department::mapGroupToDepartmentId($userGroupNames);
 
-        // Determine pipeline and stage based on request parameters
+        // Get effective pipeline ID (URL parameter takes precedence over cookie)
+        $effectivePipelineId = $this->pipelineCookieService->getEffectivePipelineId(request('pipeline_id'));
+        
+        // Determine pipeline and stage based on request parameters and cookie
         $pipelineData = $this->determinePipelineForLead(
-            request('pipeline_id'),
+            $effectivePipelineId,
             request('stage_id'),
             $defaultDepartmentId
         );
@@ -253,6 +274,8 @@ class LeadController extends Controller
 
                 session()->flash('success', trans('admin::app.leads.create-success'));
 
+                // Set cookie to remember pipeline selection
+                $this->pipelineCookieService->setLastSelectedPipelineId($leadPipelineId);
                 return redirect()->route('admin.leads.index', ['pipeline_id' => $leadPipelineId]);
             } catch (InvalidArgumentException $e) {
                 if (request()->ajax()) {
@@ -380,7 +403,10 @@ class LeadController extends Controller
             $userIds
             && !in_array($lead->user_id, $userIds)
         ) {
-            return redirect()->route('admin.leads.index');
+            // Get last selected pipeline from cookie to preserve selection
+            $lastPipelineId = $this->pipelineCookieService->getLastSelectedPipelineId();
+            $routeParams = $lastPipelineId ? ['pipeline_id' => $lastPipelineId] : [];
+            return redirect()->route('admin.leads.index', $routeParams);
         }
 
         return view('admin::leads.view', compact('lead'));
@@ -470,6 +496,8 @@ class LeadController extends Controller
             if (request()->has('closed_at')) {
                 return redirect()->back();
             } else {
+                // Set cookie to remember pipeline selection
+                $this->pipelineCookieService->setLastSelectedPipelineId($data['lead_pipeline_id']);
                 return redirect()->route('admin.leads.index', ['pipeline_id' => $data['lead_pipeline_id']]);
             }
         } catch (InvalidArgumentException $e) {

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -611,8 +611,12 @@
                                 message: 'Lead succesvol aangemaakt!'
                             });
 
-                            // Redirect to leads index
-                            window.location.href = '{{ route('admin.leads.index') }}';
+                            // Redirect to leads index with pipeline preservation
+                            const pipelineId = this.getCookieValue('last_selected_pipeline_id');
+                            const url = pipelineId 
+                                ? '{{ route('admin.leads.index') }}?pipeline_id=' + pipelineId
+                                : '{{ route('admin.leads.index') }}';
+                            window.location.href = url;
 
                         } catch (error) {
                             console.error('Error submitting form:', error);
@@ -793,6 +797,16 @@
                         } else {
                             return 'bg-red-500';
                         }
+                    },
+
+                    /**
+                     * Helper method to get cookie value
+                     */
+                    getCookieValue(name) {
+                        const value = `; ${document.cookie}`;
+                        const parts = value.split(`; ${name}=`);
+                        if (parts.length === 2) return parts.pop().split(';').shift();
+                        return null;
                     }
                 }
             });

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -391,6 +391,14 @@
             computed: {
                 totalStagesAmount() {
                     return 0;
+                },
+
+                /**
+                 * Generate unique src identifier including pipeline for localStorage
+                 */
+                src() {
+                    const pipelineId = "{{ request('pipeline_id') ?? '' }}";
+                    return `{{ route('admin.leads.index') }}${pipelineId ? '?pipeline_id=' + pipelineId : ''}`;
                 }
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/view-switcher.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/view-switcher.blade.php
@@ -41,6 +41,7 @@
                         'view_type'   => request('view_type')
                     ]) }}"
                     class="block px-3 py-2.5 pl-4 text-gray-600 transition-all hover:bg-gray-100 dark:hover:bg-gray-950 dark:text-gray-300 {{ $pipeline->id == $tempPipeline->id ? 'bg-gray-100 dark:bg-gray-950' : '' }}"
+                    onclick="setPipelineCookie({{ $tempPipeline->id }})"
                 >
                     {{ $tempPipeline->name }}
                 </a>
@@ -71,7 +72,7 @@
         @if (request('view_type'))
             <a
                 class="flex"
-                href="{{ route('admin.leads.index') }}"
+                href="{{ route('admin.leads.index', request('pipeline_id') ? ['pipeline_id' => request('pipeline_id')] : []) }}"
             >
                 <span class="icon-kanban p-2 text-2xl"></span>
             </a>
@@ -81,7 +82,7 @@
             <span class="icon-kanban rounded-md bg-white p-2 text-2xl dark:bg-gray-900"></span>
 
             <a
-                href="{{ route('admin.leads.index', ['view_type' => 'table']) }}"
+                href="{{ route('admin.leads.index', array_merge(['view_type' => 'table'], request('pipeline_id') ? ['pipeline_id' => request('pipeline_id')] : [])) }}"
                 class="flex"
             >
                 <span class="icon-list p-2 text-2xl"></span>
@@ -93,3 +94,17 @@
 </div>
 
 {!! view_render_event('admin.leads.index.view_switcher.after') !!}
+
+@pushOnce('scripts')
+<script>
+    /**
+     * Set pipeline cookie when user selects a pipeline
+     */
+    function setPipelineCookie(pipelineId) {
+        // Set cookie for 30 days
+        const expires = new Date();
+        expires.setTime(expires.getTime() + (30 * 24 * 60 * 60 * 1000));
+        document.cookie = `last_selected_pipeline_id=${pipelineId}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+    }
+</script>
+@endPushOnce

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -11,7 +11,17 @@ Breadcrumbs::for('dashboard', function (BreadcrumbTrail $trail) {
 // Dashboard > Leads
 Breadcrumbs::for('leads', function (BreadcrumbTrail $trail) {
     $trail->parent('dashboard');
-    $trail->push(trans('admin::app.layouts.leads'), route('admin.leads.index'));
+    
+    // Get last selected pipeline from cookie to preserve selection
+    $pipelineCookieService = app(\App\Services\PipelineCookieService::class);
+    $lastPipelineId = $pipelineCookieService->getLastSelectedPipelineId();
+    
+    $routeParams = [];
+    if ($lastPipelineId) {
+        $routeParams['pipeline_id'] = $lastPipelineId;
+    }
+    
+    $trail->push(trans('admin::app.layouts.leads'), route('admin.leads.index', $routeParams));
 });
 
 // Dashboard > Leads > Create


### PR DESCRIPTION
## Issue Reference
When navigating away from the `admin/leads` page (e.g., to view a lead) and returning, the Kanban board reverts to the default pipeline. This PR addresses the issue by remembering the last selected pipeline using a cookie.

## Description
This pull request implements a solution to persist the user's last selected pipeline across navigation and sessions.

**Key Changes:**
-   **`PipelineCookieService`**: A new service was created to manage the `last_selected_pipeline_id` cookie, handling setting, retrieving, and validating the pipeline ID.
-   **`LeadController` Updates**: Modified `index()`, `get()`, `create()`, `store()`, `update()`, and `view()` methods to utilize the `PipelineCookieService`. This ensures that the pipeline is read from the cookie when not explicitly provided in the URL, and the cookie is updated on pipeline selection or lead creation/update.
-   **View Switcher (`view-switcher.blade.php`)**: Added JavaScript to set the pipeline cookie when a user selects a pipeline from the dropdown. Also updated view type links (Kanban/Table) to preserve the pipeline ID.
-   **Breadcrumbs (`routes/breadcrumbs.php`)**: Updated the 'Leads' breadcrumb to include the last selected pipeline ID from the cookie, ensuring "back to leads" navigation maintains context.
-   **Lead Create Form (`create.blade.php`)**: Modified the post-creation redirect to use the pipeline ID from the cookie, ensuring the user returns to the correct pipeline.
-   **Kanban View (`kanban.blade.php`)**: Updated the `src` computed property to include the pipeline ID for better local storage management.

This approach centralizes pipeline persistence logic, improving user experience by maintaining the selected pipeline context automatically.

## How To Test This?
1.  Navigate to `admin/leads`.
2.  Select a pipeline other than the default one (e.g., `pipeline_id=2`) using the dropdown.
3.  Click on any lead to view its details.
4.  Navigate back to the leads index (e.g., using the browser's back button or the breadcrumb link).
5.  Verify that the Kanban board remains on the previously selected pipeline (e.g., `pipeline_id=2`) and does not revert to the default.
6.  Create a new lead and verify that after creation, you are redirected to the leads index with the correct pipeline selected.
7.  Update an existing lead and verify the redirect maintains the correct pipeline.
8.  Close and reopen your browser, then go to `admin/leads` directly. Verify that the last selected pipeline is still active.

## Documentation
-   [ ] My pull request requires an update on the documentation repository.

## Branch Selection
-   [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-58f4216b-33b4-493d-a5cc-7a41ea9e9b71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58f4216b-33b4-493d-a5cc-7a41ea9e9b71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

