### PR TITLE
Configure lead status transition validations

### DIFF
--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Services;
+
+use Webkul\Lead\Models\Lead;
+use Webkul\Lead\Models\Stage;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class LeadStatusTransitionValidator
+{
+    /**
+     * Validatie regels per status transitie.
+     * Key format: "from_stage_code->to_stage_code"
+     * 
+     * @var array
+     */
+    private static array $transitionRules = [
+        // Voorbeeld: van klant-adviseren-start naar klant-adviseren-opvolgen
+        'klant-adviseren-start->klant-adviseren-opvolgen' => [
+            'min_persons' => 1,
+            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ],
+        
+        // Andere voorbeelden kunnen hier worden toegevoegd:
+        // 'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
+        //     'required_fields' => ['first_name', 'last_name', 'emails'],
+        //     'message' => 'Voor deze status zijn naam en email verplicht.',
+        // ],
+    ];
+
+    /**
+     * Valideer een status transitie voor een lead.
+     * 
+     * @param Lead $lead
+     * @param int $newStageId
+     * @return void
+     * @throws ValidationException
+     */
+    public static function validateTransition(Lead $lead, int $newStageId): void
+    {
+        $currentStage = $lead->stage;
+        $newStage = Stage::findOrFail($newStageId);
+        
+        if (!$currentStage) {
+            // Als er geen huidige stage is, is het een nieuwe lead - geen transitie validatie nodig
+            return;
+        }
+        
+        $transitionKey = $currentStage->code . '->' . $newStage->code;
+        
+        // Controleer of er validatieregels zijn voor deze transitie
+        if (!isset(self::$transitionRules[$transitionKey])) {
+            return; // Geen validatie regels voor deze transitie
+        }
+        
+        $rules = self::$transitionRules[$transitionKey];
+        $errors = [];
+        
+        // Valideer minimum aantal personen
+        if (isset($rules['min_persons'])) {
+            $personCount = $lead->persons_count;
+            if ($personCount < $rules['min_persons']) {
+                $errors[] = $rules['message'] ?? "Minimaal {$rules['min_persons']} persoon(en) vereist voor deze status.";
+            }
+        }
+        
+        // Valideer verplichte velden
+        if (isset($rules['required_fields'])) {
+            foreach ($rules['required_fields'] as $field) {
+                if (empty($lead->$field)) {
+                    $errors[] = "Het veld '{$field}' is verplicht voor deze status.";
+                }
+            }
+        }
+        
+        // Valideer custom regels
+        if (isset($rules['custom_validation'])) {
+            $customErrors = self::executeCustomValidation($lead, $rules['custom_validation']);
+            $errors = array_merge($errors, $customErrors);
+        }
+        
+        // Gooi ValidationException als er fouten zijn
+        if (!empty($errors)) {
+            $validator = Validator::make([], []);
+            foreach ($errors as $error) {
+                $validator->errors()->add('status_transition', $error);
+            }
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * Voer custom validatie uit.
+     * 
+     * @param Lead $lead
+     * @param callable $validationFunction
+     * @return array
+     */
+    private static function executeCustomValidation(Lead $lead, callable $validationFunction): array
+    {
+        try {
+            $result = $validationFunction($lead);
+            return is_array($result) ? $result : [];
+        } catch (\Exception $e) {
+            return ["Validatie fout: " . $e->getMessage()];
+        }
+    }
+
+    /**
+     * Voeg een nieuwe transitie validatie regel toe.
+     * 
+     * @param string $fromStageCode
+     * @param string $toStageCode
+     * @param array $rules
+     * @return void
+     */
+    public static function addTransitionRule(string $fromStageCode, string $toStageCode, array $rules): void
+    {
+        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        self::$transitionRules[$transitionKey] = $rules;
+    }
+
+    /**
+     * Verwijder een transitie validatie regel.
+     * 
+     * @param string $fromStageCode
+     * @param string $toStageCode
+     * @return void
+     */
+    public static function removeTransitionRule(string $fromStageCode, string $toStageCode): void
+    {
+        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        unset(self::$transitionRules[$transitionKey]);
+    }
+
+    /**
+     * Krijg alle transitie regels (voor debugging/configuratie).
+     * 
+     * @return array
+     */
+    public static function getAllTransitionRules(): array
+    {
+        return self::$transitionRules;
+    }
+
+    /**
+     * Controleer of een transitie validatie regels heeft.
+     * 
+     * @param string $fromStageCode
+     * @param string $toStageCode
+     * @return bool
+     */
+    public static function hasTransitionRule(string $fromStageCode, string $toStageCode): bool
+    {
+        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        return isset(self::$transitionRules[$transitionKey]);
+    }
+}

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -2,26 +2,24 @@
 
 namespace App\Services;
 
-use Webkul\Lead\Models\Lead;
-use Webkul\Lead\Models\Stage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
+use Webkul\Lead\Models\Lead;
+use Webkul\Lead\Models\Stage;
 
 class LeadStatusTransitionValidator
 {
     /**
      * Validatie regels per status transitie.
      * Key format: "from_stage_code->to_stage_code"
-     * 
-     * @var array
      */
     private static array $transitionRules = [
         // Voorbeeld: van klant-adviseren-start naar klant-adviseren-opvolgen
         'klant-adviseren-start->klant-adviseren-opvolgen' => [
             'min_persons' => 1,
-            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'message'     => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ],
-        
+
         // Andere voorbeelden kunnen hier worden toegevoegd:
         // 'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
         //     'required_fields' => ['first_name', 'last_name', 'emails'],
@@ -31,10 +29,7 @@ class LeadStatusTransitionValidator
 
     /**
      * Valideer een status transitie voor een lead.
-     * 
-     * @param Lead $lead
-     * @param int $newStageId
-     * @return void
+     *
      * @throws ValidationException
      */
     public static function validateTransition(Lead $lead, int $newStageId): void
@@ -44,22 +39,22 @@ class LeadStatusTransitionValidator
             ? Stage::find($lead->lead_pipeline_stage_id)
             : null;
         $newStage = Stage::findOrFail($newStageId);
-        
-        if (!$currentStage) {
+
+        if (! $currentStage) {
             // Als er geen huidige stage is, is het een nieuwe lead - geen transitie validatie nodig
             return;
         }
-        
-        $transitionKey = $currentStage->code . '->' . $newStage->code;
-        
+
+        $transitionKey = $currentStage->code.'->'.$newStage->code;
+
         // Controleer of er validatieregels zijn voor deze transitie
-        if (!isset(self::$transitionRules[$transitionKey])) {
+        if (! isset(self::$transitionRules[$transitionKey])) {
             return; // Geen validatie regels voor deze transitie
         }
-        
+
         $rules = self::$transitionRules[$transitionKey];
         $errors = [];
-        
+
         // Valideer minimum aantal personen
         if (isset($rules['min_persons'])) {
             $personCount = $lead->persons_count;
@@ -67,7 +62,7 @@ class LeadStatusTransitionValidator
                 $errors[] = $rules['message'] ?? "Minimaal {$rules['min_persons']} persoon(en) vereist voor deze status.";
             }
         }
-        
+
         // Valideer verplichte velden
         if (isset($rules['required_fields'])) {
             foreach ($rules['required_fields'] as $field) {
@@ -76,15 +71,15 @@ class LeadStatusTransitionValidator
                 }
             }
         }
-        
+
         // Valideer custom regels
         if (isset($rules['custom_validation'])) {
             $customErrors = self::executeCustomValidation($lead, $rules['custom_validation']);
             $errors = array_merge($errors, $customErrors);
         }
-        
+
         // Gooi ValidationException als er fouten zijn
-        if (!empty($errors)) {
+        if (! empty($errors)) {
             $validator = Validator::make([], []);
             foreach ($errors as $error) {
                 $validator->errors()->add('status_transition', $error);
@@ -94,53 +89,25 @@ class LeadStatusTransitionValidator
     }
 
     /**
-     * Voer custom validatie uit.
-     * 
-     * @param Lead $lead
-     * @param callable $validationFunction
-     * @return array
-     */
-    private static function executeCustomValidation(Lead $lead, callable $validationFunction): array
-    {
-        try {
-            $result = $validationFunction($lead);
-            return is_array($result) ? $result : [];
-        } catch (\Exception $e) {
-            return ["Validatie fout: " . $e->getMessage()];
-        }
-    }
-
-    /**
      * Voeg een nieuwe transitie validatie regel toe.
-     * 
-     * @param string $fromStageCode
-     * @param string $toStageCode
-     * @param array $rules
-     * @return void
      */
     public static function addTransitionRule(string $fromStageCode, string $toStageCode, array $rules): void
     {
-        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        $transitionKey = $fromStageCode.'->'.$toStageCode;
         self::$transitionRules[$transitionKey] = $rules;
     }
 
     /**
      * Verwijder een transitie validatie regel.
-     * 
-     * @param string $fromStageCode
-     * @param string $toStageCode
-     * @return void
      */
     public static function removeTransitionRule(string $fromStageCode, string $toStageCode): void
     {
-        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        $transitionKey = $fromStageCode.'->'.$toStageCode;
         unset(self::$transitionRules[$transitionKey]);
     }
 
     /**
      * Krijg alle transitie regels (voor debugging/configuratie).
-     * 
-     * @return array
      */
     public static function getAllTransitionRules(): array
     {
@@ -149,14 +116,25 @@ class LeadStatusTransitionValidator
 
     /**
      * Controleer of een transitie validatie regels heeft.
-     * 
-     * @param string $fromStageCode
-     * @param string $toStageCode
-     * @return bool
      */
     public static function hasTransitionRule(string $fromStageCode, string $toStageCode): bool
     {
-        $transitionKey = $fromStageCode . '->' . $toStageCode;
+        $transitionKey = $fromStageCode.'->'.$toStageCode;
+
         return isset(self::$transitionRules[$transitionKey]);
+    }
+
+    /**
+     * Voer custom validatie uit.
+     */
+    private static function executeCustomValidation(Lead $lead, callable $validationFunction): array
+    {
+        try {
+            $result = $validationFunction($lead);
+
+            return is_array($result) ? $result : [];
+        } catch (\Exception $e) {
+            return ['Validatie fout: '.$e->getMessage()];
+        }
     }
 }

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -39,7 +39,10 @@ class LeadStatusTransitionValidator
      */
     public static function validateTransition(Lead $lead, int $newStageId): void
     {
-        $currentStage = $lead->stage;
+        // Avoid relying on a potentially stale Eloquent relation; read current stage by ID
+        $currentStage = $lead->lead_pipeline_stage_id
+            ? Stage::find($lead->lead_pipeline_stage_id)
+            : null;
         $newStage = Stage::findOrFail($newStageId);
         
         if (!$currentStage) {

--- a/docs/LeadStatusTransitionValidation.md
+++ b/docs/LeadStatusTransitionValidation.md
@@ -1,0 +1,234 @@
+# Lead Status Transition Validation
+
+Dit document beschrijft het validatiemechanisme voor status transities in het Lead systeem.
+
+## Overzicht
+
+Het systeem maakt het mogelijk om validatieregels te definiëren die worden uitgevoerd wanneer een lead van de ene status naar de andere wordt verplaatst. Dit voorkomt dat leads in onjuiste staten terechtkomen en zorgt voor data-integriteit.
+
+## Architectuur
+
+### 1. LeadStatusTransitionValidator Service
+
+De `LeadStatusTransitionValidator` service beheert alle validatieregels voor status transities.
+
+**Locatie:** `app/Services/LeadStatusTransitionValidator.php`
+
+**Belangrijkste methoden:**
+- `validateTransition(Lead $lead, int $newStageId)` - Valideert een status transitie
+- `addTransitionRule(string $fromStageCode, string $toStageCode, array $rules)` - Voegt een validatieregel toe
+- `removeTransitionRule(string $fromStageCode, string $toStageCode)` - Verwijdert een validatieregel
+
+### 2. Lead Model Integration
+
+Het `Lead` model is uitgebreid met validatie:
+- `update()` methode controleert automatisch status transities
+- `updateStage()` methode voor directe stage updates met validatie
+
+### 3. PipelineSeeder Configuration
+
+Validatieregels worden geconfigureerd in de `PipelineSeeder` via de `configureStatusTransitionValidations()` methode.
+
+## Configuratie
+
+### Basis Configuratie
+
+Validatieregels worden gedefinieerd in de `PipelineSeeder`:
+
+```php
+private function configureStatusTransitionValidations(): void
+{
+    // Voorbeeld: Minimaal 1 persoon vereist
+    LeadStatusTransitionValidator::addTransitionRule(
+        'klant-adviseren-start',
+        'klant-adviseren-opvolgen',
+        [
+            'min_persons' => 1,
+            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ]
+    );
+}
+```
+
+### Ondersteunde Validatie Types
+
+#### 1. Minimum Aantal Personen
+```php
+[
+    'min_persons' => 1,
+    'message' => 'Minimaal 1 persoon vereist.',
+]
+```
+
+#### 2. Verplichte Velden
+```php
+[
+    'required_fields' => ['first_name', 'last_name', 'emails'],
+    'message' => 'Naam en email zijn verplicht.',
+]
+```
+
+#### 3. Custom Validatie
+```php
+[
+    'custom_validation' => function($lead) {
+        $errors = [];
+        if (!$lead->quotes()->count()) {
+            $errors[] = 'Er moet minimaal 1 offerte zijn.';
+        }
+        return $errors;
+    },
+    'message' => 'Custom validatie fout.',
+]
+```
+
+## Gebruik
+
+### Automatische Validatie
+
+Validatie gebeurt automatisch bij:
+- `$lead->update(['lead_pipeline_stage_id' => $newStageId])`
+- `$lead->updateStage($newStageId)`
+- API calls via `LeadController`
+
+### Handmatige Validatie
+
+```php
+use App\Services\LeadStatusTransitionValidator;
+
+try {
+    LeadStatusTransitionValidator::validateTransition($lead, $newStageId);
+    // Transitie is geldig
+} catch (\Illuminate\Validation\ValidationException $e) {
+    // Transitie is ongeldig
+    $errors = $e->errors();
+}
+```
+
+### Runtime Configuratie
+
+```php
+// Voeg een regel toe
+LeadStatusTransitionValidator::addTransitionRule(
+    'from-stage',
+    'to-stage',
+    ['min_persons' => 2]
+);
+
+// Verwijder een regel
+LeadStatusTransitionValidator::removeTransitionRule(
+    'from-stage',
+    'to-stage'
+);
+
+// Controleer of een regel bestaat
+$hasRule = LeadStatusTransitionValidator::hasTransitionRule(
+    'from-stage',
+    'to-stage'
+);
+```
+
+## Voorbeelden
+
+### Voorbeeld 1: Minimaal 1 Persoon
+
+```php
+LeadStatusTransitionValidator::addTransitionRule(
+    'klant-adviseren-start',
+    'klant-adviseren-opvolgen',
+    [
+        'min_persons' => 1,
+        'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+    ]
+);
+```
+
+### Voorbeeld 2: Verplichte Velden
+
+```php
+LeadStatusTransitionValidator::addTransitionRule(
+    'nieuwe-aanvraag-kwalificeren',
+    'klant-adviseren-start',
+    [
+        'required_fields' => ['first_name', 'last_name', 'emails'],
+        'message' => 'Voor de status "Klant adviseren" zijn naam en email verplicht.',
+    ]
+);
+```
+
+### Voorbeeld 3: Custom Validatie
+
+```php
+LeadStatusTransitionValidator::addTransitionRule(
+    'klant-adviseren-opvolgen',
+    'won',
+    [
+        'custom_validation' => function($lead) {
+            $errors = [];
+            if (!$lead->quotes()->count()) {
+                $errors[] = 'Er moet minimaal 1 offerte zijn voor deze lead.';
+            }
+            if (!$lead->user_id) {
+                $errors[] = 'Er moet een verantwoordelijke gebruiker zijn toegewezen.';
+            }
+            return $errors;
+        },
+        'message' => 'Voor het winnen van een lead zijn offertes en een verantwoordelijke vereist.',
+    ]
+);
+```
+
+## Error Handling
+
+Wanneer een validatie faalt, wordt een `ValidationException` gegooid met de volgende structuur:
+
+```php
+[
+    'status_transition' => [
+        'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        // ... andere foutmeldingen
+    ]
+]
+```
+
+## Testing
+
+Tests zijn beschikbaar in `tests/Feature/LeadStatusTransitionValidationTest.php`:
+
+```bash
+php artisan test tests/Feature/LeadStatusTransitionValidationTest.php
+```
+
+## Best Practices
+
+1. **Definieer regels in PipelineSeeder**: Houd validatieregels gecentraliseerd
+2. **Gebruik duidelijke foutmeldingen**: Help gebruikers begrijpen wat er mis is
+3. **Test je validaties**: Zorg voor uitgebreide test coverage
+4. **Documenteer complexe regels**: Leg custom validaties uit in comments
+5. **Performance**: Houd custom validaties licht - vermijd zware database queries
+
+## Uitbreiding
+
+Het systeem is ontworpen om eenvoudig uit te breiden:
+
+1. **Nieuwe validatie types**: Voeg nieuwe validatie opties toe aan `LeadStatusTransitionValidator`
+2. **Conditional validaties**: Gebruik custom validatie voor complexe logica
+3. **Integration met workflows**: Koppel validaties aan workflow events
+4. **UI feedback**: Toon validatiefouten in de frontend
+
+## Troubleshooting
+
+### Validatie werkt niet
+- Controleer of de regel correct is gedefinieerd in `PipelineSeeder`
+- Verificeer dat de stage codes exact overeenkomen
+- Check of de seeder is uitgevoerd
+
+### Performance issues
+- Optimaliseer custom validaties
+- Overweeg caching voor zware validaties
+- Monitor database queries in custom validaties
+
+### Foutmeldingen
+- Controleer de `message` configuratie
+- Verificeer dat alle benodigde data beschikbaar is
+- Check de lead relaties (persons, quotes, etc.)

--- a/docs/modules/technology_stack/pages/lead_status_transition_validation.adoc
+++ b/docs/modules/technology_stack/pages/lead_status_transition_validation.adoc
@@ -1,14 +1,14 @@
-# Lead Status Transition Validation
+### Lead Status Transition Validation
 
 Dit document beschrijft het validatiemechanisme voor status transities in het Lead systeem.
 
-## Overzicht
+#### Overzicht
 
 Het systeem maakt het mogelijk om validatieregels te definiëren die worden uitgevoerd wanneer een lead van de ene status naar de andere wordt verplaatst. Dit voorkomt dat leads in onjuiste staten terechtkomen en zorgt voor data-integriteit.
 
-## Architectuur
+#### Architectuur
 
-### 1. LeadStatusTransitionValidator Service
+##### 1. LeadStatusTransitionValidator Service
 
 De `LeadStatusTransitionValidator` service beheert alle validatieregels voor status transities.
 
@@ -19,19 +19,19 @@ De `LeadStatusTransitionValidator` service beheert alle validatieregels voor sta
 - `addTransitionRule(string $fromStageCode, string $toStageCode, array $rules)` - Voegt een validatieregel toe
 - `removeTransitionRule(string $fromStageCode, string $toStageCode)` - Verwijdert een validatieregel
 
-### 2. Lead Model Integration
+##### 2. Lead Model Integration
 
 Het `Lead` model is uitgebreid met validatie:
 - `update()` methode controleert automatisch status transities
 - `updateStage()` methode voor directe stage updates met validatie
 
-### 3. PipelineSeeder Configuration
+##### 3. PipelineSeeder Configuration
 
 Validatieregels worden geconfigureerd in de `PipelineSeeder` via de `configureStatusTransitionValidations()` methode.
 
-## Configuratie
+#### Configuratie
 
-### Basis Configuratie
+##### Basis Configuratie
 
 Validatieregels worden gedefinieerd in de `PipelineSeeder`:
 
@@ -50,9 +50,9 @@ private function configureStatusTransitionValidations(): void
 }
 ```
 
-### Ondersteunde Validatie Types
+##### Ondersteunde Validatie Types
 
-#### 1. Minimum Aantal Personen
+###### 1. Minimum Aantal Personen
 ```php
 [
     'min_persons' => 1,
@@ -60,7 +60,7 @@ private function configureStatusTransitionValidations(): void
 ]
 ```
 
-#### 2. Verplichte Velden
+###### 2. Verplichte Velden
 ```php
 [
     'required_fields' => ['first_name', 'last_name', 'emails'],
@@ -68,7 +68,7 @@ private function configureStatusTransitionValidations(): void
 ]
 ```
 
-#### 3. Custom Validatie
+###### 3. Custom Validatie
 ```php
 [
     'custom_validation' => function($lead) {
@@ -82,16 +82,16 @@ private function configureStatusTransitionValidations(): void
 ]
 ```
 
-## Gebruik
+#### Gebruik
 
-### Automatische Validatie
+##### Automatische Validatie
 
 Validatie gebeurt automatisch bij:
 - `$lead->update(['lead_pipeline_stage_id' => $newStageId])`
 - `$lead->updateStage($newStageId)`
 - API calls via `LeadController`
 
-### Handmatige Validatie
+##### Handmatige Validatie
 
 ```php
 use App\Services\LeadStatusTransitionValidator;
@@ -105,7 +105,7 @@ try {
 }
 ```
 
-### Runtime Configuratie
+##### Runtime Configuratie
 
 ```php
 // Voeg een regel toe
@@ -128,9 +128,9 @@ $hasRule = LeadStatusTransitionValidator::hasTransitionRule(
 );
 ```
 
-## Voorbeelden
+#### Voorbeelden
 
-### Voorbeeld 1: Minimaal 1 Persoon
+##### Voorbeeld 1: Minimaal 1 Persoon
 
 ```php
 LeadStatusTransitionValidator::addTransitionRule(
@@ -143,7 +143,7 @@ LeadStatusTransitionValidator::addTransitionRule(
 );
 ```
 
-### Voorbeeld 2: Verplichte Velden
+##### Voorbeeld 2: Verplichte Velden
 
 ```php
 LeadStatusTransitionValidator::addTransitionRule(
@@ -156,7 +156,7 @@ LeadStatusTransitionValidator::addTransitionRule(
 );
 ```
 
-### Voorbeeld 3: Custom Validatie
+##### Voorbeeld 3: Custom Validatie
 
 ```php
 LeadStatusTransitionValidator::addTransitionRule(
@@ -178,7 +178,7 @@ LeadStatusTransitionValidator::addTransitionRule(
 );
 ```
 
-## Error Handling
+#### Error Handling
 
 Wanneer een validatie faalt, wordt een `ValidationException` gegooid met de volgende structuur:
 
@@ -191,7 +191,7 @@ Wanneer een validatie faalt, wordt een `ValidationException` gegooid met de volg
 ]
 ```
 
-## Testing
+#### Testing
 
 Tests zijn beschikbaar in `tests/Feature/LeadStatusTransitionValidationTest.php`:
 
@@ -199,7 +199,7 @@ Tests zijn beschikbaar in `tests/Feature/LeadStatusTransitionValidationTest.php`
 php artisan test tests/Feature/LeadStatusTransitionValidationTest.php
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Definieer regels in PipelineSeeder**: Houd validatieregels gecentraliseerd
 2. **Gebruik duidelijke foutmeldingen**: Help gebruikers begrijpen wat er mis is
@@ -207,7 +207,7 @@ php artisan test tests/Feature/LeadStatusTransitionValidationTest.php
 4. **Documenteer complexe regels**: Leg custom validaties uit in comments
 5. **Performance**: Houd custom validaties licht - vermijd zware database queries
 
-## Uitbreiding
+#### Uitbreiding
 
 Het systeem is ontworpen om eenvoudig uit te breiden:
 
@@ -216,19 +216,19 @@ Het systeem is ontworpen om eenvoudig uit te breiden:
 3. **Integration met workflows**: Koppel validaties aan workflow events
 4. **UI feedback**: Toon validatiefouten in de frontend
 
-## Troubleshooting
+#### Troubleshooting
 
-### Validatie werkt niet
+##### Validatie werkt niet
 - Controleer of de regel correct is gedefinieerd in `PipelineSeeder`
 - Verificeer dat de stage codes exact overeenkomen
 - Check of de seeder is uitgevoerd
 
-### Performance issues
+##### Performance issues
 - Optimaliseer custom validaties
 - Overweeg caching voor zware validaties
 - Monitor database queries in custom validaties
 
-### Foutmeldingen
+##### Foutmeldingen
 - Controleer de `message` configuratie
 - Verificeer dat alle benodigde data beschikbaar is
 - Check de lead relaties (persons, quotes, etc.)

--- a/docs/modules/technology_stack/pages/tech_stack.adoc
+++ b/docs/modules/technology_stack/pages/tech_stack.adoc
@@ -130,3 +130,5 @@ Het systeem bestaat uit de volgende hoofdmodules:
 include::tool-keuzes.adoc[]
 
 include::audit_trail.adoc[]
+
+include::lead_status_transition_validation.adoc[]

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -39,6 +39,7 @@ use Webkul\User\Repositories\UserRepository;
 use InvalidArgumentException;
 use App\Services\LeadValidationService;
 use App\Services\PipelineCookieService;
+use App\Services\LeadStatusTransitionValidator;
 
 class LeadController extends Controller
 {
@@ -575,6 +576,20 @@ class LeadController extends Controller
             ->where('id', $data['lead_pipeline_stage_id'])
             ->firstOrFail();
 
+        // Validate status transition if stage is being changed
+        if (isset($data['lead_pipeline_stage_id']) && 
+            $data['lead_pipeline_stage_id'] != $lead->lead_pipeline_stage_id) {
+            
+            try {
+                LeadStatusTransitionValidator::validateTransition($lead, $data['lead_pipeline_stage_id']);
+            } catch (\Illuminate\Validation\ValidationException $e) {
+                return response()->json([
+                    'message' => 'Status transitie validatie gefaald',
+                    'errors' => $e->errors(),
+                ], 422);
+            }
+        }
+
         Event::dispatch('lead.update.before', $leadId);
 
         $lead = $this->leadRepository->update(
@@ -601,6 +616,16 @@ class LeadController extends Controller
         $lead->pipeline->stages()
             ->where('id', $nextPipelineStageId)
             ->firstOrFail();
+
+        // Validate status transition
+        try {
+            LeadStatusTransitionValidator::validateTransition($lead, (int)$nextPipelineStageId);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            return response()->json([
+                'message' => 'Status transitie validatie gefaald',
+                'errors' => $e->errors(),
+            ], 422);
+        }
 
         Event::dispatch('lead.update.before', $leadId);
 

--- a/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
@@ -253,15 +253,15 @@ class PipelineSeeder extends BaseSeeder
         // Andere voorbeelden kunnen hier worden toegevoegd:
         
         // Voorbeeld: Validatie voor nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
-        // Lead moet naam en email hebben
-        // LeadStatusTransitionValidator::addTransitionRule(
-        //     'nieuwe-aanvraag-kwalificeren',
-        //     'klant-adviseren-start',
-        //     [
-        //         'required_fields' => ['first_name', 'last_name', 'emails'],
-        //         'message' => 'Voor de status "Klant adviseren" zijn naam en email verplicht.',
-        //     ]
-        // );
+        // Lead moet naam hebben
+        LeadStatusTransitionValidator::addTransitionRule(
+            'nieuwe-aanvraag-kwalificeren',
+            'klant-adviseren-start',
+            [
+                'required_fields' => ['first_name', 'last_name'],
+                'message' => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
+            ]
+        );
 
         // Voorbeeld: Custom validatie voor won status
         // LeadStatusTransitionValidator::addTransitionRule(

--- a/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
@@ -12,6 +12,7 @@ use Exception;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Webkul\Lead\Models\Stage;
+use App\Services\LeadStatusTransitionValidator;
 
 class PipelineSeeder extends BaseSeeder
 {
@@ -226,5 +227,56 @@ class PipelineSeeder extends BaseSeeder
         if (PipelineStageDefaultKeys::PIPELINE_FIRST_STAGE_HERNIA_ID->value != $firstStageHerniaLeadPipeline) {
             throw new Exception('Pipeline stage is niet geldig voor hernia: ' . $firstStageHerniaLeadPipeline);
         }
+
+        // Configure status transition validations
+        $this->configureStatusTransitionValidations();
+    }
+
+    /**
+     * Configure status transition validations.
+     * 
+     * @return void
+     */
+    private function configureStatusTransitionValidations(): void
+    {
+        // Voorbeeld: Validatie voor klant-adviseren-start -> klant-adviseren-opvolgen
+        // Minimaal 1 persoon moet gekoppeld zijn aan de lead
+        LeadStatusTransitionValidator::addTransitionRule(
+            'klant-adviseren-start',
+            'klant-adviseren-opvolgen',
+            [
+                'min_persons' => 1,
+                'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+        );
+
+        // Andere voorbeelden kunnen hier worden toegevoegd:
+        
+        // Voorbeeld: Validatie voor nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
+        // Lead moet naam en email hebben
+        // LeadStatusTransitionValidator::addTransitionRule(
+        //     'nieuwe-aanvraag-kwalificeren',
+        //     'klant-adviseren-start',
+        //     [
+        //         'required_fields' => ['first_name', 'last_name', 'emails'],
+        //         'message' => 'Voor de status "Klant adviseren" zijn naam en email verplicht.',
+        //     ]
+        // );
+
+        // Voorbeeld: Custom validatie voor won status
+        // LeadStatusTransitionValidator::addTransitionRule(
+        //     'klant-adviseren-opvolgen',
+        //     'won',
+        //     [
+        //         'custom_validation' => function($lead) {
+        //             $errors = [];
+        //             if (!$lead->quotes()->count()) {
+        //                 $errors[] = 'Er moet minimaal 1 offerte zijn voor deze lead.';
+        //             }
+        //             return $errors;
+        //         },
+        //         'message' => 'Voor het winnen van een lead moet er minimaal 1 offerte zijn.',
+        //     ]
+        // );
     }
 }

--- a/packages/Webkul/Lead/src/Models/Lead.php
+++ b/packages/Webkul/Lead/src/Models/Lead.php
@@ -26,6 +26,7 @@ use Webkul\Tag\Models\TagProxy;
 use Webkul\User\Models\UserProxy;
 use Database\Factories\LeadFactory;
 use App\Models\Address;
+use App\Services\LeadStatusTransitionValidator;
 
 class Lead extends Model implements LeadContract
 {
@@ -525,5 +526,41 @@ class Lead extends Model implements LeadContract
     public function getDefaultGroupId(): int
     {
         return Department::getGroupIdForLead($this);
+    }
+
+    /**
+     * Override the update method to validate status transitions.
+     * 
+     * @param array $attributes
+     * @param array $options
+     * @return bool
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function update(array $attributes = [], array $options = [])
+    {
+        // Check if lead_pipeline_stage_id is being updated
+        if (isset($attributes['lead_pipeline_stage_id']) && 
+            $attributes['lead_pipeline_stage_id'] != $this->lead_pipeline_stage_id) {
+            
+            // Validate the status transition
+            LeadStatusTransitionValidator::validateTransition($this, $attributes['lead_pipeline_stage_id']);
+        }
+
+        return parent::update($attributes, $options);
+    }
+
+    /**
+     * Update the lead's stage with validation.
+     * 
+     * @param int $newStageId
+     * @return bool
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function updateStage(int $newStageId): bool
+    {
+        // Validate the status transition
+        LeadStatusTransitionValidator::validateTransition($this, $newStageId);
+        
+        return $this->update(['lead_pipeline_stage_id' => $newStageId]);
     }
 }

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -1,201 +1,203 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Services\LeadStatusTransitionValidator;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
 use Webkul\Lead\Models\Lead;
 use Webkul\Lead\Models\Pipeline;
 use Webkul\Lead\Models\Stage;
 use Webkul\Contact\Models\Person;
+use Webkul\User\Models\User;
 
-class LeadStatusTransitionValidationTest extends TestCase
-{
-    use RefreshDatabase;
+beforeEach(function () {
+    // Create a test pipeline
+    test()->pipeline = Pipeline::create([
+        'name' => 'Test Pipeline',
+        'is_default' => 1,
+        'type' => 'lead',
+    ]);
 
-    private Lead $lead;
-    private Stage $startStage;
-    private Stage $followUpStage;
+    // Create test stages
+    test()->startStage = Stage::create([
+        'code' => 'klant-adviseren-start',
+        'name' => 'Klant adviseren',
+        'probability' => 100,
+        'sort_order' => 1,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    test()->followUpStage = Stage::create([
+        'code' => 'klant-adviseren-opvolgen',
+        'name' => 'Klant adviseren opvolgen',
+        'probability' => 100,
+        'sort_order' => 2,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
 
-        // Create a test pipeline
-        $pipeline = Pipeline::create([
-            'name' => 'Test Pipeline',
-            'is_default' => 1,
-            'type' => 'lead',
-        ]);
+    // Create a test lead
+    test()->lead = Lead::create([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'lead_pipeline_id' => test()->pipeline->id,
+        'lead_pipeline_stage_id' => test()->startStage->id,
+    ]);
 
-        // Create test stages
-        $this->startStage = Stage::create([
-            'code' => 'klant-adviseren-start',
-            'name' => 'Klant adviseren',
-            'probability' => 100,
-            'sort_order' => 1,
-            'lead_pipeline_id' => $pipeline->id,
-        ]);
+    // Configure the validation rules
+    LeadStatusTransitionValidator::addTransitionRule(
+        'klant-adviseren-start',
+        'klant-adviseren-opvolgen',
+        [
+            'min_persons' => 1,
+            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ]
+    );
 
-        $this->followUpStage = Stage::create([
-            'code' => 'klant-adviseren-opvolgen',
-            'name' => 'Klant adviseren opvolgen',
-            'probability' => 100,
-            'sort_order' => 2,
-            'lead_pipeline_id' => $pipeline->id,
-        ]);
+    // Configure validation rule for first stage transition
+    LeadStatusTransitionValidator::addTransitionRule(
+        'nieuwe-aanvraag-kwalificeren',
+        'klant-adviseren-start',
+        [
+            'required_fields' => ['first_name', 'last_name'],
+            'message' => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
+        ]
+    );
+});
 
-        // Create a test lead
-        $this->lead = Lead::create([
-            'first_name' => 'John',
-            'last_name' => 'Doe',
-            'lead_pipeline_id' => $pipeline->id,
-            'lead_pipeline_stage_id' => $this->startStage->id,
-        ]);
+test('it blocks transition when no persons are attached', function () {
+    // Lead has no persons attached
+    expect(test()->lead->persons_count)->toBe(0);
 
-        // Configure the validation rule
-        LeadStatusTransitionValidator::addTransitionRule(
-            'klant-adviseren-start',
-            'klant-adviseren-opvolgen',
-            [
-                'min_persons' => 1,
-                'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-            ]
-        );
-    }
+    // Attempt to transition should fail
+    expect(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+        ->toThrow(ValidationException::class);
+});
 
-    /** @test */
-    public function it_blocks_transition_when_no_persons_are_attached()
-    {
-        // Lead has no persons attached
-        $this->assertEquals(0, $this->lead->persons_count);
+test('it allows transition when persons are attached', function () {
+    // Create and attach a person to the lead
+    $person = Person::create([
+        'name' => 'Jane Doe',
+        'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
+    ]);
 
-        // Attempt to transition should fail
-        $this->expectException(ValidationException::class);
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
-    }
+    test()->lead->attachPersons([$person->id]);
+    
+    // Refresh the lead to get updated persons_count
+    test()->lead->refresh();
+    
+    expect(test()->lead->persons_count)->toBe(1);
 
-    /** @test */
-    public function it_allows_transition_when_persons_are_attached()
-    {
-        // Create and attach a person to the lead
-        $person = Person::create([
-            'name' => 'Jane Doe',
-            'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
-        ]);
+    // Transition should succeed
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
+});
 
-        $this->lead->attachPersons([$person->id]);
-        
-        // Refresh the lead to get updated persons_count
-        $this->lead->refresh();
-        
-        $this->assertEquals(1, $this->lead->persons_count);
+test('it allows transition when multiple persons are attached', function () {
+    // Create and attach multiple persons to the lead
+    $person1 = Person::create([
+        'name' => 'Jane Doe',
+        'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
+    ]);
 
-        // Transition should succeed
-        $this->expectNotToPerformAssertions();
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
-    }
+    $person2 = Person::create([
+        'name' => 'Bob Smith',
+        'emails' => [['value' => 'bob@example.com', 'is_default' => true]],
+    ]);
 
-    /** @test */
-    public function it_allows_transition_when_multiple_persons_are_attached()
-    {
-        // Create and attach multiple persons to the lead
-        $person1 = Person::create([
-            'name' => 'Jane Doe',
-            'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
-        ]);
+    test()->lead->attachPersons([$person1->id, $person2->id]);
+    
+    // Refresh the lead to get updated persons_count
+    test()->lead->refresh();
+    
+    expect(test()->lead->persons_count)->toBe(2);
 
-        $person2 = Person::create([
-            'name' => 'Bob Smith',
-            'emails' => [['value' => 'bob@example.com', 'is_default' => true]],
-        ]);
+    // Transition should succeed
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
+});
 
-        $this->lead->attachPersons([$person1->id, $person2->id]);
-        
-        // Refresh the lead to get updated persons_count
-        $this->lead->refresh();
-        
-        $this->assertEquals(2, $this->lead->persons_count);
+test('it ignores validation for transitions without rules', function () {
+    // Create a stage without validation rules
+    $otherStage = Stage::create([
+        'code' => 'other-stage',
+        'name' => 'Other Stage',
+        'probability' => 100,
+        'sort_order' => 3,
+        'lead_pipeline_id' => test()->lead->pipeline->id,
+    ]);
 
-        // Transition should succeed
-        $this->expectNotToPerformAssertions();
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
-    }
+    // Transition should succeed even without persons
+    LeadStatusTransitionValidator::validateTransition(test()->lead, $otherStage->id);
+});
 
-    /** @test */
-    public function it_ignores_validation_for_transitions_without_rules()
-    {
-        // Create a stage without validation rules
-        $otherStage = Stage::create([
-            'code' => 'other-stage',
-            'name' => 'Other Stage',
-            'probability' => 100,
-            'sort_order' => 3,
-            'lead_pipeline_id' => $this->lead->pipeline->id,
-        ]);
+test('it works with lead model update method', function () {
+    // Lead has no persons attached
+    expect(test()->lead->persons_count)->toBe(0);
 
-        // Transition should succeed even without persons
-        $this->expectNotToPerformAssertions();
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $otherStage->id);
-    }
+    // Attempt to update stage should fail
+    expect(fn() => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
+        ->toThrow(ValidationException::class);
+});
 
-    /** @test */
-    public function it_works_with_lead_model_update_method()
-    {
-        // Lead has no persons attached
-        $this->assertEquals(0, $this->lead->persons_count);
+test('it works with lead model update stage method', function () {
+    // Lead has no persons attached
+    expect(test()->lead->persons_count)->toBe(0);
 
-        // Attempt to update stage should fail
-        $this->expectException(ValidationException::class);
-        
-        $this->lead->update(['lead_pipeline_stage_id' => $this->followUpStage->id]);
-    }
+    // Attempt to update stage should fail
+    expect(fn() => test()->lead->updateStage(test()->followUpStage->id))
+        ->toThrow(ValidationException::class);
+});
 
-    /** @test */
-    public function it_works_with_lead_model_update_stage_method()
-    {
-        // Lead has no persons attached
-        $this->assertEquals(0, $this->lead->persons_count);
+test('it can add and remove transition rules', function () {
+    // Remove the existing rule
+    LeadStatusTransitionValidator::removeTransitionRule(
+        'klant-adviseren-start',
+        'klant-adviseren-opvolgen'
+    );
 
-        // Attempt to update stage should fail
-        $this->expectException(ValidationException::class);
-        
-        $this->lead->updateStage($this->followUpStage->id);
-    }
+    // Now transition should succeed even without persons
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
 
-    /** @test */
-    public function it_can_add_and_remove_transition_rules()
-    {
-        // Remove the existing rule
-        LeadStatusTransitionValidator::removeTransitionRule(
-            'klant-adviseren-start',
-            'klant-adviseren-opvolgen'
-        );
+    // Add the rule back
+    LeadStatusTransitionValidator::addTransitionRule(
+        'klant-adviseren-start',
+        'klant-adviseren-opvolgen',
+        [
+            'min_persons' => 1,
+            'message' => 'Test message',
+        ]
+    );
 
-        // Now transition should succeed even without persons
-        $this->expectNotToPerformAssertions();
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+    // Now transition should fail again
+    expect(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+        ->toThrow(ValidationException::class);
+});
 
-        // Add the rule back
-        LeadStatusTransitionValidator::addTransitionRule(
-            'klant-adviseren-start',
-            'klant-adviseren-opvolgen',
-            [
-                'min_persons' => 1,
-                'message' => 'Test message',
-            ]
-        );
+test('it validates required fields for first stage transition', function () {
+    // Create a lead without first_name and last_name
+    $incompleteLead = Lead::create([
+        'lead_pipeline_id' => test()->pipeline->id,
+        'lead_pipeline_stage_id' => test()->startStage->id,
+    ]);
 
-        // Now transition should fail again
-        $this->expectException(ValidationException::class);
-        
-        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
-    }
-}
+    // Create a new stage for the first transition
+    $newStage = Stage::create([
+        'code' => 'nieuwe-aanvraag-kwalificeren',
+        'name' => 'Nieuwe aanvraag kwalificeren',
+        'probability' => 100,
+        'sort_order' => 0,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
+
+    // Set the lead to the first stage
+    $incompleteLead->update(['lead_pipeline_stage_id' => $newStage->id]);
+
+    // Attempt to transition should fail due to missing required fields
+    expect(fn() => LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id))
+        ->toThrow(ValidationException::class);
+
+    // Now add the required fields
+    $incompleteLead->update([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+    ]);
+
+    // Transition should now succeed
+    LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id);
+});

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -69,7 +69,7 @@ beforeEach(function () {
 test('it blocks transition when no persons are attached', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 
     // Attempt to transition should fail
@@ -134,7 +134,7 @@ test('it ignores validation for transitions without rules', function () {
 test('it works with lead model update method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn() => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
+        ->and(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
@@ -143,7 +143,7 @@ test('it works with lead model update method', function () {
 test('it works with lead model update stage method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn() => test()->lead->updateStage(test()->followUpStage->id))
+        ->and(fn () => test()->lead->updateStage(test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -2,12 +2,16 @@
 
 use App\Services\LeadStatusTransitionValidator;
 use Illuminate\Validation\ValidationException;
+use Webkul\User\Models\User;
 use Webkul\Contact\Models\Person;
 use Webkul\Lead\Models\Lead;
 use Webkul\Lead\Models\Pipeline;
 use Webkul\Lead\Models\Stage;
 
 beforeEach(function () {
+    // Ensure an authenticated user exists to satisfy activity/user FKs
+    test()->user = User::factory()->active()->create();
+    actingAs(test()->user);
     // Create a test pipeline
     test()->pipeline = Pipeline::create([
         'name'       => 'Test Pipeline',
@@ -38,6 +42,7 @@ beforeEach(function () {
         'last_name'              => 'Doe',
         'lead_pipeline_id'       => test()->pipeline->id,
         'lead_pipeline_stage_id' => test()->startStage->id,
+        'user_id'                => test()->user->id,
     ]);
 
     // Configure the validation rules

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -2,16 +2,16 @@
 
 use App\Services\LeadStatusTransitionValidator;
 use Illuminate\Validation\ValidationException;
-use Webkul\User\Models\User;
 use Webkul\Contact\Models\Person;
 use Webkul\Lead\Models\Lead;
 use Webkul\Lead\Models\Pipeline;
 use Webkul\Lead\Models\Stage;
+use Webkul\User\Models\User;
 
 beforeEach(function () {
     // Ensure an authenticated user exists to satisfy activity/user FKs
-    test()->user = User::factory()->active()->create();
-    actingAs(test()->user);
+    test()->user = User::factory()->create();
+    test()->actingAs(test()->user);
     // Create a test pipeline
     test()->pipeline = Pipeline::create([
         'name'       => 'Test Pipeline',
@@ -68,11 +68,11 @@ beforeEach(function () {
 
 test('it blocks transition when no persons are attached', function () {
     // Lead has no persons attached
-    expect(test()->lead->persons_count)->toBe(0);
+    expect(test()->lead->persons_count)->toBe(0)
+        ->and(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+        ->toThrow(ValidationException::class);
 
     // Attempt to transition should fail
-    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
-        ->toThrow(ValidationException::class);
 });
 
 test('it allows transition when persons are attached', function () {
@@ -133,20 +133,20 @@ test('it ignores validation for transitions without rules', function () {
 
 test('it works with lead model update method', function () {
     // Lead has no persons attached
-    expect(test()->lead->persons_count)->toBe(0);
+    expect(test()->lead->persons_count)->toBe(0)
+        ->and(fn() => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
+        ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
-    expect(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
-        ->toThrow(ValidationException::class);
 });
 
 test('it works with lead model update stage method', function () {
     // Lead has no persons attached
-    expect(test()->lead->persons_count)->toBe(0);
+    expect(test()->lead->persons_count)->toBe(0)
+        ->and(fn() => test()->lead->updateStage(test()->followUpStage->id))
+        ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
-    expect(fn () => test()->lead->updateStage(test()->followUpStage->id))
-        ->toThrow(ValidationException::class);
 });
 
 test('it can add and remove transition rules', function () {

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\LeadStatusTransitionValidator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+use Webkul\Lead\Models\Lead;
+use Webkul\Lead\Models\Pipeline;
+use Webkul\Lead\Models\Stage;
+use Webkul\Contact\Models\Person;
+
+class LeadStatusTransitionValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Lead $lead;
+    private Stage $startStage;
+    private Stage $followUpStage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a test pipeline
+        $pipeline = Pipeline::create([
+            'name' => 'Test Pipeline',
+            'is_default' => 1,
+            'type' => 'lead',
+        ]);
+
+        // Create test stages
+        $this->startStage = Stage::create([
+            'code' => 'klant-adviseren-start',
+            'name' => 'Klant adviseren',
+            'probability' => 100,
+            'sort_order' => 1,
+            'lead_pipeline_id' => $pipeline->id,
+        ]);
+
+        $this->followUpStage = Stage::create([
+            'code' => 'klant-adviseren-opvolgen',
+            'name' => 'Klant adviseren opvolgen',
+            'probability' => 100,
+            'sort_order' => 2,
+            'lead_pipeline_id' => $pipeline->id,
+        ]);
+
+        // Create a test lead
+        $this->lead = Lead::create([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'lead_pipeline_id' => $pipeline->id,
+            'lead_pipeline_stage_id' => $this->startStage->id,
+        ]);
+
+        // Configure the validation rule
+        LeadStatusTransitionValidator::addTransitionRule(
+            'klant-adviseren-start',
+            'klant-adviseren-opvolgen',
+            [
+                'min_persons' => 1,
+                'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_blocks_transition_when_no_persons_are_attached()
+    {
+        // Lead has no persons attached
+        $this->assertEquals(0, $this->lead->persons_count);
+
+        // Attempt to transition should fail
+        $this->expectException(ValidationException::class);
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+    }
+
+    /** @test */
+    public function it_allows_transition_when_persons_are_attached()
+    {
+        // Create and attach a person to the lead
+        $person = Person::create([
+            'name' => 'Jane Doe',
+            'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
+        ]);
+
+        $this->lead->attachPersons([$person->id]);
+        
+        // Refresh the lead to get updated persons_count
+        $this->lead->refresh();
+        
+        $this->assertEquals(1, $this->lead->persons_count);
+
+        // Transition should succeed
+        $this->expectNotToPerformAssertions();
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+    }
+
+    /** @test */
+    public function it_allows_transition_when_multiple_persons_are_attached()
+    {
+        // Create and attach multiple persons to the lead
+        $person1 = Person::create([
+            'name' => 'Jane Doe',
+            'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
+        ]);
+
+        $person2 = Person::create([
+            'name' => 'Bob Smith',
+            'emails' => [['value' => 'bob@example.com', 'is_default' => true]],
+        ]);
+
+        $this->lead->attachPersons([$person1->id, $person2->id]);
+        
+        // Refresh the lead to get updated persons_count
+        $this->lead->refresh();
+        
+        $this->assertEquals(2, $this->lead->persons_count);
+
+        // Transition should succeed
+        $this->expectNotToPerformAssertions();
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+    }
+
+    /** @test */
+    public function it_ignores_validation_for_transitions_without_rules()
+    {
+        // Create a stage without validation rules
+        $otherStage = Stage::create([
+            'code' => 'other-stage',
+            'name' => 'Other Stage',
+            'probability' => 100,
+            'sort_order' => 3,
+            'lead_pipeline_id' => $this->lead->pipeline->id,
+        ]);
+
+        // Transition should succeed even without persons
+        $this->expectNotToPerformAssertions();
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $otherStage->id);
+    }
+
+    /** @test */
+    public function it_works_with_lead_model_update_method()
+    {
+        // Lead has no persons attached
+        $this->assertEquals(0, $this->lead->persons_count);
+
+        // Attempt to update stage should fail
+        $this->expectException(ValidationException::class);
+        
+        $this->lead->update(['lead_pipeline_stage_id' => $this->followUpStage->id]);
+    }
+
+    /** @test */
+    public function it_works_with_lead_model_update_stage_method()
+    {
+        // Lead has no persons attached
+        $this->assertEquals(0, $this->lead->persons_count);
+
+        // Attempt to update stage should fail
+        $this->expectException(ValidationException::class);
+        
+        $this->lead->updateStage($this->followUpStage->id);
+    }
+
+    /** @test */
+    public function it_can_add_and_remove_transition_rules()
+    {
+        // Remove the existing rule
+        LeadStatusTransitionValidator::removeTransitionRule(
+            'klant-adviseren-start',
+            'klant-adviseren-opvolgen'
+        );
+
+        // Now transition should succeed even without persons
+        $this->expectNotToPerformAssertions();
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+
+        // Add the rule back
+        LeadStatusTransitionValidator::addTransitionRule(
+            'klant-adviseren-start',
+            'klant-adviseren-opvolgen',
+            [
+                'min_persons' => 1,
+                'message' => 'Test message',
+            ]
+        );
+
+        // Now transition should fail again
+        $this->expectException(ValidationException::class);
+        
+        LeadStatusTransitionValidator::validateTransition($this->lead, $this->followUpStage->id);
+    }
+}

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -124,6 +124,7 @@ test('it ignores validation for transitions without rules', function () {
 
     // Transition should succeed even without persons
     LeadStatusTransitionValidator::validateTransition(test()->lead, $otherStage->id);
+    expect(true)->toBeTrue();
 });
 
 test('it works with lead model update method', function () {

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -2,42 +2,41 @@
 
 use App\Services\LeadStatusTransitionValidator;
 use Illuminate\Validation\ValidationException;
+use Webkul\Contact\Models\Person;
 use Webkul\Lead\Models\Lead;
 use Webkul\Lead\Models\Pipeline;
 use Webkul\Lead\Models\Stage;
-use Webkul\Contact\Models\Person;
-use Webkul\User\Models\User;
 
 beforeEach(function () {
     // Create a test pipeline
     test()->pipeline = Pipeline::create([
-        'name' => 'Test Pipeline',
+        'name'       => 'Test Pipeline',
         'is_default' => 1,
-        'type' => 'lead',
+        'type'       => 'lead',
     ]);
 
     // Create test stages
     test()->startStage = Stage::create([
-        'code' => 'klant-adviseren-start',
-        'name' => 'Klant adviseren',
-        'probability' => 100,
-        'sort_order' => 1,
+        'code'             => 'klant-adviseren-start',
+        'name'             => 'Klant adviseren',
+        'probability'      => 100,
+        'sort_order'       => 1,
         'lead_pipeline_id' => test()->pipeline->id,
     ]);
 
     test()->followUpStage = Stage::create([
-        'code' => 'klant-adviseren-opvolgen',
-        'name' => 'Klant adviseren opvolgen',
-        'probability' => 100,
-        'sort_order' => 2,
+        'code'             => 'klant-adviseren-opvolgen',
+        'name'             => 'Klant adviseren opvolgen',
+        'probability'      => 100,
+        'sort_order'       => 2,
         'lead_pipeline_id' => test()->pipeline->id,
     ]);
 
     // Create a test lead
     test()->lead = Lead::create([
-        'first_name' => 'John',
-        'last_name' => 'Doe',
-        'lead_pipeline_id' => test()->pipeline->id,
+        'first_name'             => 'John',
+        'last_name'              => 'Doe',
+        'lead_pipeline_id'       => test()->pipeline->id,
         'lead_pipeline_stage_id' => test()->startStage->id,
     ]);
 
@@ -47,7 +46,7 @@ beforeEach(function () {
         'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
-            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'message'     => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ]
     );
 
@@ -57,7 +56,7 @@ beforeEach(function () {
         'klant-adviseren-start',
         [
             'required_fields' => ['first_name', 'last_name'],
-            'message' => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
+            'message'         => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
         ]
     );
 });
@@ -67,22 +66,22 @@ test('it blocks transition when no persons are attached', function () {
     expect(test()->lead->persons_count)->toBe(0);
 
     // Attempt to transition should fail
-    expect(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 });
 
 test('it allows transition when persons are attached', function () {
     // Create and attach a person to the lead
     $person = Person::create([
-        'name' => 'Jane Doe',
+        'name'   => 'Jane Doe',
         'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
     ]);
 
     test()->lead->attachPersons([$person->id]);
-    
+
     // Refresh the lead to get updated persons_count
     test()->lead->refresh();
-    
+
     expect(test()->lead->persons_count)->toBe(1);
 
     // Transition should succeed
@@ -92,20 +91,20 @@ test('it allows transition when persons are attached', function () {
 test('it allows transition when multiple persons are attached', function () {
     // Create and attach multiple persons to the lead
     $person1 = Person::create([
-        'name' => 'Jane Doe',
+        'name'   => 'Jane Doe',
         'emails' => [['value' => 'jane@example.com', 'is_default' => true]],
     ]);
 
     $person2 = Person::create([
-        'name' => 'Bob Smith',
+        'name'   => 'Bob Smith',
         'emails' => [['value' => 'bob@example.com', 'is_default' => true]],
     ]);
 
     test()->lead->attachPersons([$person1->id, $person2->id]);
-    
+
     // Refresh the lead to get updated persons_count
     test()->lead->refresh();
-    
+
     expect(test()->lead->persons_count)->toBe(2);
 
     // Transition should succeed
@@ -115,10 +114,10 @@ test('it allows transition when multiple persons are attached', function () {
 test('it ignores validation for transitions without rules', function () {
     // Create a stage without validation rules
     $otherStage = Stage::create([
-        'code' => 'other-stage',
-        'name' => 'Other Stage',
-        'probability' => 100,
-        'sort_order' => 3,
+        'code'             => 'other-stage',
+        'name'             => 'Other Stage',
+        'probability'      => 100,
+        'sort_order'       => 3,
         'lead_pipeline_id' => test()->lead->pipeline->id,
     ]);
 
@@ -132,7 +131,7 @@ test('it works with lead model update method', function () {
     expect(test()->lead->persons_count)->toBe(0);
 
     // Attempt to update stage should fail
-    expect(fn() => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
+    expect(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
         ->toThrow(ValidationException::class);
 });
 
@@ -141,7 +140,7 @@ test('it works with lead model update stage method', function () {
     expect(test()->lead->persons_count)->toBe(0);
 
     // Attempt to update stage should fail
-    expect(fn() => test()->lead->updateStage(test()->followUpStage->id))
+    expect(fn () => test()->lead->updateStage(test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 });
 
@@ -161,28 +160,28 @@ test('it can add and remove transition rules', function () {
         'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
-            'message' => 'Test message',
+            'message'     => 'Test message',
         ]
     );
 
     // Now transition should fail again
-    expect(fn() => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 });
 
 test('it validates required fields for first stage transition', function () {
     // Create a lead without first_name and last_name
     $incompleteLead = Lead::create([
-        'lead_pipeline_id' => test()->pipeline->id,
+        'lead_pipeline_id'       => test()->pipeline->id,
         'lead_pipeline_stage_id' => test()->startStage->id,
     ]);
 
     // Create a new stage for the first transition
     $newStage = Stage::create([
-        'code' => 'nieuwe-aanvraag-kwalificeren',
-        'name' => 'Nieuwe aanvraag kwalificeren',
-        'probability' => 100,
-        'sort_order' => 0,
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag kwalificeren',
+        'probability'      => 100,
+        'sort_order'       => 0,
         'lead_pipeline_id' => test()->pipeline->id,
     ]);
 
@@ -190,13 +189,13 @@ test('it validates required fields for first stage transition', function () {
     $incompleteLead->update(['lead_pipeline_stage_id' => $newStage->id]);
 
     // Attempt to transition should fail due to missing required fields
-    expect(fn() => LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id))
+    expect(fn () => LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id))
         ->toThrow(ValidationException::class);
 
     // Now add the required fields
     $incompleteLead->update([
         'first_name' => 'John',
-        'last_name' => 'Doe',
+        'last_name'  => 'Doe',
     ]);
 
     // Transition should now succeed


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Implements a configurable validation mechanism for lead status transitions. This allows defining rules (e.g., minimum persons, required fields, custom logic) per stage transition, preventing leads from entering invalid states. Configuration is managed in `PipelineSeeder`, and validation is automatically applied during lead stage updates via the `Lead` model and `LeadController`. An example rule ensures a lead has at least one person when transitioning from `klant-adviseren-start` to `klant-adviseren-opvolgen`.

## How To Test This?
1.  Run the dedicated feature test: `php artisan test tests/Feature/LeadStatusTransitionValidationTest.php`
2.  Manually:
    *   Create a lead and set its status to `klant-adviseren-start`.
    *   Attempt to change its status to `klant-adviseren-opvolgen` without any persons attached. This should result in a validation error.
    *   Attach at least one person to the lead.
    *   Attempt the same status transition again. This should now succeed.

## Documentation
- [x] My pull request requires an update on the documentation repository.
A new documentation file `docs/LeadStatusTransitionValidation.md` has been created, detailing the new validation mechanism, its configuration, and usage.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-af9b1179-147c-4735-8c03-f47a79b8f90d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af9b1179-147c-4735-8c03-f47a79b8f90d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

