### PR TITLE
Prevent lead pipeline change on drag

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -738,12 +738,6 @@
                         .put("{{ route('admin.leads.stage.update', 'replace') }}".replace('replace', leadId), data)
                         .then(response => {
                             this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
-                            
-                            // Update stage counters after successful update
-                            const stage = this.stages.find(s => s.id === stageId);
-                            if (stage) {
-                                this.stageLeads[stage.sort_order].leads.meta.total = this.stageLeads[stage.sort_order].leads.meta.total + 1;
-                            }
                         })
                         .catch(error => {
                             this.$emitter.emit('add-flash', { type: 'error', message: error.response.data.message });


### PR DESCRIPTION
## Issue Reference
Addresses a reported UI inconsistency where moving a lead on the Kanban board appeared to change its pipeline.

## Description
Removed a redundant client-side increment of the target stage's lead counter after a successful lead stage update. This extra increment caused a visual discrepancy, making it seem like the lead count was incorrectly updated or that the lead moved to a different pipeline, even though the backend update was correct. The UI now accurately reflects the lead counts based on the backend response.

## How To Test This?
1.  Navigate to the Leads Kanban board.
2.  Drag and drop a lead from one stage to another within the same pipeline.
3.  Observe that the lead count for the source and target stages updates correctly, and there are no visual artifacts suggesting the lead moved to a different pipeline.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-6ba349c8-3236-4474-b33f-aad15a96ebc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ba349c8-3236-4474-b33f-aad15a96ebc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

