### PR TITLE
Fix intermittent user factory test failure

### DIFF
--- a/database/factories/WebkulUserFactory.php
+++ b/database/factories/WebkulUserFactory.php
@@ -37,7 +37,7 @@ class WebkulUserFactory extends Factory
             'name'     => $this->faker->name,
             'email'    => $this->faker->unique()->safeEmail,
             'password' => bcrypt('password'), // Default password
-            'status'   => $this->faker->boolean(80), // 80% chance of being active
+            'status'   => true, // Always active in factory to avoid flaky tests
             'role_id'  => $role->id,
         ];
     }


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR addresses a flaky test (`PersonControllerSearchTest`) that occasionally failed with a 302 redirect instead of the expected 200 status. The root cause was the `WebkulUserFactory` having a 20% chance of creating an inactive user, which could lead to authentication redirects during tests.

The `WebkulUserFactory` has been updated to always create active users, ensuring consistent test execution and preventing unexpected authentication failures.

## How To Test This?
Run the specific feature test or the entire feature test suite:
*   `./vendor/bin/pest --testsuite=Feature --filter=PersonControllerSearchTest`
*   `./vendor/bin/phpunit --filter PersonControllerSearchTest`

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering

---
<a href="https://cursor.com/background-agent?bcId=bc-eae23a2f-8b03-488b-8b8b-cf78d2cf1f0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eae23a2f-8b03-488b-8b8b-cf78d2cf1f0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

