### PR TITLE
Add lead diagnostic form property and update kanban

### DIFF
--- a/database/migrations/2025_09_10_000001_add_has_diagnosis_form_to_leads_table.php
+++ b/database/migrations/2025_09_10_000001_add_has_diagnosis_form_to_leads_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            if (!Schema::hasColumn('leads', 'has_diagnosis_form')) {
+                $table->boolean('has_diagnosis_form')->default(false)->after('mri_status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            if (Schema::hasColumn('leads', 'has_diagnosis_form')) {
+                $table->dropColumn('has_diagnosis_form');
+            }
+        });
+    }
+};
+

--- a/packages/Webkul/Admin/src/Http/Resources/LeadResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/LeadResource.php
@@ -33,6 +33,7 @@ class LeadResource extends JsonResource
             'status'               => $this->status,
             'mri_status'           => $this->mri_status,
             'mri_status_label'     => $this->mri_status?->label() ?? null,
+            'has_diagnosis_form'   => (bool) ($this->has_diagnosis_form ?? false),
             'lost_reason'          => $this->lost_reason,
             'closed_at'            => $this->closed_at?->format('Y-m-d H:i:s'),
             'rotten_days'          => $this->rotten_days,

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -448,6 +448,23 @@
                                                     @endforeach
                                                 </x-admin::form.control-group.control>
                                             </x-admin::form.control-group>
+
+                                            <!-- Diagnoseformulier aanwezig? -->
+                                            <x-admin::form.control-group class="mt-2">
+                                                <x-admin::form.control-group.label>
+                                                    Diagnoseformulier aanwezig?
+                                                </x-admin::form.control-group.label>
+                                                <div class="flex items-center gap-2">
+                                                    <input type="hidden" name="has_diagnosis_form" value="0" />
+                                                    <input
+                                                        type="checkbox"
+                                                        name="has_diagnosis_form"
+                                                        value="1"
+                                                        class="cursor-pointer"
+                                                    />
+                                                    <span class="text-sm text-gray-600 dark:text-gray-300">Ja</span>
+                                                </div>
+                                            </x-admin::form.control-group>
                                         </div>
                                         <!-- Combine Order Setting -->
                                         <div class="flex-1">

--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -238,7 +238,7 @@
                                 </div>
                             </div>
 
-                            <!-- MRI STATUS -->
+                            <!-- MRI STATUS + Diagnoseformulier -->
                             <div class="mb-0.5">
                                 <x-admin::form.control-group class="w-40">
                                     <x-admin::form.control-group.label>
@@ -246,7 +246,7 @@
                                     </x-admin::form.control-group.label>
 
                                     @php
-                                        $current = old('mri_status', $lead->mri_status?->value); // 'mr' | 'mrs' | null
+                                        $current = old('mri_status', $lead->mri_status?->value);
                                     @endphp
                                     @php
                                         if ($current === null || $current === '') {
@@ -267,6 +267,23 @@
                                     </x-admin::form.control-group.control>
 
                                     <x-admin::form.control-group.error control-name="mri_status"/>
+                                </x-admin::form.control-group>
+
+                                <x-admin::form.control-group class="w-40 mt-2">
+                                    <x-admin::form.control-group.label>
+                                        Diagnoseformulier aanwezig?
+                                    </x-admin::form.control-group.label>
+                                    <div class="flex items-center gap-2">
+                                        <input type="hidden" name="has_diagnosis_form" value="0" />
+                                        <input
+                                            type="checkbox"
+                                            name="has_diagnosis_form"
+                                            value="1"
+                                            class="cursor-pointer"
+                                            {{ old('has_diagnosis_form', $lead->has_diagnosis_form ? '1' : '0') == '1' ? 'checked' : '' }}
+                                        />
+                                        <span class="text-sm text-gray-600 dark:text-gray-300">Ja</span>
+                                    </div>
                                 </x-admin::form.control-group>
                             </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -194,7 +194,7 @@
                                     <!-- Card Footer -->
                                     <div
                                         class="flex items-center justify-between mt-2 pt-2 border-t border-gray-200 dark:border-gray-600"
-                                        v-if="element.has_duplicates || (element.open_activities_count && element.open_activities_count > 0) || (element.unread_emails_count && element.unread_emails_count > 0) || element.mri_status"
+                                        v-if="element.has_duplicates || (element.open_activities_count && element.open_activities_count > 0) || (element.unread_emails_count && element.unread_emails_count > 0) || element.mri_status || element.has_diagnosis_form"
                                     >
                                         <div class="flex items-center gap-3">
                                             <!-- Open Activities Count -->
@@ -262,6 +262,18 @@
                                             >
                                                 @{{ Math.abs(element.days_until_due_date) }}d over
                                             </span>
+
+                                            <!-- Diagnosis Form Icon bottom-right (to the left of MRI) -->
+                                            <div v-if="element.has_diagnosis_form"
+                                                 class="absolute -bottom-1 right-4 group">
+                                                <span class="icon-attachment text-xs"></span>
+                                                <div class="absolute -top-1 right-5 hidden w-max flex-col items-center group-hover:flex">
+                                                    <span class="whitespace-no-wrap relative rounded-md bg-black px-2 py-1 text-[10px] leading-none text-white shadow-lg">
+                                                        Diagnoseformulier aanwezig
+                                                    </span>
+                                                    <div class="absolute -right-1 top-2 h-2 w-2 rotate-45 bg-black"></div>
+                                                </div>
+                                            </div>
 
                                             <!-- MRI Status Icon bottom-right -->
                                             <div v-if="element.mri_status"

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/compact-overview.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/compact-overview.blade.php
@@ -161,6 +161,21 @@
                             </div>
                         </div>
 
+                        <!-- Diagnoseformulier aanwezig -->
+                        <div class="mb-3">
+                            <div class="text-xs text-gray-400 dark:text-gray-500 mb-1">Diagnoseformulier</div>
+                            <div class="text-sm text-gray-900 dark:text-gray-100">
+                                @if($lead->has_diagnosis_form)
+                                    <span class="inline-flex items-center gap-1 text-green-700">
+                                        <span class="icon-attachment text-xs"></span>
+                                        Aanwezig
+                                    </span>
+                                @else
+                                    <span class="text-gray-500">Niet aanwezig</span>
+                                @endif
+                            </div>
+                        </div>
+
                         <!-- Lead Source -->
                         <div class="mb-3">
                             <div class="text-xs text-gray-400 dark:text-gray-500 mb-1">Bron</div>

--- a/packages/Webkul/Lead/src/Models/Lead.php
+++ b/packages/Webkul/Lead/src/Models/Lead.php
@@ -43,6 +43,7 @@ class Lead extends Model implements LeadContract
         'gender'              => PersonGender::class,
         'salutation'          => PersonSalutation::class,
         'mri_status'          => MRIStatus::class,
+        'has_diagnosis_form'  => 'boolean',
     ];
 
     /**
@@ -90,6 +91,7 @@ class Lead extends Model implements LeadContract
         'created_by',
         'updated_by',
         'mri_status',
+        'has_diagnosis_form',
     ];
 
     /**


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces a new `has_diagnosis_form` boolean property to the `Lead` entity. This property is now exposed via the API and used to conditionally display an attachment icon on the Leads Kanban card. The new icon is positioned to the left of the existing MRI icon when a diagnosis form is present.

## How To Test This?
1.  Run `php artisan migrate --force`.
2.  Update an existing lead or create a new one, setting the `has_diagnosis_form` column to `true` in the database.
3.  Navigate to the Leads Kanban board.
4.  Verify that leads with `has_diagnosis_form = true` display an attachment icon to the left of the MRI icon (if the MRI icon is also present).

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Tailwind Reordering
- [x]

---
<a href="https://cursor.com/background-agent?bcId=bc-5c66631c-357e-490e-aeb0-30bcea2ce9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c66631c-357e-490e-aeb0-30bcea2ce9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

