### PR TITLE
Integrate user default values in lead creation

### DIFF
--- a/app/Services/UserDefaultValueService.php
+++ b/app/Services/UserDefaultValueService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services;
+
+use Webkul\User\Models\UserDefaultValue;
+use Illuminate\Support\Collection;
+
+class UserDefaultValueService
+{
+    /**
+     * Get default values for a user by key pattern
+     *
+     * @param int $userId
+     * @param string $keyPattern
+     * @return Collection
+     */
+    public function getDefaultsForUser(int $userId, string $keyPattern = 'lead.%'): Collection
+    {
+        return UserDefaultValue::where('user_id', $userId)
+            ->where('key', 'like', $keyPattern)
+            ->get()
+            ->pluck('value', 'key');
+    }
+
+    /**
+     * Get default values for lead fields
+     *
+     * @param int $userId
+     * @return array
+     */
+    public function getLeadDefaults(int $userId): array
+    {
+        $defaults = $this->getDefaultsForUser($userId, 'lead.%');
+        
+        $leadDefaults = [];
+        
+        foreach ($defaults as $key => $value) {
+            // Remove 'lead.' prefix to get the field name
+            $fieldName = str_replace('lead.', '', $key);
+            $leadDefaults[$fieldName] = $value;
+        }
+        
+        return $leadDefaults;
+    }
+
+    /**
+     * Set a default value for a user
+     *
+     * @param int $userId
+     * @param string $key
+     * @param string $value
+     * @return UserDefaultValue
+     */
+    public function setDefault(int $userId, string $key, string $value): UserDefaultValue
+    {
+        return UserDefaultValue::updateOrCreate(
+            [
+                'user_id' => $userId,
+                'key' => $key,
+            ],
+            [
+                'value' => $value,
+                'created_by' => $userId,
+                'updated_by' => $userId,
+            ]
+        );
+    }
+
+    /**
+     * Get a specific default value for a user
+     *
+     * @param int $userId
+     * @param string $key
+     * @return string|null
+     */
+    public function getDefault(int $userId, string $key): ?string
+    {
+        $default = UserDefaultValue::where('user_id', $userId)
+            ->where('key', $key)
+            ->first();
+            
+        return $default ? $default->value : null;
+    }
+}

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -40,6 +40,7 @@ use InvalidArgumentException;
 use App\Services\LeadValidationService;
 use App\Services\PipelineCookieService;
 use App\Services\LeadStatusTransitionValidator;
+use App\Services\UserDefaultValueService;
 
 class LeadController extends Controller
 {
@@ -68,7 +69,8 @@ class LeadController extends Controller
         protected LeadRepository      $leadRepository,
         protected ProductRepository   $productRepository,
         protected PersonRepository    $personRepository,
-        protected PipelineCookieService $pipelineCookieService
+        protected PipelineCookieService $pipelineCookieService,
+        protected UserDefaultValueService $userDefaultValueService
     )
     {
         request()->request->add(['entity_type' => 'leads']);
@@ -238,6 +240,9 @@ class LeadController extends Controller
         $userGroupNames = $user->groups->pluck('name')->toArray();
         $defaultDepartmentId = Department::mapGroupToDepartmentId($userGroupNames);
 
+        // Get user default values for lead fields
+        $userDefaults = $this->userDefaultValueService->getLeadDefaults($user->id);
+
         // Get effective pipeline ID (URL parameter takes precedence over cookie)
         $effectivePipelineId = $this->pipelineCookieService->getEffectivePipelineId(request('pipeline_id'));
 
@@ -304,6 +309,7 @@ class LeadController extends Controller
             'departmentOptions' => Department::pluck('name', 'id')->toArray(),
             'prefilledPersons' => $prefilledPersons,
             'prefilledLeadPerson' => $prefilledLeadPerson,
+            'userDefaults' => $userDefaults,
         ]);
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -7,7 +7,7 @@
     {!! view_render_event('admin.leads.create.form.before') !!}
 
     <!-- Two-Step Lead Form -->
-    <v-two-step-lead-form :initial-persons='@json($prefilledPersons ?? [])' :initial-lead-person='@json($prefilledLeadPerson ?? null)'></v-two-step-lead-form>
+    <v-two-step-lead-form :initial-persons='@json($prefilledPersons ?? [])' :initial-lead-person='@json($prefilledLeadPerson ?? null)' :user-defaults='@json($userDefaults ?? {})'></v-two-step-lead-form>
 
     {!! view_render_event('admin.leads.create.form.after') !!}
 
@@ -306,10 +306,10 @@
                                     @include('admin::leads.common.sections.channel-to-owner', [
                                         'entity' => null,
                                         'defaults' => [
-                                            'department_id' => $defaultDepartmentId ?? '',
+                                            'department_id' => $userDefaults['department_id'] ?? $defaultDepartmentId ?? '',
                                             'combine_order' => 1,
-                                            'lead_channel_id' => '1',
-                                            'lead_source_id' => 32,
+                                            'lead_channel_id' => $userDefaults['lead_channel_id'] ?? '1',
+                                            'lead_source_id' => $userDefaults['lead_source_id'] ?? 32,
                                         ],
                                         'useVueModel' => false,
                                     ])
@@ -355,6 +355,10 @@
                     initialLeadPerson: {
                         type: Object,
                         default: null
+                    },
+                    userDefaults: {
+                        type: Object,
+                        default: () => ({})
                     }
                 },
 
@@ -366,24 +370,24 @@
                         isSubmitting: false,
                         formData: {
                         description: '',
-                        lead_channel_id: '1', // Default: Telefoon
-                        lead_source_id: 32, // Default: Anders
-                        department_id: '{{ $defaultDepartmentId ?? "" }}', // Set based on pipeline or user groups
+                        lead_channel_id: this.userDefaults.lead_channel_id || '1', // Default: Telefoon
+                        lead_source_id: this.userDefaults.lead_source_id || 32, // Default: Anders
+                        department_id: this.userDefaults.department_id || '{{ $defaultDepartmentId ?? "" }}', // Set based on pipeline or user groups
                         lead_pipeline_id: '{{ $defaultPipelineId ?? "" }}', // Set based on department or URL param
                         lead_pipeline_stage_id: '{{ $defaultStageId ?? "" }}', // Set based on pipeline or URL param
                         combine_order: 1,
-                        mri_status: '',
-                            lead_type_id: '1', // Default: Preventie
+                        mri_status: this.userDefaults.mri_status || '',
+                            lead_type_id: this.userDefaults.lead_type_id || '1', // Default: Preventie
                             // Personal fields for matching
-                            salutation: this.initialLeadPerson?.salutation?.value || '',
-                            initials: this.initialLeadPerson?.initials || '',
-                            first_name: this.initialLeadPerson?.first_name || '',
-                            lastname_prefix: this.initialLeadPerson?.lastname_prefix || '',
-                            last_name: this.initialLeadPerson?.last_name || '',
-                            married_name_prefix: this.initialLeadPerson?.married_name_prefix || '',
-                            married_name: this.initialLeadPerson?.married_name || '',
-                            email: '',
-                            phone: '',
+                            salutation: this.initialLeadPerson?.salutation?.value || this.userDefaults.salutation || '',
+                            initials: this.initialLeadPerson?.initials || this.userDefaults.initials || '',
+                            first_name: this.initialLeadPerson?.first_name || this.userDefaults.first_name || '',
+                            lastname_prefix: this.initialLeadPerson?.lastname_prefix || this.userDefaults.lastname_prefix || '',
+                            last_name: this.initialLeadPerson?.last_name || this.userDefaults.last_name || '',
+                            married_name_prefix: this.initialLeadPerson?.married_name_prefix || this.userDefaults.married_name_prefix || '',
+                            married_name: this.initialLeadPerson?.married_name || this.userDefaults.married_name || '',
+                            email: this.userDefaults.email || '',
+                            phone: this.userDefaults.phone || '',
                         },
                         hasSelectedPersons: false,
                         joinedPersonNames: ''

--- a/tests/Feature/UserDefaultValueServiceTest.php
+++ b/tests/Feature/UserDefaultValueServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Services\UserDefaultValueService;
+use Webkul\User\Models\User;
+use Webkul\User\Models\UserDefaultValue;
+
+it('can get lead defaults for a user', function () {
+    $user = User::factory()->create();
+    $service = new UserDefaultValueService();
+
+    // Create some default values
+    UserDefaultValue::create([
+        'user_id' => $user->id,
+        'key' => 'lead.department_id',
+        'value' => '2',
+        'created_by' => $user->id,
+        'updated_by' => $user->id,
+    ]);
+
+    UserDefaultValue::create([
+        'user_id' => $user->id,
+        'key' => 'lead.lead_channel_id',
+        'value' => '3',
+        'created_by' => $user->id,
+        'updated_by' => $user->id,
+    ]);
+
+    $defaults = $service->getLeadDefaults($user->id);
+
+    expect($defaults)->toHaveKey('department_id')
+        ->and($defaults)->toHaveKey('lead_channel_id')
+        ->and($defaults['department_id'])->toBe('2')
+        ->and($defaults['lead_channel_id'])->toBe('3');
+});
+
+it('can set and get a specific default value', function () {
+    $user = User::factory()->create();
+    $service = new UserDefaultValueService();
+
+    // Set a default value
+    $service->setDefault($user->id, 'lead.lead_source_id', '5');
+
+    // Get the default value
+    $value = $service->getDefault($user->id, 'lead.lead_source_id');
+
+    expect($value)->toBe('5');
+});
+
+it('returns null for non-existent default values', function () {
+    $user = User::factory()->create();
+    $service = new UserDefaultValueService();
+
+    $value = $service->getDefault($user->id, 'lead.non_existent');
+
+    expect($value)->toBeNull();
+});
+
+it('can update existing default values', function () {
+    $user = User::factory()->create();
+    $service = new UserDefaultValueService();
+
+    // Set initial value
+    $service->setDefault($user->id, 'lead.department_id', '2');
+
+    // Update the value
+    $service->setDefault($user->id, 'lead.department_id', '3');
+
+    $value = $service->getDefault($user->id, 'lead.department_id');
+
+    expect($value)->toBe('3');
+    
+    // Should only have one record
+    $count = UserDefaultValue::where('user_id', $user->id)
+        ->where('key', 'lead.department_id')
+        ->count();
+        
+    expect($count)->toBe(1);
+});


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
This PR integrates the `userDefaultValues` entity into the lead creation flow. A new `UserDefaultValueService` fetches user-specific default values for lead fields (e.g., `department_id`, `lead_channel_id`, personal fields). These defaults are passed to the lead creation Vue component, which then pre-fills the relevant form fields. This enhances the user experience by reducing repetitive data entry.

## How To Test This?
1.  Log in as an admin.
2.  Navigate to `admin/settings/users` and edit a user.
3.  In the "User Default Values" section, set default values for various lead fields (e.g., `lead.department_id`, `lead.lead_channel_id`, `lead.first_name`).
4.  Save the user.
5.  Navigate to "Leads" and click "Create Lead".
6.  Verify that the lead creation form fields are pre-filled with the values set in step 3.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-cb17786d-e777-4157-9a62-95d954a1140e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb17786d-e777-4157-9a62-95d954a1140e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

