### PR TITLE
Adjust datagrid settings and columns

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
@@ -170,46 +170,7 @@ class ActivityDataGrid extends DataGrid
             'sortable'   => true,
         ]);
 
-        $this->addColumn([
-            'index'              => 'type',
-            'label'              => trans('admin::app.activities.index.datagrid.type'),
-            'type'               => 'string',
-            'searchable'         => false,
-            'filterable'         => true,
-            'filterable_type'    => 'dropdown',
-            'filterable_options' => $this->getActivityTypeDropdownOptions(),
-            'sortable'           => true,
-            'closure'            => fn ($row) => trans('admin::app.activities.edit.'.$row->type),
-        ]);
-
-        $this->addColumn([
-            'index'              => 'assigned_user_id',
-            'label'              => trans('admin::app.activities.index.datagrid.assigned_to'),
-            'type'               => 'string',
-            'searchable'         => false,
-            'sortable'           => true,
-            'filterable'         => true,
-            'filterable_type'    => 'searchable_dropdown',
-            'filterable_options' => [
-                'repository' => UserRepository::class,
-                'column'     => [
-                    'label' => 'name',
-                    'value' => 'name',
-                ],
-            ],
-            'closure'    => function ($row) {
-                $route = urldecode(route('admin.settings.users.index', ['id[eq]' => $row->assigned_user_id]));
-
-                return "<a class='text-brandColor hover:underline' href='".$route."'>".$row->created_by.'</a>';
-            },
-        ]);
-
-        $this->addColumn([
-            'index'   => 'comment',
-            'label'   => trans('admin::app.activities.index.datagrid.comment'),
-            'type'    => 'string',
-        ]);
-
+        // Place "Gerelateerd aan" (entity_type) before "type"
         $this->addColumn([
             'index'              => 'entity_type',
             'label'              => 'Gerelateerd aan',
@@ -273,6 +234,42 @@ class ActivityDataGrid extends DataGrid
                 return "<a class='text-brandColor hover:underline' target='_blank' href='".$route."'>".$label.'</a>';
             },
         ]);
+
+        $this->addColumn([
+            'index'              => 'type',
+            'label'              => trans('admin::app.activities.index.datagrid.type'),
+            'type'               => 'string',
+            'searchable'         => false,
+            'filterable'         => true,
+            'filterable_type'    => 'dropdown',
+            'filterable_options' => $this->getActivityTypeDropdownOptions(),
+            'sortable'           => true,
+            'closure'            => fn ($row) => trans('admin::app.activities.edit.'.$row->type),
+        ]);
+
+        $this->addColumn([
+            'index'              => 'assigned_user_id',
+            'label'              => trans('admin::app.activities.index.datagrid.assigned_to'),
+            'type'               => 'string',
+            'searchable'         => false,
+            'sortable'           => true,
+            'filterable'         => true,
+            'filterable_type'    => 'searchable_dropdown',
+            'filterable_options' => [
+                'repository' => UserRepository::class,
+                'column'     => [
+                    'label' => 'name',
+                    'value' => 'name',
+                ],
+            ],
+            'closure'    => function ($row) {
+                $route = urldecode(route('admin.settings.users.index', ['id[eq]' => $row->assigned_user_id]));
+
+                return "<a class='text-brandColor hover:underline' href='".$route."'>".$row->created_by.'</a>';
+            },
+        ]);
+
+        // Removed comment column as requested
 
 
         $this->addColumn([
@@ -385,11 +382,7 @@ class ActivityDataGrid extends DataGrid
      */
     public function prepareMassActions(): void
     {
-        $this->addMassAction([
-            'title'  => trans('admin::app.activities.index.datagrid.delete'),
-            'url'    => route('admin.activities.mass_delete'),
-            'method' => 'POST',
-        ]);
+        // Intentionally left blank: no bulk/mass actions; also hides bulk selection UI
     }
 
 }


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This pull request implements the following changes to the activity datagrid based on user requirements:
-   Removed the bulk selection functionality and its associated UI.
-   Reordered columns to display "Gerelateerd aan" before "Type".
-   Removed the "Comment" column.

## How To Test This?
1.  Navigate to the activity datagrid in the admin panel.
2.  Verify that no checkboxes for bulk selection are present in the datagrid.
3.  Confirm that the "Gerelateerd aan" column appears immediately before the "Type" column.
4.  Ensure that the "Comment" column is no longer visible in the datagrid.

## Documentation
-   [ ] My pull request requires an update on the documentation repository.

## Branch Selection
-   [x] Target Branch: master

## Tailwind Reordering
-   [x] Please make sure all the Tailwind classes are reordered.

---
<a href="https://cursor.com/background-agent?bcId=bc-81f11c6c-23a6-402c-b80b-7987ef393b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81f11c6c-23a6-402c-b80b-7987ef393b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

