### PR TITLE
Make completed status unclickable

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -122,10 +122,12 @@
                         </script>
                         <div class="flex items-center gap-2" id="activity-status-buttons" data-update-url="{{ route('admin.activities.update', $activity->id) }}" data-csrf="{{ csrf_token() }}">
                             @foreach ($options as $opt)
+                                @php $isDone = $opt === 'done'; @endphp
                                 <button type="button"
                                         data-status="{{ $opt }}"
-                                        onclick="window.updateActivityStatus && window.updateActivityStatus('{{ $opt }}')"
-                                        class="status-btn {{ $baseClasses }} {{ $status === $opt ? ($activeMap[$opt] ?? '') : $inactiveClasses }}">
+                                        @if(!$isDone) onclick="window.updateActivityStatus && window.updateActivityStatus('{{ $opt }}')" @endif
+                                        @if($isDone) disabled aria-disabled="true" @endif
+                                        class="status-btn {{ $baseClasses }} {{ $status === $opt ? ($activeMap[$opt] ?? '') : $inactiveClasses }} @if($isDone) cursor-not-allowed opacity-80 @endif">
                                     {{ $statusLabels[$opt] }}
                                 </button>
                             @endforeach
@@ -141,6 +143,7 @@
                                 document.addEventListener('click', async function(e){
                                     const btn = e.target && e.target.closest ? e.target.closest('button.status-btn') : null;
                                     if (!btn || !container.contains(btn)) return;
+                                    if (btn.hasAttribute('disabled') || btn.getAttribute('aria-disabled') === 'true') return;
                                     e.preventDefault();
                                     e.stopPropagation();
                                     const status = btn.getAttribute('data-status');


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Prevents direct clicking on the 'Afgerond' (Completed) status pill in the activity edit view. This ensures that the activity completion status is exclusively managed via the dedicated 'Afgerond' or 'Heropenen' buttons, aligning with the intended user flow.

## How To Test This?
1.  Navigate to an activity's edit page.
2.  Observe the status pills (e.g., 'Open', 'Pending', 'Afgerond').
3.  Verify that the 'Afgerond' status pill is visually disabled and cannot be clicked to change the status.
4.  Confirm that the activity's completion status can still be changed correctly using the 'Afronden' or 'Heropenen' buttons.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-f389b59f-d97f-46ab-a103-e2d3397025a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f389b59f-d97f-46ab-a103-e2d3397025a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

