### PR TITLE
Fix undefined status in activity resource

### DIFF
--- a/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
@@ -3,6 +3,7 @@
 namespace Webkul\Admin\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Throwable;
 
 class ActivityResource extends JsonResource
 {
@@ -42,7 +43,7 @@ class ActivityResource extends JsonResource
                             ];
                         });
                     }
-                } catch (\Throwable $e) {
+                } catch (Throwable $e) {
                     // Fallback handled below
                 }
 

--- a/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
@@ -97,7 +97,24 @@ class ActivityResource extends JsonResource
         return $data;
     }
 
-    private function renderStatus():string {
-        return $this->status?->label() ?? ($this->is_done ? 'Afgerond' : 'Open');
+    private function renderStatus(): string
+    {
+        // Safely fetch status from the underlying resource (array|object|model)
+        $status = data_get($this->resource, 'status');
+
+        // If status is an enum/object with a label method
+        if (is_object($status) && method_exists($status, 'label')) {
+            return $status->label();
+        }
+
+        // If status is already a scalar/string value
+        if (is_string($status) && $status !== '') {
+            return $status;
+        }
+
+        // Fallback to is_done when status is not available
+        $isDone = (bool) data_get($this->resource, 'is_done', false);
+
+        return $isDone ? 'Afgerond' : 'Open';
     }
 }

--- a/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
@@ -176,11 +176,11 @@
 
         <!-- Right Panel -->
         @if($activity->type == ActivityType::CALL)
-            <div class="flex wfull flex-col gap-4 rounded-lg">
+            <div class="flex w-full flex-1 flex-col gap-4 rounded-lg">
                 <div class="flex gap-2.5 max-lg:flex-wrap-reverse">
                     <!-- Main content -->
                     <div
-                        class="box-shadow flex-1 gap-2 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 max-lg:flex-auto">
+                        class="box-shadow flex-1 min-w-0 gap-2 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900 max-lg:flex-auto">
 
                         <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Gekoppelde
                             E-mails</h3>
@@ -222,7 +222,7 @@
                     </div>
 
                     <!-- Right side column: Call status manager (like edit) -->
-                    <div class="w-[360px] max-w-full gap-2 max-lg:w-full">
+                    <div class="w-[360px] shrink-0 max-w-full gap-2 max-lg:w-full">
                         @if ($activity->type === ActivityType::CALL)
                             @include('admin::components.activities.call-status', ['activity' => $activity, 'callStatuses' => $callStatuses ?? []])
                         @endif


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fixes an `Undefined property: stdClass::$status` error when viewing lead activities.

## Description
<!--- Please describe your changes in detail. -->
This PR resolves an `Undefined property: stdClass::$status` error encountered when viewing lead activities. The `ActivityResource::renderStatus()` method previously assumed the underlying resource was an Eloquent model, leading to failures when it was an `stdClass` or array.

The fix updates `renderStatus()` to safely access `status` and `is_done` properties using `data_get($this->resource, ...)`, ensuring compatibility with various resource types. It also adds robust logic to correctly display the status based on whether it's an object with a `label()` method, a string, or falls back to `is_done`.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1.  Navigate to a lead detail page that displays a list of activities.
2.  Ensure that the activity list renders correctly without any `Undefined property: stdClass::$status` errors.
3.  Verify that the status for each activity is displayed accurately, considering cases where the underlying activity data might be an `stdClass` or an array.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-150300ad-2b04-40aa-b217-60a6490e8b0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-150300ad-2b04-40aa-b217-60a6490e8b0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

