### PR TITLE
Investigate duplicate webhook triggers

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -100,6 +100,22 @@ class ActivityController extends Controller
             ], 422);
         }
 
+        // Duplicate guard: same title on same lead with is_done = 0 should be rejected
+        $isDuplicate = $this->activityRepository
+            ->where('lead_id', $id)
+            ->where('title', $data['title'] ?? null)
+            ->where('is_done', 0)
+            ->exists();
+
+        if ($isDuplicate) {
+            return response()->json([
+                'message' => 'Duplicate activity: same title exists for this lead and is not done.',
+                'errors' => [
+                    'title' => ['Duplicate for this lead while open (is_done = 0).']
+                ]
+            ], 409);
+        }
+
         $activity = $this->activityRepository->create(array_merge($data, [
             'is_done' => $request->type == 'note' ? 1 : 0,
             'user_id' => $data['user_id'] ?? null,

--- a/tests/Feature/ActivityStoreTest.php
+++ b/tests/Feature/ActivityStoreTest.php
@@ -50,3 +50,38 @@ test('test fields with storing activities', function () {
         'lead_id'  => $lead->id,
     ]);
 });
+
+test('reject duplicate open activity by same title on same lead', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $department = Department::where('name', Departments::PRIVATESCAN->value)->firstOrFail();
+    $lead = Lead::factory()->create([
+        'created_by'    => $user->id,
+        'department_id' => $department->id,
+    ]);
+    $this->actingAs($user, 'user');
+
+    $activityPayload = [
+        'title'         => 'Bel klant terug',
+        'description'   => 'Eerste poging',
+        'type'          => 'task',
+        'schedule_from' => now()->format('Y-m-d H:i:s'),
+        'schedule_to'   => now()->addHour()->format('Y-m-d H:i:s'),
+    ];
+
+    // Create first activity (should succeed)
+    $first = test()->withHeaders([
+        'X-API-KEY' => 'valid-api-key-123',
+    ])->postJson(route('admin.leads.activities.store', $lead->id), $activityPayload);
+    $first->assertStatus(200);
+
+    // Attempt duplicate with same title for same lead while is_done = 0
+    $duplicate = test()->withHeaders([
+        'X-API-KEY' => 'valid-api-key-123',
+    ])->postJson(route('admin.leads.activities.store', $lead->id), array_merge($activityPayload, [
+        'description' => 'Tweede poging zelfde titel',
+    ]));
+
+    $duplicate->assertStatus(409);
+    $duplicate->assertJsonStructure(['message', 'errors' => ['title']]);
+});


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
This PR implements a duplicate guard for activity creation to prevent multiple identical open activities from being created for the same lead.

Previously, external webhooks (e.g., from n8n) could trigger the creation of the same activity multiple times, leading to duplicate tasks. This change introduces a check in the `ActivityController@store` method:
- If an activity with the exact same `title` already exists for the given `lead_id` and has `is_done = 0` (i.e., it's an open activity), the API will now return an HTTP 409 Conflict response.
- This ensures that only one open activity with a specific title can exist per lead, preventing redundant task creation.

## How To Test This?
1. Log in as an admin user.
2. Create a lead (or use an existing one).
3. Make an API request to `POST /admin/leads/{lead_id}/activities` with a payload similar to:
   ```json
   {
       "title": "Follow up with client",
       "description": "Initial contact",
       "type": "task",
       "schedule_from": "2025-09-15 10:00:00",
       "schedule_to": "2025-09-15 11:00:00"
   }
   ```
   Verify that the activity is created successfully (HTTP 200).
4. Immediately make the *exact same* API request again (same `lead_id`, same `title`).
5. Verify that the API now returns an HTTP 409 Conflict status code with a message indicating a duplicate activity.
6. Change the `title` in the payload and retry step 3 and 4. It should allow a new activity with a different title.
7. Mark the first created activity as `is_done = 1` (e.g., via the UI or another API call). Then, retry step 3 with the original title. It should now allow the creation of a new activity, as the previous one is no longer "open".

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
The API documentation for `POST /admin/leads/{lead_id}/activities` should be updated to reflect the new 409 Conflict response for duplicate open activities.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-bc6c7204-fff7-413d-8363-ad8f081811bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc6c7204-fff7-413d-8363-ad8f081811bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

