### PR TITLE
Adapt doc.sh for windows environment

### DIFF
--- a/doc.bat
+++ b/doc.bat
@@ -1,0 +1,18 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+
+rem Ensure cache directory exists
+if not exist ".cache" mkdir ".cache"
+
+rem Convert Windows path (e.g., C:\path) to Docker-friendly (/c/path)
+set "PWD_WIN=%cd%"
+for /f "tokens=1,2 delims=:" %%a in ("%PWD_WIN%") do (
+  set "DRIVE=%%a"
+  set "REST=%%b"
+)
+set "REST=!REST:\=/!"
+set "MOUNT=/%DRIVE%!REST!"
+
+docker run --rm -v "%MOUNT%/docs:/documents" -v "%MOUNT%/.cache:/tmp/.cache" -e XDG_CACHE_HOME=/tmp/.cache asciidoctor/docker-asciidoctor:latest ./doc.sh
+
+endlocal


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces `doc.bat`, a Windows-compatible script that mirrors the functionality of `doc.sh`. It allows Windows users to run the Asciidoctor Docker container for documentation generation by:
*   Ensuring the `.cache` directory exists.
*   Converting Windows paths to a Docker-friendly format for volume mounting.
*   Executing the same Docker command as `doc.sh`.

## How To Test This?
1.  Ensure Docker Desktop is installed and running on a Windows machine.
2.  Navigate to the project root in Command Prompt or PowerShell.
3.  Execute `.\doc.bat`.
4.  Verify that the Asciidoctor container runs successfully and processes documentation.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-91287759-18bd-4ace-a932-6c1d3fb81fc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91287759-18bd-4ace-a932-6c1d3fb81fc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

