### PR TITLE
Adapt doc.sh for windows environment

### DIFF
--- a/doc.bat
+++ b/doc.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Windows batch equivalent of doc.sh
+REM Runs AsciiDoctor in Docker container to process documentation
+
+docker run --rm -v "%cd%/docs:/documents/" -v "%cd%/.cache:/tmp/.cache" --env HOME="/tmp" -e XDG_CACHE_HOME=/tmp/.cache asciidoctor/docker-asciidoctor:latest ./doc.sh


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces `doc.bat`, a Windows-compatible batch script that mirrors the functionality of `doc.sh`. It allows users on Windows environments to generate documentation using the AsciiDoctor Docker container.

Key changes include:
*   Replaced `$(pwd)` with `%cd%` for current directory resolution.
*   Removed `-u $(id -u)` as it's not applicable in Windows Docker.
*   Set `HOME="/tmp"` to ensure consistent caching behavior across platforms.
*   Adapted syntax for Windows batch file execution.

## How To Test This?
1.  Ensure Docker is installed and running on a Windows machine.
2.  Navigate to the project's root directory.
3.  Execute `doc.bat` from the command line.
4.  Verify that the documentation is generated successfully, similar to how `doc.sh` would function on Linux.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Tailwind Reordering
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-f20f7511-067c-45da-9d73-e73776ef4972">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f20f7511-067c-45da-9d73-e73776ef4972">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

