### PR TITLE
Validate activity group id against lead department

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -160,7 +160,7 @@ class ActivityController extends Controller
             }
         }
 
-        // Ensure group_id is set for lead activities
+        // Ensure group_id is set and valid for lead activities
         $result = $this->ensureGroupIdForLeadActivity($data);
         if ($result !== null) {
             return $result; // Return error response if group_id could not be determined
@@ -504,8 +504,8 @@ class ActivityController extends Controller
     {
         // If lead_id is provided, group_id is required
         if (!empty($data['lead_id'])) {
+            $lead = app(LeadRepository::class)->findOrFail($data['lead_id']);
             if (!isset($data['group_id']) || !$data['group_id']) {
-                $lead = app(LeadRepository::class)->findOrFail($data['lead_id']);
                 try {
                     $data['group_id'] = Department::getGroupIdForLead($lead);
                 } catch (Exception $e) {
@@ -515,6 +515,18 @@ class ActivityController extends Controller
                         ], 422);
                     }
                     session()->flash('error', 'Kan geen groep bepalen voor deze activiteit. Lead heeft geen geldig department.');
+                    return redirect()->back();
+                }
+            } else {
+                // Validate provided group_id belongs to the same department as the lead
+                $group = \Webkul\User\Models\Group::query()->find($data['group_id']);
+                if (!$group || ($group->department_id !== $lead->department_id)) {
+                    if (request()->ajax()) {
+                        return response()->json([
+                            'message' => 'De opgegeven groep komt niet overeen met het departement van de lead.',
+                        ], 422);
+                    }
+                    session()->flash('error', 'De opgegeven groep komt niet overeen met het departement van de lead.');
                     return redirect()->back();
                 }
             }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -74,10 +74,12 @@ class ActivityController extends Controller
             }
         }
 
+        // Always load the lead for department validation
+        $lead = $this->leadRepository->findOrFail($id);
+
         // Set group_id from lead's department if not provided (required for lead activities)
         $groupId = $data['group_id'] ?? null;
         if (!$groupId || $groupId === '') {
-            $lead = $this->leadRepository->findOrFail($id);
             try {
                 $groupId = \App\Models\Department::getGroupIdForLead($lead);
             } catch (\Exception $e) {
@@ -85,6 +87,17 @@ class ActivityController extends Controller
                     'message' => 'Kan geen groep bepalen voor deze activiteit. Lead heeft geen geldig department.',
                     'errors' => [
                         'group_id' => ['Kan geen groep bepalen vanuit lead department.']
+                    ]
+                ], 422);
+            }
+        } else {
+            // If group_id is provided, enforce it matches the lead's department
+            $group = \Webkul\User\Models\Group::query()->find($groupId);
+            if (!$group || ($group->department_id !== $lead->department_id)) {
+                return response()->json([
+                    'message' => 'De opgegeven groep komt niet overeen met het departement van de lead.',
+                    'errors' => [
+                        'group_id' => ['Group behoort niet tot het departement van deze lead.']
                     ]
                 ], 422);
             }


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
This PR introduces validation to ensure that when an activity is created for a lead, the `group_id` associated with the activity must belong to the same department as the lead. This prevents the creation of activities with mismatched departmental assignments.

Validation has been added to:
- `packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php::store` (API endpoint for lead activities).
- `packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php::store` (general admin activity creation, specifically within `ensureGroupIdForLeadActivity`).

Existing auto-assignment logic for `group_id` (when not provided) based on the lead's department remains intact.

## How To Test This?
1.  **Prerequisites:**
    *   Create a Lead (e.g., "Test Lead") and assign it to a specific Department (e.g., "Sales Department").
    *   Create at least two Groups: one belonging to the "Sales Department" (e.g., "Sales Group A") and another belonging to a different department (e.g., "Marketing Group B").

2.  **Test via API (e.g., using Postman or similar):**
    *   **Success Case (Matching Group):**
        *   Make a POST request to `/api/leads/{lead_id}/activities` with `group_id` set to "Sales Group A".
        *   Expected: Activity created successfully (HTTP 200/201).
    *   **Failure Case (Mismatched Group):**
        *   Make a POST request to `/api/leads/{lead_id}/activities` with `group_id` set to "Marketing Group B".
        *   Expected: HTTP 422 Unprocessable Entity with an error message indicating the group does not match the lead's department.
    *   **Auto-assign Case (No Group ID):**
        *   Make a POST request to `/api/leads/{lead_id}/activities` *without* providing a `group_id`.
        *   Expected: Activity created successfully, and the `group_id` should be automatically assigned to "Sales Group A" (or another group in "Sales Department" if configured).

3.  **Test via Admin Panel:**
    *   Navigate to the Admin panel.
    *   **Success Case (Matching Group):**
        *   Go to Leads -> "Test Lead" -> Activities tab -> "Add Activity".
        *   Select "Sales Group A" for the activity.
        *   Expected: Activity created successfully.
    *   **Failure Case (Mismatched Group):**
        *   Go to Leads -> "Test Lead" -> Activities tab -> "Add Activity".
        *   Select "Marketing Group B" for the activity.
        *   Expected: An error flash message indicating the group does not match the lead's department, and the activity should not be created.
    *   **Auto-assign Case (No Group Selected):**
        *   Go to Leads -> "Test Lead" -> Activities tab -> "Add Activity".
        *   Leave the "Group" field empty.
        *   Expected: Activity created successfully, and the `group_id` should be automatically assigned to "Sales Group A".

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-bfe5fefe-0f38-4d7c-bddf-5fc6729a7dac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bfe5fefe-0f38-4d7c-bddf-5fc6729a7dac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

