### PR TITLE
Validate activity group id against lead department

### DIFF
--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -120,4 +120,32 @@ class Department extends Model
     {
         return $this->hasMany(Group::class, 'department_id');
     }
+
+    /**
+     * Validate that a group_id matches the department_id of a lead.
+     * This ensures that activities are assigned to groups within the correct department.
+     *
+     * @param int $groupId The group ID to validate
+     * @param \Webkul\Lead\Models\Lead $lead The lead to validate against
+     * @return bool True if the group belongs to the lead's department
+     * @throws Exception if lead has no department or group doesn't exist
+     */
+    public static function validateGroupForLead(int $groupId, $lead): bool
+    {
+        if (!$lead) {
+            throw new Exception('Lead cannot be null');
+        }
+
+        if (!$lead->department_id) {
+            throw new Exception("Lead {$lead->id} has no department_id");
+        }
+
+        // Find the group and check if it belongs to the lead's department
+        $group = Group::query()
+            ->where('id', $groupId)
+            ->where('department_id', $lead->department_id)
+            ->first();
+
+        return $group !== null;
+    }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -496,6 +496,7 @@ class ActivityController extends Controller
 
     /**
      * Ensure group_id is set for lead activities by auto-determining from lead's department.
+     * Also validates that any provided group_id matches the lead's department.
      *
      * @param array $data Activity data (passed by reference)
      * @return \Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|null
@@ -504,8 +505,10 @@ class ActivityController extends Controller
     {
         // If lead_id is provided, group_id is required
         if (!empty($data['lead_id'])) {
+            $lead = app(LeadRepository::class)->findOrFail($data['lead_id']);
+            
             if (!isset($data['group_id']) || !$data['group_id']) {
-                $lead = app(LeadRepository::class)->findOrFail($data['lead_id']);
+                // Auto-determine group_id from lead's department
                 try {
                     $data['group_id'] = Department::getGroupIdForLead($lead);
                 } catch (Exception $e) {
@@ -515,6 +518,31 @@ class ActivityController extends Controller
                         ], 422);
                     }
                     session()->flash('error', 'Kan geen groep bepalen voor deze activiteit. Lead heeft geen geldig department.');
+                    return redirect()->back();
+                }
+            } else {
+                // Validate that the provided group_id matches the lead's department
+                try {
+                    $isValid = Department::validateGroupForLead($data['group_id'], $lead);
+                    if (!$isValid) {
+                        if (request()->ajax()) {
+                            return response()->json([
+                                'message' => 'De opgegeven groep komt niet overeen met het department van de lead.',
+                                'errors' => [
+                                    'group_id' => ['Groep moet binnen het department van de lead vallen.']
+                                ]
+                            ], 422);
+                        }
+                        session()->flash('error', 'De opgegeven groep komt niet overeen met het department van de lead.');
+                        return redirect()->back();
+                    }
+                } catch (Exception $e) {
+                    if (request()->ajax()) {
+                        return response()->json([
+                            'message' => 'Fout bij valideren van groep: ' . $e->getMessage(),
+                        ], 422);
+                    }
+                    session()->flash('error', 'Fout bij valideren van groep: ' . $e->getMessage());
                     return redirect()->back();
                 }
             }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -75,9 +75,11 @@ class ActivityController extends Controller
         }
 
         // Set group_id from lead's department if not provided (required for lead activities)
+        $lead = $this->leadRepository->findOrFail($id);
         $groupId = $data['group_id'] ?? null;
+        
         if (!$groupId || $groupId === '') {
-            $lead = $this->leadRepository->findOrFail($id);
+            // Auto-determine group_id from lead's department
             try {
                 $groupId = \App\Models\Department::getGroupIdForLead($lead);
             } catch (\Exception $e) {
@@ -85,6 +87,26 @@ class ActivityController extends Controller
                     'message' => 'Kan geen groep bepalen voor deze activiteit. Lead heeft geen geldig department.',
                     'errors' => [
                         'group_id' => ['Kan geen groep bepalen vanuit lead department.']
+                    ]
+                ], 422);
+            }
+        } else {
+            // Validate that the provided group_id matches the lead's department
+            try {
+                $isValid = \App\Models\Department::validateGroupForLead($groupId, $lead);
+                if (!$isValid) {
+                    return response()->json([
+                        'message' => 'De opgegeven groep komt niet overeen met het department van de lead.',
+                        'errors' => [
+                            'group_id' => ['Groep moet binnen het department van de lead vallen.']
+                        ]
+                    ], 422);
+                }
+            } catch (\Exception $e) {
+                return response()->json([
+                    'message' => 'Fout bij valideren van groep: ' . $e->getMessage(),
+                    'errors' => [
+                        'group_id' => ['Kan groep niet valideren voor deze lead.']
                     ]
                 ], 422);
             }

--- a/tests/Feature/ActivityStoreTest.php
+++ b/tests/Feature/ActivityStoreTest.php
@@ -85,3 +85,77 @@ test('reject duplicate open activity by same title on same lead', function () {
     $duplicate->assertStatus(409);
     $duplicate->assertJsonStructure(['message', 'errors' => ['title']]);
 });
+
+test('reject activity creation with group_id that does not match lead department', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $privateScanDept = Department::where('name', Departments::PRIVATESCAN->value)->firstOrFail();
+    $herniaDept = Department::where('name', Departments::HERNIA->value)->firstOrFail();
+    
+    // Create lead in PrivateScan department
+    $lead = Lead::factory()->create([
+        'created_by'    => $user->id,
+        'department_id' => $privateScanDept->id,
+    ]);
+    $this->actingAs($user, 'user');
+
+    // Get a group from the Hernia department (wrong department)
+    $wrongGroup = Group::where('department_id', $herniaDept->id)->firstOrFail();
+
+    $activityData = [
+        'title'         => 'Test activity with wrong group',
+        'description'   => 'This should fail validation.',
+        'type'          => 'task',
+        'schedule_from' => now()->format('Y-m-d H:i:s'),
+        'schedule_to'   => now()->addHour()->format('Y-m-d H:i:s'),
+        'group_id'      => $wrongGroup->id, // Wrong department group
+    ];
+
+    // Act
+    $response = test()->withHeaders([
+        'X-API-KEY' => 'valid-api-key-123',
+    ])->postJson(route('admin.leads.activities.store', $lead->id), $activityData);
+
+    // Assert
+    $response->assertStatus(422);
+    $response->assertJsonStructure(['message', 'errors' => ['group_id']]);
+    $response->assertJsonFragment([
+        'message' => 'De opgegeven groep komt niet overeen met het department van de lead.'
+    ]);
+});
+
+test('accept activity creation with group_id that matches lead department', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $department = Department::where('name', Departments::PRIVATESCAN->value)->firstOrFail();
+    $lead = Lead::factory()->create([
+        'created_by'    => $user->id,
+        'department_id' => $department->id,
+    ]);
+    $this->actingAs($user, 'user');
+
+    // Get a group from the correct department
+    $correctGroup = Group::where('department_id', $department->id)->firstOrFail();
+
+    $activityData = [
+        'title'         => 'Test activity with correct group',
+        'description'   => 'This should pass validation.',
+        'type'          => 'task',
+        'schedule_from' => now()->format('Y-m-d H:i:s'),
+        'schedule_to'   => now()->addHour()->format('Y-m-d H:i:s'),
+        'group_id'      => $correctGroup->id, // Correct department group
+    ];
+
+    // Act
+    $response = test()->withHeaders([
+        'X-API-KEY' => 'valid-api-key-123',
+    ])->postJson(route('admin.leads.activities.store', $lead->id), $activityData);
+
+    // Assert
+    $response->assertStatus(200);
+    $this->assertDatabaseHas('activities', [
+        'title'    => 'Test activity with correct group',
+        'group_id' => $correctGroup->id,
+        'lead_id'  => $lead->id,
+    ]);
+});


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
Implemented validation to ensure that the `group_id` of an activity, when explicitly provided, matches the `department_id` of the associated lead. This prevents activities from being incorrectly assigned to groups outside the lead's department.

The validation is applied in both the API (`Lead\ActivityController`) and the general UI (`Activity\ActivityController`) when creating or updating activities linked to a lead.

**Key Changes:**
- Added `Department::validateGroupForLead(int $groupId, $lead)` method to verify if a given `group_id` belongs to the lead's department.
- Integrated this validation into `Webkul\Admin\Http\Controllers\Lead\ActivityController@store` and `Webkul\Admin\Http\Controllers\Activity\ActivityController@ensureGroupIdForLeadActivity`.
- If a `group_id` is provided and does not match the lead's department, a 422 Unprocessable Entity response is returned with a clear error message.
- If no `group_id` is provided, it is still automatically determined based on the lead's department, as per existing logic.

## How To Test This?
1.  **Via API (e.g., Postman):**
    *   Create a lead associated with a specific department (e.g., `PrivateScan`).
    *   Attempt to create an activity for this lead via `POST /api/leads/{id}/activities` with a `group_id` that belongs to the `PrivateScan` department. This should succeed (HTTP 200).
    *   Attempt to create an activity for the same lead with a `group_id` that belongs to a *different* department (e.g., `Hernia`). This should fail with a 422 status code and an error message like "De opgegeven groep komt niet overeen met het department van de lead."
    *   Attempt to create an activity for the lead without providing a `group_id`. This should succeed, with the `group_id` being automatically assigned based on the lead's department.

2.  **Via UI:**
    *   Navigate to a lead's detail page in the admin panel.
    *   Try to create a new activity for this lead.
    *   If the activity form allows manual selection of `group_id`, select a group that does not belong to the lead's department. Attempting to save should show an error message.
    *   Select a group that belongs to the lead's department. Attempting to save should succeed.

3.  **Run Tests:**
    *   Execute the feature tests, specifically `tests/Feature/ActivityStoreTest.php`, which now includes new tests for both valid and invalid `group_id` scenarios.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-4b2ee6fa-e878-4ac2-8113-fb061ccf4787">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b2ee6fa-e878-4ac2-8113-fb061ccf4787">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

