### PR TITLE
Fix email search and stray f

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
@@ -900,7 +900,7 @@
                                 </div>
                             </span>
 
-                            <!-- Popup Box -->f
+                            <!-- Popup Box -->
                             <div
                                 v-if="showPopup"
                                 class="absolute top-full z-10 mt-1 flex w-full origin-top transform flex-col gap-2 rounded-lg border border-gray-200 bg-white p-2 shadow-lg transition-transform dark:border-gray-900 dark:bg-gray-800"
@@ -1719,11 +1719,16 @@
 
                         this.cancelToken = this.$axios.CancelToken.source();
 
+                        // Check if search term looks like an email address
+                        const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.searchTerm);
+                        const searchParams = {
+                            ...this.params,
+                            query: isEmail ? `email:${this.searchTerm}` : this.searchTerm,
+                            searchFields: 'first_name:like;last_name:like;married_name:like;emails:like'
+                        };
+
                         this.$axios.get('{{ route('admin.contacts.persons.search') }}', {
-                                params: {
-                                    ...this.params,
-                                    query: this.searchTerm
-                                },
+                                params: searchParams,
                                 cancelToken: this.cancelToken.token,
                             })
                             .then(response => {
@@ -1906,15 +1911,20 @@
 
                         this.cancelToken = this.$axios.CancelToken.source();
 
+                        // Check if search term looks like an email address
+                        const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.searchTerm);
+                        const searchParams = {
+                            ...this.params,
+                            query: isEmail ? `email:${this.searchTerm}` : this.searchTerm,
+                            searchFields: 'first_name:like;last_name:like;married_name:like;emails:like'
+                        };
+
                         const request = pid
                             ? this.$axios.get('{{ route('admin.leads.open_by_person', ['person' => ':id']) }}'.replace(':id', pid), {
                                 cancelToken: this.cancelToken.token,
                               })
                             : this.$axios.get('{{ route('admin.leads.search') }}', {
-                                params: {
-                                    ...this.params,
-                                    query: this.searchTerm
-                                },
+                                params: searchParams,
                                 cancelToken: this.cancelToken.token,
                               });
 


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A (User reported issues directly)

## Description
This PR addresses two issues in the email view:

1.  **Fixed a stray 'f' character:** Removed an unintended 'f' character appearing in the email view template.
2.  **Improved email address search for contacts and leads:**
    *   Previously, searching for contacts/leads by email address in the email view did not consistently find existing records.
    *   The search logic has been enhanced to detect if the search term is an email address.
    *   If an email is detected, the search query is formatted with an `email:` prefix (e.g., `email:user@example.com`) to leverage the backend's specific email search capabilities.
    *   Additionally, `searchFields` are explicitly set to include `first_name`, `last_name`, `married_name`, and `emails` for more comprehensive results.
    *   This ensures that both `Person` and `Lead` records with matching email addresses are correctly suggested.

## How To Test This?
1.  **Verify 'f' character fix:**
    *   Navigate to any email view page (`/admin/mail/view/{id}`).
    *   Confirm that no standalone 'f' character is visible near the "Popup Box" comment area.

2.  **Verify email search fix:**
    *   Create a new `Person` or `Lead` record with a unique email address (e.g., `test@example.com`).
    *   Send an email to your system from this email address (e.g., `test@example.com`).
    *   Go to the email view for the received email.
    *   In the "Contact Person" or "Lead" lookup fields, the system should now correctly suggest the `Person` or `Lead` you created based on the sender's email address.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-fb875830-e4d0-4954-9bc6-3da1f389168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb875830-e4d0-4954-9bc6-3da1f389168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

