### PR TITLE
Add optional length and weight to create lead

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -470,6 +470,14 @@ class LeadController extends Controller
                         $anamnesisUpdate['allergies_notes'] = $data['allergies_notes'];
                     }
 
+                    // Optional physical metrics
+                    if (isset($data['height']) && $data['height'] !== '') {
+                        $anamnesisUpdate['height'] = (int) $data['height'];
+                    }
+                    if (isset($data['weight']) && $data['weight'] !== '') {
+                        $anamnesisUpdate['weight'] = (int) $data['weight'];
+                    }
+
                     if (!empty($anamnesisUpdate)) {
                         // Update all related anamnesis for this lead
                         foreach ($lead->persons as $person) {

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -395,6 +395,38 @@
                                                 </div>
                                             </x-admin::form.control-group>
                                         </div>
+
+                                        <!-- Lengte (cm) -->
+                                        <div class="mt-3">
+                                            <x-admin::form.control-group>
+                                                <x-admin::form.control-group.label>
+                                                    Lengte (cm)
+                                                </x-admin::form.control-group.label>
+                                                <x-admin::form.control-group.control
+                                                    type="number"
+                                                    name="height"
+                                                    min="0"
+                                                    step="1"
+                                                    placeholder="Bijv. 180"
+                                                />
+                                            </x-admin::form.control-group>
+                                        </div>
+
+                                        <!-- Gewicht (kg) -->
+                                        <div class="mt-3">
+                                            <x-admin::form.control-group>
+                                                <x-admin::form.control-group.label>
+                                                    Gewicht (kg)
+                                                </x-admin::form.control-group.label>
+                                                <x-admin::form.control-group.control
+                                                    type="number"
+                                                    name="weight"
+                                                    min="0"
+                                                    step="1"
+                                                    placeholder="Bijv. 75"
+                                                />
+                                            </x-admin::form.control-group>
+                                        </div>
                                     </div>
                                     <!-- /Anamnese -->
 


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
Adds optional `lengte` (height) and `gewicht` (weight) fields to the lead creation form, specifically under the "Anamnese" section. These values are persisted to the `Anamnesis` entity for associated persons. These fields are only visible on the lead creation page and not on the lead edit page, as per requirements.

## How To Test This?
1.  Navigate to the lead creation page (`/admin/leads/create`).
2.  Scroll down to the "Anamnese" section.
3.  Observe the new "Lengte (cm)" and "Gewicht (kg)" input fields at the end of this section.
4.  Enter optional values for these fields (e.g., 180 for height, 75 for weight).
5.  Fill in other required lead details and create the lead.
6.  Verify the lead is created successfully.
7.  (Optional) Attempt to edit the newly created lead or any existing lead; confirm that the "Lengte (cm)" and "Gewicht (kg)" fields are *not* present on the edit form.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-02f040ec-d615-4379-bdc7-c727ebbfbd10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02f040ec-d615-4379-bdc7-c727ebbfbd10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

