### PR TITLE
Create person card component and integrate

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
@@ -1,0 +1,149 @@
+<div class="relative rounded-xl border border-indigo-100 bg-indigo-50/80
+            dark:border-zinc-700 dark:bg-zinc-800/70
+            shadow-sm hover:shadow-md transition p-4">
+    <!-- accent links -->
+    <span class="absolute inset-y-0 left-0 w-1 rounded-l-xl bg-indigo-600 dark:bg-indigo-500"></span>
+
+    <dt class="flex items-start gap-3">
+
+    <dd class="min-w-0 flex-1">
+        <div class="flex items-center gap-2">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                {{ $person->name }}
+            </h3>
+
+            @if(! empty($person->job_title))
+                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium
+                             bg-white text-indigo-700 border border-indigo-200
+                             dark:bg-indigo-900/40 dark:text-indigo-200 dark:border-indigo-700">
+                  {{ $person->job_title }}
+                </span>
+            @endif
+        </div>
+
+        <!-- Default contact info onder naam -->
+        <div class="mt-2 flex items-center gap-4 text-sm">
+            @php
+                $defaultPhone = null;
+                $defaultEmail = null;
+                $otherPhones = collect();
+                $otherEmails = collect();
+
+                $phones = is_array($person->phones ?? null) ? $person->phones : ($person->phones?->toArray() ?? []);
+                $emails = is_array($person->emails ?? null) ? $person->emails : ($person->emails?->toArray() ?? []);
+
+                if($phones && count($phones) > 0) {
+                    $defaultPhone = collect($phones)->firstWhere('is_default', true) ?? collect($phones)->first();
+                    $otherPhones = collect($phones)->reject(function($phone) use ($defaultPhone) {
+                        return $defaultPhone && isset($defaultPhone['value']) && ($phone['value'] ?? null) === ($defaultPhone['value'] ?? null);
+                    });
+                }
+
+                if($emails && count($emails) > 0) {
+                    $defaultEmail = collect($emails)->firstWhere('is_default', true) ?? collect($emails)->first();
+                    $otherEmails = collect($emails)->reject(function($email) use ($defaultEmail) {
+                        return ($email['value'] ?? null) === ($defaultEmail['value'] ?? null);
+                    });
+                }
+            @endphp
+
+            @if($defaultPhone)
+                <a href="tel:{{ $defaultPhone['value'] ?? '' }}" 
+                   class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
+                    </svg>
+                    {{ $defaultPhone['value'] ?? '' }}
+                </a>
+            @endif
+
+            @if($defaultEmail)
+                <a href="mailto:{{ $defaultEmail['value'] ?? '' }}" 
+                   class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                    </svg>
+                    {{ $defaultEmail['value'] ?? '' }}
+                </a>
+            @endif
+        </div>
+
+        <!-- Uitklapbare sectie voor overige contactgegevens -->
+        @if(($otherPhones && $otherPhones->count() > 0) || ($otherEmails && $otherEmails->count() > 0))
+            <div class="mt-3">
+                <button type="button" 
+                        onclick="toggleContactDetails('contact-{{ $person->id }}')"
+                        class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                    <svg id="icon-contact-{{ $person->id }}" class="w-3 h-3 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                    </svg>
+                    Overige contactgegevens
+                </button>
+                
+                <div id="contact-{{ $person->id }}" class="hidden mt-2 space-y-1 text-xs">
+                    @if($otherPhones && $otherPhones->count() > 0)
+                        <div class="pl-5 space-y-1">
+                            @foreach($otherPhones as $phone)
+                                <a href="tel:{{ $phone['value'] ?? '' }}" 
+                                   class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
+                                    </svg>
+                                    {{ $phone['value'] ?? '' }}
+                                    @if(isset($phone['label']) && $phone['label'])
+                                        <span class="text-gray-400 dark:text-gray-500">({{ $phone['label'] }})</span>
+                                    @endif
+                                </a>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    @if($otherEmails && $otherEmails->count() > 0)
+                        <div class="pl-5 space-y-1">
+                            @foreach($otherEmails as $email)
+                                <a href="mailto:{{ $email['value'] ?? '' }}" 
+                                   class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                    </svg>
+                                    {{ $email['value'] ?? '' }}
+                                    @if(isset($email['label']) && $email['label'])
+                                        <span class="text-gray-400 dark:text-gray-500">({{ $email['label'] }})</span>
+                                    @endif
+                                </a>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        @endif
+
+        @if($show_actions ?? true)
+            <!-- acties -->
+            <div class="mt-3 flex flex-wrap gap-2">
+                <a href="{{ route('admin.contacts.persons.view', $person->id) }}"
+                   class="inline-flex items-center rounded-lg px-3 py-1.5 text-xs
+                      bg-white text-indigo-700 border border-indigo-200 hover:bg-indigo-50
+                      dark:bg-transparent dark:text-indigo-200 dark:border-zinc-600">
+                    Bekijk persoon
+                </a>
+            </div>
+        @endif
+    </dd>
+</div>
+
+<script>
+function toggleContactDetails(contactId) {
+    const element = document.getElementById(contactId);
+    const icon = document.getElementById('icon-' + contactId);
+    
+    if (element.classList.contains('hidden')) {
+        element.classList.remove('hidden');
+        if (icon) icon.style.transform = 'rotate(180deg)';
+    } else {
+        element.classList.add('hidden');
+        if (icon) icon.style.transform = 'rotate(0deg)';
+    }
+}
+</script>
+

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
@@ -9,7 +9,7 @@
     <dd class="min-w-0 flex-1">
         <div class="flex items-center gap-2">
             <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-                {{ $person->name }}
+                {{ $person->name }} (  {{ $person->age }} jaar)
             </h3>
 
             @if(! empty($person->job_title))
@@ -48,7 +48,7 @@
             @endphp
 
             @if($defaultPhone)
-                <a href="tel:{{ $defaultPhone['value'] ?? '' }}" 
+                <a href="tel:{{ $defaultPhone['value'] ?? '' }}"
                    class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
@@ -58,7 +58,7 @@
             @endif
 
             @if($defaultEmail)
-                <a href="mailto:{{ $defaultEmail['value'] ?? '' }}" 
+                <a href="mailto:{{ $defaultEmail['value'] ?? '' }}"
                    class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
@@ -71,7 +71,7 @@
         <!-- Uitklapbare sectie voor overige contactgegevens -->
         @if(($otherPhones && $otherPhones->count() > 0) || ($otherEmails && $otherEmails->count() > 0))
             <div class="mt-3">
-                <button type="button" 
+                <button type="button"
                         onclick="toggleContactDetails('contact-{{ $person->id }}')"
                         class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                     <svg id="icon-contact-{{ $person->id }}" class="w-3 h-3 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -79,12 +79,12 @@
                     </svg>
                     Overige contactgegevens
                 </button>
-                
+
                 <div id="contact-{{ $person->id }}" class="hidden mt-2 space-y-1 text-xs">
                     @if($otherPhones && $otherPhones->count() > 0)
                         <div class="pl-5 space-y-1">
                             @foreach($otherPhones as $phone)
-                                <a href="tel:{{ $phone['value'] ?? '' }}" 
+                                <a href="tel:{{ $phone['value'] ?? '' }}"
                                    class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
@@ -101,7 +101,7 @@
                     @if($otherEmails && $otherEmails->count() > 0)
                         <div class="pl-5 space-y-1">
                             @foreach($otherEmails as $email)
-                                <a href="mailto:{{ $email['value'] ?? '' }}" 
+                                <a href="mailto:{{ $email['value'] ?? '' }}"
                                    class="flex items-center gap-1.5 text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
@@ -136,7 +136,7 @@
 function toggleContactDetails(contactId) {
     const element = document.getElementById(contactId);
     const icon = document.getElementById('icon-' + contactId);
-    
+
     if (element.classList.contains('hidden')) {
         element.classList.remove('hidden');
         if (icon) icon.style.transform = 'rotate(180deg)';

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/view.blade.php
@@ -120,6 +120,8 @@
                 </div>
             </div>
 
+            @include('admin::contacts.persons.common.card', ['person' => $person, 'show_actions' => false])
+
             <!-- Person Overview (merged attributes and organization) -->
             @include ('admin::contacts.persons.view.compact-overview')
 

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/view/compact-overview.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/view/compact-overview.blade.php
@@ -2,51 +2,17 @@
 
 <div class="flex w-full flex-col gap-4 border-b border-gray-200 p-4 dark:border-gray-800">
     <x-admin::accordion class="select-none !border-none">
-        <x-slot:header class="!p-0">
-            <h4 class="font-semibold dark:text-white">
-                Over de persoon
-            </h4>
-        </x-slot>
 
         <x-slot:content class="mt-4 !px-0 !pb-0">
             {!! view_render_event('admin.contacts.persons.view.attributes.form_controls.before', ['person' => $person]) !!}
 
             <div class="flex flex-col text-sm">
-                <!-- Name Summary -->
-                <div class="mb-4">
-                    <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Naam</div>
-                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                         {{ $person->name }}
-                    </div>
-                </div>
-
-                <!-- Contact Person (Job Title) -->
-                @if($person->job_title)
-                <div class="mb-4">
-                    <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Functie</div>
-                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {{ $person->job_title }}
-                    </div>
-                </div>
-                @endif
-
-                <!-- Age -->
-                @if($person->age)
-                <div class="mb-4">
-                    <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Leeftijd</div>
-                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {{ $person->age }} jaar
-                    </div>
-                </div>
-                @endif
-
-                                <!-- Organization -->
                 @if($person->organization)
                 <div class="mb-4">
                     <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Organisatie</div>
                     <div>
-                        <a 
-                            href="{{ route('admin.contacts.organizations.view', $person->organization->id) }}" 
+                        <a
+                            href="{{ route('admin.contacts.organizations.view', $person->organization->id) }}"
                             target="_blank"
                             class="text-sm font-medium text-brandColor hover:underline"
                         >
@@ -63,9 +29,9 @@
                     <div class="text-sm text-gray-900 dark:text-gray-100">
                         @if($person->address && $person->address->full_address)
                             {{ $person->address->full_address }}
-                            <a 
-                                href="https://maps.google.com/?q={{ urlencode($person->address->full_address) }}" 
-                                target="_blank" 
+                            <a
+                                href="https://maps.google.com/?q={{ urlencode($person->address->full_address) }}"
+                                target="_blank"
                                 class="ml-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                                 title="Bekijk op Google Maps"
                             >
@@ -76,63 +42,6 @@
                         @endif
                     </div>
                 </div>
-
-                <!-- Contact Information -->
-                <div class="mb-4">
-                    <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Contactgegevens</div>
-                    <div class="text-sm">
-                        <!-- Email Addresses -->
-                        @if($person->emails && count($person->emails) > 0)
-                            @php
-                                $defaultEmail = collect($person->emails)->firstWhere('is_default', true)
-                                               ?? collect($person->emails)->first();
-                                $otherEmails = collect($person->emails)->reject(function($email) use ($defaultEmail) {
-                                    return $email['value'] === $defaultEmail['value'];
-                                });
-                            @endphp
-
-                            <div class="text-gray-900 dark:text-gray-100">
-                                {{ $defaultEmail['value'] }}
-                            </div>
-
-                            @if($otherEmails->count() > 0)
-                                <div class="text-xs text-gray-500 dark:text-gray-400 italic ml-2">
-                                    @foreach($otherEmails as $email)
-                                        {{ $email['value'] }}@if(!$loop->last), @endif
-                                    @endforeach
-                                </div>
-                            @endif
-                        @else
-                            <div class="text-gray-500 dark:text-gray-400 italic">Geen e-mailadres</div>
-                        @endif
-
-                        <!-- Phone Numbers -->
-                        @if($person->phones && count($person->phones) > 0)
-                            @php
-                                $defaultPhone = collect($person->phones)->firstWhere('is_default', true)
-                                               ?? collect($person->phones)->first();
-                                $otherPhones = collect($person->phones)->reject(function($phone) use ($defaultPhone) {
-                                    return $phone['value'] === $defaultPhone['value'];
-                                });
-                            @endphp
-
-                            <div class="text-gray-900 dark:text-gray-100 mt-1">
-                                {{ $defaultPhone['value'] }}
-                            </div>
-
-                            @if($otherPhones->count() > 0)
-                                <div class="text-xs text-gray-500 dark:text-gray-400 italic ml-2">
-                                    @foreach($otherPhones as $phone)
-                                        {{ $phone['value'] }}@if(!$loop->last), @endif
-                                    @endforeach
-                                </div>
-                            @endif
-                        @else
-                            <div class="text-gray-500 dark:text-gray-400 italic mt-1">Geen telefoonnummer</div>
-                        @endif
-                    </div>
-                </div>
-            </div>
 
             <!-- Custom Attributes Section -->
             <div class="mt-6">


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
<!--- Please describe your changes in detail. -->
This PR introduces a new `card.blade.php` partial for persons, mirroring the existing lead card.
The new card displays the person's name, job title, default phone and email, and an expandable section for additional contact details.
It has been integrated into the person's detail view page (`view.blade.php`) to provide a consistent and prominent overview of key person information, similar to how lead details are presented.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1.  Navigate to the Admin panel.
2.  Go to 'Contacts' -> 'Persons'.
3.  Click on any person to view their details.
4.  Verify that a new card component is displayed at the top of the left panel, showing the person's name, job title, and primary contact information.
5.  If the person has multiple phone numbers or emails, check that the "Overige contactgegevens" (Other contact details) button is present and expands to show the additional contacts.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-b6c69dfa-828a-49cb-8b2c-8b3d1907ac91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6c69dfa-828a-49cb-8b2c-8b3d1907ac91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

