### PR TITLE
Make email entities clickable for viewing

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
@@ -588,10 +588,14 @@
 
                             <!-- Mailer receivers -->
                             <div class="flex flex-col gap-1">
-                                <!-- Mailer Name -->
-                                <span class="text-xs font-medium text-gray-800 dark:text-gray-300">
+                                <!-- Mailer Name (clickable to person view) -->
+                                <a
+                                    :href="'{{ route('admin.contacts.persons.view', ':id') }}'.replace(':id', email.person_id)"
+                                    target="_blank"
+                                    class="text-xs font-medium text-brandColor hover:underline dark:text-gray-300"
+                                >
                                     @{{ email.person?.name }}
-                                </span>
+                                </a>
 
                                 <!-- Mailer Additional Deatils -->
                                 <div class="flex flex-col gap-1">
@@ -634,7 +638,7 @@
                             </template>
 
                             <a
-                                :href="'{{ route('admin.contacts.persons.edit', ':id') }}'.replace(':id', email.person_id)"
+                                :href="'{{ route('admin.contacts.persons.view', ':id') }}'.replace(':id', email.person_id)"
                                 target="_blank"
                                 class="icon-right-arrow flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-2xl hover:rounded-md hover:bg-gray-100 dark:hover:bg-gray-950"
                             ></a>


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Implemented the request to make linked entities in the email view clickable. The person's name and the associated arrow icon in the email view now link directly to the person's view page (`admin.contacts.persons.view`). Lead and activity entities were already correctly linked.

## How To Test This?
1. Navigate to an email view page in the admin panel.
2. Locate the "Mailer Name" section.
3. Click on the person's name and verify it opens the person's view page in a new tab.
4. Click on the arrow icon next to the person's name and verify it also opens the person's view page in a new tab.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-e282ce05-51dd-4f63-b768-3e23cdaad51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e282ce05-51dd-4f63-b768-3e23cdaad51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

