### PR TITLE
Make person card background green

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/common/card.blade.php
@@ -1,4 +1,4 @@
-<div class="relative rounded-xl border border-indigo-100 bg-indigo-50/80
+<div class="relative rounded-xl border border-indigo-100 bg-green-50/80
             dark:border-zinc-700 dark:bg-zinc-800/70
             shadow-sm hover:shadow-md transition p-4">
     <!-- accent links -->


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR changes the background color of the person card to green (`bg-green-50/80`) to visually differentiate it from lead cards, as requested.

## How To Test This?
1. Navigate to the Contacts > Persons section in the admin panel.
2. Observe the person cards and verify that their background color is now green.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-0b0cbd68-b1be-49e6-a998-9ec7ca215a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b0cbd68-b1be-49e6-a998-9ec7ca215a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

