### PR TITLE
Synchronize person activity tabs to lead view

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/view.blade.php
@@ -132,6 +132,7 @@
             <div class="flex-1">
                 <x-admin::activities
                     :endpoint="route('admin.contacts.persons.activities.index', $person->id)"
+                    :activeType="'planned'"
                 />
             </div>
         </div>


### PR DESCRIPTION
## Issue Reference

## Description
This PR aligns the default active tab for activities in the person view with the lead view, making 'Planned' the initial selected tab for consistency across contact views.

## How To Test This?
1.  Navigate to an existing person's detail page (e.g., `admin/contacts/persons/{id}/view`).
2.  Observe the 'Activities' section.
3.  Verify that the 'Planned' tab is selected by default and its content is displayed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-62ffc215-be49-49aa-a1df-2ca8c3cb4193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62ffc215-be49-49aa-a1df-2ca8c3cb4193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

