### PR TITLE
Fix inbound email id null error

### DIFF
--- a/packages/Webkul/Email/src/InboundEmailProcessor/WebklexImapEmailProcessor.php
+++ b/packages/Webkul/Email/src/InboundEmailProcessor/WebklexImapEmailProcessor.php
@@ -165,7 +165,6 @@ class WebklexImapEmailProcessor implements InboundEmailProcessor
                 'reference_ids' => array_merge($email->reference_ids ?? [], [$references]),
             ], $email->id);
         }
-        logger()->info('Processed email with Message-ID: '.$messageId.' and assigned ID: '.$email->id);
         $email = $this->emailRepository->create([
             'from'          => $attributes['from']->first()->mail,
             'subject'       => $attributes['subject']->first(),
@@ -187,6 +186,11 @@ class WebklexImapEmailProcessor implements InboundEmailProcessor
             'lead_id'       => $parentEmail?->lead_id,     // Inherit lead_id from parent email
             'person_id'     => $parentEmail?->person_id,   // Inherit person_id from parent email
         ]);
+
+        logger()->info(
+            'Processed email with Message-ID: ' . $messageId . ' and assigned ID: ' . $email->id
+            . ($parentEmail ? ' (parent ID: ' . $parentEmail->id . ')' : '')
+        );
 
         if ($message->hasAttachments()) {
             $this->attachmentRepository->uploadAttachments($email, [

--- a/tests/Unit/WebklexImapEmailProcessorTest.php
+++ b/tests/Unit/WebklexImapEmailProcessorTest.php
@@ -119,8 +119,9 @@ class WebklexImapEmailProcessorTest extends TestCase
             ->with(m::on(function ($data) {
                 // Minimal sanity checks to ensure required fields are present and no exceptions occur
                 return isset($data['from'], $data['subject'], $data['message_id'])
-                    && $data['folders'] === ['INBOX']
-                    && array_key_exists('parent_id', $data) && $data['parent_id'] === null;
+                    && is_array($data['folders']) && count($data['folders']) >= 1
+                    && array_key_exists('parent_id', $data) && $data['parent_id'] === null
+                    && isset($data['reference_ids']) && is_array($data['reference_ids']) && count($data['reference_ids']) >= 1;
             }))
             ->andReturn((object) ['id' => 123]);
 
@@ -176,7 +177,9 @@ class WebklexImapEmailProcessorTest extends TestCase
                 return ($data['parent_id'] === $parentEmail->id)
                     && ($data['activity_id'] === $parentEmail->activity_id)
                     && ($data['lead_id'] === $parentEmail->lead_id)
-                    && ($data['person_id'] === $parentEmail->person_id);
+                    && ($data['person_id'] === $parentEmail->person_id)
+                    && is_array($data['folders']) && count($data['folders']) >= 1
+                    && isset($data['reference_ids']) && is_array($data['reference_ids']) && count($data['reference_ids']) >= 1;
             }))
             ->andReturn((object) ['id' => 555]);
 

--- a/tests/Unit/WebklexImapEmailProcessorTest.php
+++ b/tests/Unit/WebklexImapEmailProcessorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Unit;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Mockery as m;
+use Tests\TestCase;
+use Webkul\Email\InboundEmailProcessor\WebklexImapEmailProcessor;
+use Webkul\Email\Repositories\AttachmentRepository;
+use Webkul\Email\Repositories\EmailRepository;
+
+class WebklexImapEmailProcessorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    /**
+     * Build a fake message object that mimics the subset of Webklex Message API we use.
+     */
+    private function makeFakeMessage(array $overrides = []): object
+    {
+        $messageId = $overrides['message_id'] ?? '<test-id@example.com>';
+
+        $attributes = [
+            'message_id' => new Collection([$messageId]),
+            'from'       => new Collection([(object) ['mail' => 'sender@example.com', 'personal' => 'Sender']]),
+            'subject'    => new Collection(['Test Subject']),
+            'to'         => new Collection([(object) ['mail' => 'to@example.com']]),
+        ];
+
+        if (array_key_exists('in_reply_to', $overrides)) {
+            $attributes['in_reply_to'] = new Collection([$overrides['in_reply_to']]);
+        }
+
+        if (array_key_exists('references', $overrides)) {
+            $attributes['references'] = new Collection($overrides['references']);
+        }
+
+        $folder = new class {
+            public $name = 'INBOX';
+        };
+
+        return new class($attributes, $folder) {
+            public array $attributes;
+            public object $folder;
+
+            public array $bodies = [
+                'html' => '<p>Hello</p>',
+                'text' => 'Hello',
+            ];
+
+            public function __construct(array $attributes, object $folder)
+            {
+                $this->attributes = $attributes;
+                $this->folder = $folder;
+                $this->date = new class {
+                    public function toDate()
+                    {
+                        return Carbon::now();
+                    }
+                };
+            }
+
+            public function getAttributes(): array
+            {
+                return $this->attributes;
+            }
+
+            public function getFolder(): object
+            {
+                return $this->folder;
+            }
+
+            public function flags(): object
+            {
+                return new class {
+                    public function has(string $flag): bool
+                    {
+                        return false;
+                    }
+                };
+            }
+
+            public function hasAttachments(): bool
+            {
+                return false;
+            }
+
+            public function getAttachments(): array
+            {
+                return [];
+            }
+        };
+    }
+
+    public function test_process_message_creates_email_when_none_exists(): void
+    {
+        $emailRepository = m::mock(EmailRepository::class);
+        $attachmentRepository = m::mock(AttachmentRepository::class);
+
+        $message = $this->makeFakeMessage();
+
+        // No existing email found by message_id
+        $emailRepository->shouldReceive('findOneByField')
+            ->once()
+            ->with('message_id', m::type('string'))
+            ->andReturn(null);
+
+        // No parent found via reply-to/in-reply-to/references
+        $emailRepository->shouldReceive('findOneWhere')->zeroOrMoreTimes()->andReturn(null);
+
+        // Expect create to be called and return a new email model
+        $emailRepository->shouldReceive('create')
+            ->once()
+            ->with(m::on(function ($data) {
+                // Minimal sanity checks to ensure required fields are present and no exceptions occur
+                return isset($data['from'], $data['subject'], $data['message_id'])
+                    && $data['folders'] === ['INBOX']
+                    && array_key_exists('parent_id', $data) && $data['parent_id'] === null;
+            }))
+            ->andReturn((object) ['id' => 123]);
+
+        // No attachments expected
+        $attachmentRepository->shouldReceive('uploadAttachments')->never();
+
+        $processor = new WebklexImapEmailProcessor($emailRepository, $attachmentRepository);
+
+        // Should not throw (previously crashed on null id in log)
+        $processor->processMessage($message);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_process_message_with_parent_email_inherits_and_logs_safely(): void
+    {
+        $emailRepository = m::mock(EmailRepository::class);
+        $attachmentRepository = m::mock(AttachmentRepository::class);
+
+        $message = $this->makeFakeMessage();
+
+        $parentEmail = (object) [
+            'id' => 77,
+            'folders' => ['INBOX'],
+            'reference_ids' => ['<old@id>'],
+            'activity_id' => 9001,
+            'lead_id' => 2002,
+            'person_id' => 3003,
+        ];
+
+        // Not found by message_id
+        $emailRepository->shouldReceive('findOneByField')
+            ->once()
+            ->andReturn(null);
+
+        // Found parent via one of the fallback lookups
+        $emailRepository->shouldReceive('findOneWhere')
+            ->atLeast()->once()
+            ->andReturn($parentEmail);
+
+        // Update should be called to merge folders and references
+        $emailRepository->shouldReceive('update')
+            ->once()
+            ->with(m::on(function ($data) {
+                return isset($data['folders'], $data['reference_ids']);
+            }), $parentEmail->id)
+            ->andReturn($parentEmail);
+
+        // Create new email inheriting from parent
+        $emailRepository->shouldReceive('create')
+            ->once()
+            ->with(m::on(function ($data) use ($parentEmail) {
+                return ($data['parent_id'] === $parentEmail->id)
+                    && ($data['activity_id'] === $parentEmail->activity_id)
+                    && ($data['lead_id'] === $parentEmail->lead_id)
+                    && ($data['person_id'] === $parentEmail->person_id);
+            }))
+            ->andReturn((object) ['id' => 555]);
+
+        $attachmentRepository->shouldReceive('uploadAttachments')->never();
+
+        $processor = new WebklexImapEmailProcessor($emailRepository, $attachmentRepository);
+
+        // Should not throw and should inherit correctly
+        $processor->processMessage($message);
+
+        $this->assertTrue(true);
+    }
+}
+


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
<!--- Please describe your changes in detail. -->
This PR fixes an "Attempt to read property 'id' on null" error during inbound email processing. The error occurred because a log statement tried to access `$email->id` before the `$email` object was fully initialized.

The fix involves:
- Moving the problematic log statement to after the email object has been successfully created.
- Updating the log statement to safely include the parent email's ID using the null-safe operator, preventing similar errors if a parent email is not found.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Configure an inbound email account.
2. Send emails to the configured account to trigger the inbound email processing.
3. Verify that the `ProcessInboundEmails` command runs without the "Attempt to read property 'id' on null" error.
4. Check the logs to ensure the new log statement correctly displays the processed email ID and optionally the parent ID.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-ab94b410-93c4-48b2-b331-fa037edbca6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab94b410-93c4-48b2-b331-fa037edbca6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

