### PR TITLE
Build and push latest docker image on main branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,31 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image using build_image.sh
+        run: |
+          chmod +x ./build_image.sh
+          ./build_image.sh


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces a new GitHub Actions workflow (`.github/workflows/docker-publish.yml`) to automate the Docker image build and push process. On every push to the `main` branch, the workflow will log in to GitHub Container Registry (GHCR) and execute the existing `build_image.sh` script to build and push the Docker image with the `latest` tag to GHCR.

## How To Test This?
1.  Merge this PR into the `main` branch.
2.  Make any subsequent commit and push it to the `main` branch.
3.  Navigate to the "Actions" tab in the GitHub repository.
4.  Verify that a new workflow run named "Build and push Docker image" is triggered and completes successfully.
5.  Confirm that the `latest` Docker image is available in the repository's GitHub Container Registry.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-55ada90b-74e9-47bd-8379-796a9ac3e53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55ada90b-74e9-47bd-8379-796a9ac3e53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

