### PR TITLE
Fix docker publish pipeline failure reporting

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Stel de variabelen in
 IMAGE_NAME="krayincrm"


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
The `docker-publish.yml` pipeline was reported as green despite `docker push` failing with a `permission_denied` error.

## Description
This change adds `set -euo pipefail` to `build_image.sh`. This ensures that any command failure within the script, such as a `docker push` permission error, will immediately terminate the script and cause the GitHub Actions job to fail, correctly marking the pipeline as red.

## How To Test This?
Trigger the `docker-publish.yml` workflow with a `GITHUB_TOKEN` that does not have `write:packages` permission. The pipeline should now fail (turn red) at the `build_image.sh` step, instead of succeeding.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-67986eeb-a6af-4a35-a901-a6bc4b231638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67986eeb-a6af-4a35-a901-a6bc4b231638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

