### PR TITLE
Fix syntax error in call status controller test

### DIFF
--- a/tests/Feature/CallStatusControllerTest.php
+++ b/tests/Feature/CallStatusControllerTest.php
@@ -119,7 +119,7 @@ test('call status with send_email returns email data', function () {
 	$lead = Lead::create([
 		'first_name' => 'John',
 		'last_name'  => 'Doe',
-		emails'     => [
+		'emails'     => [
 			['value' => 'john.doe@example.com', 'is_default' => true],
 		],
 		'user_id'    => $user->id,


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Fixed a PHP syntax error in `tests/Feature/CallStatusControllerTest.php` by adding a missing single quote to the `'emails'` array key. This resolves the "unexpected single-quoted string" error when running tests.

## How To Test This?
Run `sail artisan test`. The test suite should now execute without the reported syntax error.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-33033074-0a1d-45a3-bbbd-1e2a9003574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33033074-0a1d-45a3-bbbd-1e2a9003574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

