### PR TITLE
Fix vite manifest not found error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,63 @@
 name: CI
 
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          extensions: sqlite, pdo_sqlite, mbstring, intl, pcntl
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install PHP dependencies
+        run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Admin frontend dependencies
+        run: npm ci --prefix packages/Webkul/Admin
+
+      - name: Build Admin assets
+        run: npm run build --prefix packages/Webkul/Admin
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always | cat
+
+name: CI
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
## Issue Reference
Resolves "Vite manifest not found" error in CI.

## Description
This PR addresses the `Vite manifest not found` error occurring in CI during feature tests. The issue arose because Blade views rendered by feature tests require compiled Vite assets, which were not being built in the CI environment.

The solution involves adding steps to the GitHub Actions workflow (`.github/workflows/ci.yml`) to:
1. Set up Node.js.
2. Install frontend dependencies for the `packages/Webkul/Admin` directory.
3. Build the Admin frontend assets using Vite.

These steps ensure that `public/admin/build/manifest.json` is generated before PHPUnit runs, resolving the manifest error.

## How To Test This?
Trigger the CI workflow by pushing changes to a branch or opening a pull request. Verify that the `tests` job completes successfully without the `Vite manifest not found` error.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-52814619-d8e7-4941-a7d2-340f404daf39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52814619-d8e7-4941-a7d2-340f404daf39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

