### PR TITLE
Cleanup untagged container images

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -21,3 +21,12 @@ jobs:
           tag-selection: both
           cut-off: '2w'
           rust-log: info
+      - name: Verwijder ongetagde GHCR images
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: privatescanbv
+          token: ${{ secrets.GHCR_PAT }}
+          image-names: "krayin-laravel-crm/krayincrm"
+          tag-selection: untagged
+          dry-run: false
+          rust-log: info


### PR DESCRIPTION
## Issue Reference
Addresses the reported issue where untagged GitHub Container Registry (GHCR) images were not being cleaned up by the existing workflow.

## Description
This PR adds a second step to the `cleanup-ghcr.yml` workflow. This new step explicitly targets and deletes untagged GHCR images for the `krayin-laravel-crm/krayincrm` package using `snok/container-retention-policy` with `tag-selection: untagged`. The original step continues to manage tagged images (keeping 3 most recent, excluding `latest`, and older than 2 weeks).

## How To Test This?
1. Trigger the `cleanup-ghcr.yml` workflow.
2. Verify in the GitHub Container Registry for `privatescanbv/krayin-laravel-crm/krayincrm` that untagged images are now being removed.
3. Ensure the `GHCR_PAT` secret has the necessary `delete:packages` scope for the cleanup to succeed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-90cf4a4b-8b54-432c-a1b2-2204290e0195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90cf4a4b-8b54-432c-a1b2-2204290e0195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

