### PR TITLE
Refactor lead import report generation

### DIFF
--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -41,6 +41,23 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
     protected MeetingImporter $meetingImporter;
 
+    // Totals across all chunks
+    private int $totalImported = 0;
+    private int $totalSkipped = 0;
+    private int $totalErrors = 0;
+    private int $totalPersonNotFound = 0;
+    private int $totalSkippedAlreadyExisting = 0;
+    private int $totalSkippedNoRelatedPersons = 0;
+    private int $totalSkippedNotAllPersonsFound = 0;
+    private int $totalCallActivitiesImported = 0;
+    private int $totalCallActivitiesSkipped = 0;
+    private int $totalEmailActivitiesImported = 0;
+    private int $totalEmailActivitiesSkipped = 0;
+    private int $totalMeetingActivitiesImported = 0;
+    private int $totalMeetingActivitiesSkipped = 0;
+    private int $totalEmailAttachmentsImported = 0;
+    private int $totalEmailAttachmentsSkipped = 0;
+
     /**
      * The name and signature of the console command.
      *
@@ -292,6 +309,11 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                 unset($records);
                 gc_collect_cycles();
             });
+
+            // After processing all chunks, print a single consolidated summary
+            if (! $dryRun) {
+                $this->printImportSummary();
+            }
         });
     }
 
@@ -688,38 +710,62 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         $bar->finish();
+
+        // Accumulate totals across all chunks
+        $this->totalImported += $imported;
+        $this->totalSkipped += $skipped;
+        $this->totalErrors += $errors;
+        $this->totalPersonNotFound += $personNotFound;
+        $this->totalSkippedAlreadyExisting += $skippedAlreadyExisting;
+        $this->totalSkippedNoRelatedPersons += $skippedNoRelatedPersons;
+        $this->totalSkippedNotAllPersonsFound += $skippedNotAllPersonsFound;
+        $this->totalCallActivitiesImported += $callActivitiesImported;
+        $this->totalCallActivitiesSkipped += $callActivitiesSkipped;
+        $this->totalEmailActivitiesImported += $emailActivitiesImported;
+        $this->totalEmailActivitiesSkipped += $emailActivitiesSkipped;
+        $this->totalMeetingActivitiesImported += $meetingActivitiesImported;
+        $this->totalMeetingActivitiesSkipped += $meetingActivitiesSkipped;
+        $this->totalEmailAttachmentsImported += $emailAttachmentsImported;
+        $this->totalEmailAttachmentsSkipped += $emailAttachmentsSkipped;
+    }
+
+    /**
+     * Print a consolidated import summary across all chunks
+     */
+    private function printImportSummary(): void
+    {
         $this->newLine(2);
         $this->info('Import completed!');
-        $this->info("✓ Imported: {$imported}");
-        $this->info("⚠ Skipped: {$skipped}");
-        $this->info("✗ Person not found: {$personNotFound}");
-        $this->info("✗ Errors: {$errors}");
+        $this->info("✓ Imported: {$this->totalImported}");
+        $this->info("⚠ Skipped: {$this->totalSkipped}");
+        $this->info("✗ Person not found: {$this->totalPersonNotFound}");
+        $this->info("✗ Errors: {$this->totalErrors}");
         $this->line('');
         $this->info('Call Activities:');
-        $this->info("✓ Call activities imported: {$callActivitiesImported}");
-        $this->info("⚠ Call activities skipped: {$callActivitiesSkipped}");
+        $this->info("✓ Call activities imported: {$this->totalCallActivitiesImported}");
+        $this->info("⚠ Call activities skipped: {$this->totalCallActivitiesSkipped}");
 
         $this->line('');
         $this->info('Email Activities:');
-        $this->info("✓ Email activities imported: {$emailActivitiesImported}");
-        $this->info("⚠ Email activities skipped: {$emailActivitiesSkipped}");
+        $this->info("✓ Email activities imported: {$this->totalEmailActivitiesImported}");
+        $this->info("⚠ Email activities skipped: {$this->totalEmailActivitiesSkipped}");
 
         $this->line('');
         $this->info('Meeting Activities:');
-        $this->info("✓ Meeting activities imported: {$meetingActivitiesImported}");
-        $this->info("⚠ Meeting activities skipped: {$meetingActivitiesSkipped}");
+        $this->info("✓ Meeting activities imported: {$this->totalMeetingActivitiesImported}");
+        $this->info("⚠ Meeting activities skipped: {$this->totalMeetingActivitiesSkipped}");
 
         $this->line('');
         $this->info('Email Attachments:');
-        $this->info("✓ Email attachments imported: {$emailAttachmentsImported}");
-        $this->info("⚠ Email attachments skipped: {$emailAttachmentsSkipped}");
+        $this->info("✓ Email attachments imported: {$this->totalEmailAttachmentsImported}");
+        $this->info("⚠ Email attachments skipped: {$this->totalEmailAttachmentsSkipped}");
 
         // Detailed skip breakdown
         $this->line('');
         $this->info('Skip breakdown:');
-        $this->info("- Already existing (external_id present): {$skippedAlreadyExisting}");
-        $this->info("- No related persons found: {$skippedNoRelatedPersons}");
-        $this->info("- Not all related persons found: {$skippedNotAllPersonsFound}");
+        $this->info("- Already existing (external_id present): {$this->totalSkippedAlreadyExisting}");
+        $this->info("- No related persons found: {$this->totalSkippedNoRelatedPersons}");
+        $this->info("- Not all related persons found: {$this->totalSkippedNotAllPersonsFound}");
     }
 
     /**


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
The import summary for `ImportLeadsFromSugarCRM` was previously printed per chunk, which was not desired. This change refactors the summary to be printed only once at the end of the entire import process, providing a consolidated overview.

To achieve this:
- Class-level properties were introduced to accumulate totals across all processed chunks.
- The summary printing logic (originally lines 690-722) has been extracted into a new `printImportSummary()` method.
- This new method is now called once after all chunks have been processed (when not in dry-run mode).
- All counters correctly reflect the overall totals for the complete import.

## How To Test This?
1.  Run the `ImportLeadsFromSugarCRM` command (e.g., `php artisan app:import-leads-from-sugarcrm`).
2.  Observe that the import summary is now printed only once at the very end of the command execution.
3.  Verify that the reported totals (imported, skipped, errors, activities, etc.) are accurate for the complete dataset.
4.  Run the command with `--dry-run` to confirm that the consolidated summary is not printed in dry-run mode.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-048a44e0-dcb4-4fd9-a1c1-31622f2f1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-048a44e0-dcb4-4fd9-a1c1-31622f2f1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

