### PR TITLE
Update email and phone label system

### DIFF
--- a/app/Console/Commands/AbstractSugarCRMImport.php
+++ b/app/Console/Commands/AbstractSugarCRMImport.php
@@ -37,6 +37,18 @@ abstract class AbstractSugarCRMImport extends Command
     }
 
     /**
+     * @throws Exception if any of the specified tables do not exist
+     */
+    public function validateTableExists(string $connection, array $tables): void
+    {
+        foreach ($tables as $table) {
+            if (! Schema::connection($connection)->hasTable($table)) {
+                throw new Exception("Missing table: {$table}");
+            }
+        }
+    }
+
+    /**
      * Parse SugarCRM date format to our timezone
      */
     protected function parseSugarDate($value): ?string
@@ -177,12 +189,10 @@ abstract class AbstractSugarCRMImport extends Command
      */
     protected function sanitizePhoneAndInferLabel(?string $raw, string $defaultLabel): array
     {
-        $value = trim((string) ($raw ?? ''));
+        $value = trim($raw ?? '');
         if ($value === '') {
             return [$defaultLabel, $value];
         }
-
-        $lower = strtolower($value);
 
         // Known label keywords and their mapped labels used in our system
         $labelMap = [
@@ -252,17 +262,5 @@ abstract class AbstractSugarCRMImport extends Command
     {
         Config::set('webhook.enabled', true);
         $this->info('🔔 Webhooks re-enabled after import operation');
-    }
-
-    /**
-     * @throws Exception if any of the specified tables do not exist
-     */
-    public function validateTableExists(string $connection, array $tables): void
-    {
-        foreach ($tables as $table) {
-            if (!Schema::connection($connection)->hasTable($table)) {
-                throw new Exception("Missing table: {$table}");
-            }
-        }
     }
 }

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\ContactLabel;
 use App\Enums\LostReason;
 use App\Enums\PipelineDefaultKeys;
 use App\Enums\PipelineStageDefaultKeys;
@@ -42,24 +43,6 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
     protected MeetingImporter $meetingImporter;
 
-    // Totals across all chunks
-    private int $totalImported = 0;
-    private int $totalSkipped = 0;
-    private int $totalErrors = 0;
-    private int $totalPersonNotFound = 0;
-    private int $totalSkippedAlreadyExisting = 0;
-    private int $totalSkippedNoRelatedPersons = 0;
-    private int $totalSkippedNotAllPersonsFound = 0;
-    private int $totalCallActivitiesImported = 0;
-    private int $totalCallActivitiesSkipped = 0;
-    private int $totalEmailActivitiesImported = 0;
-    private int $totalEmailActivitiesSkipped = 0;
-    private int $totalMeetingActivitiesImported = 0;
-    private int $totalMeetingActivitiesSkipped = 0;
-    private int $totalEmailAttachmentsImported = 0;
-    private int $totalEmailAttachmentsSkipped = 0;
-    private ProgressBar $bar;
-
     /**
      * The name and signature of the console command.
      *
@@ -77,6 +60,39 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
      * @var string
      */
     protected $description = 'Import leads from SugarCRM database with anamnesis data, call activities, email activities, meeting activities and email attachments';
+
+    // Totals across all chunks
+    private int $totalImported = 0;
+
+    private int $totalSkipped = 0;
+
+    private int $totalErrors = 0;
+
+    private int $totalPersonNotFound = 0;
+
+    private int $totalSkippedAlreadyExisting = 0;
+
+    private int $totalSkippedNoRelatedPersons = 0;
+
+    private int $totalSkippedNotAllPersonsFound = 0;
+
+    private int $totalCallActivitiesImported = 0;
+
+    private int $totalCallActivitiesSkipped = 0;
+
+    private int $totalEmailActivitiesImported = 0;
+
+    private int $totalEmailActivitiesSkipped = 0;
+
+    private int $totalMeetingActivitiesImported = 0;
+
+    private int $totalMeetingActivitiesSkipped = 0;
+
+    private int $totalEmailAttachmentsImported = 0;
+
+    private int $totalEmailAttachmentsSkipped = 0;
+
+    private ProgressBar $bar;
 
     /**
      * Map SugarCRM reden_afvoeren_c (free text/code) to our LostReason enum value
@@ -139,6 +155,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
     /**
      * Execute the console command.
+     *
      * @throws Exception
      */
     public function handle()
@@ -181,7 +198,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                 ->where('soort_aanvraag_c', '!=', 'ccsvi');
 
             if (! empty($leadIds)) {
-                $idQuery= $idQuery->whereIn('l.id', $leadIds);
+                $idQuery = $idQuery->whereIn('l.id', $leadIds);
             }
             $this->info('Total leads to process: '.$idQuery->count());
             $this->infoVV($idQuery->toRawSql());
@@ -194,6 +211,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
             $idQuery->select('l.id')->chunkById($batchSize, function ($rows) use ($limit, $connection, $dryRun, &$processed) {
                 if ($rows->isEmpty()) {
                     $this->info('No more leads to process, exiting chunk loop');
+
                     return false;
                 }
                 if ($limit > 0) {
@@ -206,7 +224,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
                     $leadIdsBatch = $rows->pluck('id')->all();
                 }
                 $this->infoV('Running next batch, number of leads: '.count($leadIdsBatch));
-//                $this->info(print_r($leadIdsBatch, true));
+                //                $this->info(print_r($leadIdsBatch, true));
 
                 // Build the full select for this batch
                 $sqlBatch = DB::connection($connection)
@@ -509,7 +527,6 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
      */
     private function importRecords($records, $leadByPersonsByAnamnesis, $callActivities = [], $emailActivities = [], $meetingActivities = [], $emailAttachments = []): void
     {
-
 
         $imported = 0;
         $skipped = 0;
@@ -823,7 +840,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
         if ($primary) {
             $emails[] = [
-                'label'      => \App\Enums\ContactLabel::Eigen->value,
+                'label'      => ContactLabel::Eigen->value,
                 'value'      => $primary,
                 'is_default' => true,
             ];
@@ -831,7 +848,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
         if ($any && $any !== $primary) {
             $emails[] = [
-                'label'      => \App\Enums\ContactLabel::Eigen->value,
+                'label'      => ContactLabel::Eigen->value,
                 'value'      => $any,
                 'is_default' => false,
             ];
@@ -848,10 +865,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         $phones = [];
 
         if ($record->phone_work) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, \App\Enums\ContactLabel::Eigen->value);
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
+                    'label'      => ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => true,
                 ];
@@ -859,10 +876,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         if ($record->phone_mobile) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, \App\Enums\ContactLabel::Eigen->value);
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
+                    'label'      => ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => empty($phones),
                 ];
@@ -870,10 +887,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         if ($record->phone_home) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, \App\Enums\ContactLabel::Eigen->value);
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
+                    'label'      => ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => empty($phones),
                 ];

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -823,7 +823,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
         if ($primary) {
             $emails[] = [
-                'label'      => 'work',
+                'label'      => \App\Enums\ContactLabel::Eigen->value,
                 'value'      => $primary,
                 'is_default' => true,
             ];
@@ -831,7 +831,7 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
 
         if ($any && $any !== $primary) {
             $emails[] = [
-                'label'      => 'work',
+                'label'      => \App\Enums\ContactLabel::Eigen->value,
                 'value'      => $any,
                 'is_default' => false,
             ];
@@ -848,10 +848,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         $phones = [];
 
         if ($record->phone_work) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, 'work');
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, \App\Enums\ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => $label,
+                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => true,
                 ];
@@ -859,10 +859,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         if ($record->phone_mobile) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, 'mobile');
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, \App\Enums\ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => $label,
+                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => empty($phones),
                 ];
@@ -870,10 +870,10 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         if ($record->phone_home) {
-            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, 'home');
+            [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, \App\Enums\ContactLabel::Eigen->value);
             if ($value !== '') {
                 $phones[] = [
-                    'label'      => $label,
+                    'label'      => \App\Enums\ContactLabel::fromOld($label)->value,
                     'value'      => $value,
                     'is_default' => empty($phones),
                 ];

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\ContactLabel;
 use App\Models\Address;
 use Exception;
 use Illuminate\Support\Facades\DB;
@@ -217,35 +218,35 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
                 // Build phones array from available SugarCRM fields with sanitization
                 $phones = [];
                 if (! empty($record->phone_work)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, \App\Enums\ContactLabel::Eigen->value);
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => true];
+                        $phones[] = ['label' => ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => true];
                     }
                 }
                 if (! empty($record->phone_mobile)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, \App\Enums\ContactLabel::Eigen->value);
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
                 if (! empty($record->phone_home)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, \App\Enums\ContactLabel::Eigen->value);
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
                 if (! empty($record->phone_other)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_other, \App\Enums\ContactLabel::Eigen->value);
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_other, ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
 
                 $emails = [];
                 if (! empty($record->email_primary)) {
-                    $emails[] = ['label' => \App\Enums\ContactLabel::Eigen->value, 'value' => $record->email_primary, 'is_default' => true];
+                    $emails[] = ['label' => ContactLabel::Eigen->value, 'value' => $record->email_primary, 'is_default' => true];
                 } elseif (! empty($record->email_any)) {
-                    $emails[] = ['label' => \App\Enums\ContactLabel::Eigen->value, 'value' => $record->email_any, 'is_default' => true];
+                    $emails[] = ['label' => ContactLabel::Eigen->value, 'value' => $record->email_any, 'is_default' => true];
                 }
 
                 $gender = $this->mapGenderFromSugar($record->gender_c ?? null);

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -217,35 +217,35 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
                 // Build phones array from available SugarCRM fields with sanitization
                 $phones = [];
                 if (! empty($record->phone_work)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, 'work');
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_work, \App\Enums\ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => $label, 'value' => $value, 'is_default' => true];
+                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => true];
                     }
                 }
                 if (! empty($record->phone_mobile)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, 'mobile');
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_mobile, \App\Enums\ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => $label, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
                 if (! empty($record->phone_home)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, 'home');
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_home, \App\Enums\ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => $label, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
                 if (! empty($record->phone_other)) {
-                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_other, 'other');
+                    [$label, $value] = $this->sanitizePhoneAndInferLabel($record->phone_other, \App\Enums\ContactLabel::Eigen->value);
                     if ($value !== '') {
-                        $phones[] = ['label' => $label, 'value' => $value, 'is_default' => empty($phones)];
+                        $phones[] = ['label' => \App\Enums\ContactLabel::fromOld($label)->value, 'value' => $value, 'is_default' => empty($phones)];
                     }
                 }
 
                 $emails = [];
                 if (! empty($record->email_primary)) {
-                    $emails[] = ['label' => 'work', 'value' => $record->email_primary, 'is_default' => true];
+                    $emails[] = ['label' => \App\Enums\ContactLabel::Eigen->value, 'value' => $record->email_primary, 'is_default' => true];
                 } elseif (! empty($record->email_any)) {
-                    $emails[] = ['label' => 'work', 'value' => $record->email_any, 'is_default' => true];
+                    $emails[] = ['label' => \App\Enums\ContactLabel::Eigen->value, 'value' => $record->email_any, 'is_default' => true];
                 }
 
                 $gender = $this->mapGenderFromSugar($record->gender_c ?? null);

--- a/app/Enums/ContactLabel.php
+++ b/app/Enums/ContactLabel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+enum ContactLabel: string
+{
+    case Eigen = 'eigen';
+    case Relatie = 'relatie';
+    case Anders = 'anders';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Eigen   => 'Eigen',
+            self::Relatie => 'Relatie',
+            self::Anders  => 'Anders',
+        };
+    }
+
+    public static function fromOld(?string $oldLabel): self
+    {
+        $normalized = strtolower(trim((string) $oldLabel));
+
+        return match ($normalized) {
+            'work', 'home', 'mobile' => self::Eigen,
+            'other'                  => self::Anders,
+            default                  => self::Eigen,
+        };
+    }
+}
+

--- a/app/Enums/ContactLabel.php
+++ b/app/Enums/ContactLabel.php
@@ -27,5 +27,23 @@ enum ContactLabel: string
             default                  => self::Eigen,
         };
     }
+
+    public static function default(): self
+    {
+        return self::Eigen;
+    }
+
+    /**
+     * Return enum options for UI: [ ['value' => 'eigen', 'label' => 'Eigen'], ... ]
+     */
+    public static function options(): array
+    {
+        return array_map(static function (self $case) {
+            return [
+                'value' => $case->value,
+                'label' => $case->label(),
+            ];
+        }, self::cases());
+    }
 }
 

--- a/app/Enums/ContactLabel.php
+++ b/app/Enums/ContactLabel.php
@@ -8,21 +8,11 @@ enum ContactLabel: string
     case Relatie = 'relatie';
     case Anders = 'anders';
 
-    public function label(): string
-    {
-        return match ($this) {
-            self::Eigen   => 'Eigen',
-            self::Relatie => 'Relatie',
-            self::Anders  => 'Anders',
-        };
-    }
-
     public static function fromOld(?string $oldLabel): self
     {
         $normalized = strtolower(trim((string) $oldLabel));
 
         return match ($normalized) {
-            'work', 'home', 'mobile' => self::Eigen,
             'other'                  => self::Anders,
             default                  => self::Eigen,
         };
@@ -45,5 +35,13 @@ enum ContactLabel: string
             ];
         }, self::cases());
     }
-}
 
+    public function label(): string
+    {
+        return match ($this) {
+            self::Eigen   => 'Eigen',
+            self::Relatie => 'Relatie',
+            self::Anders  => 'Anders',
+        };
+    }
+}

--- a/app/Services/Importers/SugarCRM/ActivityImporter.php
+++ b/app/Services/Importers/SugarCRM/ActivityImporter.php
@@ -8,10 +8,8 @@ use App\Models\Department;
 use App\Services\ActivityStatusService;
 use App\Services\Importers\SugarCRM\Concerns\ImportsSugarHelpers;
 use Exception;
-use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Webkul\Activity\Models\Activity;
 use Webkul\Email\Models\Email;
 use Webkul\Lead\Models\Lead;
@@ -36,6 +34,7 @@ class ActivityImporter
      * Extract call activities from SugarCRM for the given leads
      *
      * @return array [lead_id => [call_data1, call_data2, ...]]
+     *
      * @throws Exception
      */
     public function extractCallActivities(array $leadIds): array

--- a/app/Services/Importers/SugarCRM/AttachmentImporter.php
+++ b/app/Services/Importers/SugarCRM/AttachmentImporter.php
@@ -7,7 +7,6 @@ use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Webkul\Email\Models\Attachment;
 use Webkul\Lead\Models\Lead;
 
@@ -27,6 +26,7 @@ class AttachmentImporter
      * Extract email attachments from SugarCRM for the given leads
      *
      * @return array [lead_id => [attachment_data1, attachment_data2, ...]]
+     *
      * @throws Exception
      */
     public function extractEmailAttachments(array $leadIds): array

--- a/app/Services/Importers/SugarCRM/MeetingImporter.php
+++ b/app/Services/Importers/SugarCRM/MeetingImporter.php
@@ -8,7 +8,6 @@ use App\Services\Importers\SugarCRM\Concerns\ImportsSugarHelpers;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Webkul\Activity\Models\Activity;
 use Webkul\Lead\Models\Lead;
 use Webkul\User\Models\User;
@@ -31,6 +30,7 @@ class MeetingImporter
      * Extract meeting activities from SugarCRM for the given leads
      *
      * @return array [lead_id => [meeting_data1, meeting_data2, ...]]
+     *
      * @throws Exception
      */
     public function extractMeetingActivities(array $leadIds): array

--- a/app/Validators/ContactArrayValidator.php
+++ b/app/Validators/ContactArrayValidator.php
@@ -2,6 +2,7 @@
 
 namespace App\Validators;
 
+use App\Enums\ContactLabel;
 use Illuminate\Contracts\Validation\Rule;
 
 class ContactArrayValidator implements Rule
@@ -56,7 +57,7 @@ class ContactArrayValidator implements Rule
             // If label is provided, it must be valid
             if (isset($item['label']) && ! empty(trim($item['label']))) {
                 // Validate label values using ContactLabel enum
-                $validLabels = array_map(fn($c) => $c->value, \App\Enums\ContactLabel::cases());
+                $validLabels = array_map(fn ($c) => $c->value, ContactLabel::cases());
 
                 if (! in_array($item['label'], $validLabels, true)) {
                     $validLabelsStr = implode(', ', $validLabels);

--- a/app/Validators/ContactArrayValidator.php
+++ b/app/Validators/ContactArrayValidator.php
@@ -61,7 +61,7 @@ class ContactArrayValidator implements Rule
 
                 if (! in_array($item['label'], $validLabels, true)) {
                     $validLabelsStr = implode(', ', $validLabels);
-                    $this->message = "Het {$this->type} label moet een van de volgende waarden zijn: {$validLabelsStr}.";
+                    $this->message = "Het {$this->type} label '{$item['label']}' moet een van de volgende waarden zijn: {$validLabelsStr}.";
 
                     return false;
                 }

--- a/app/Validators/ContactArrayValidator.php
+++ b/app/Validators/ContactArrayValidator.php
@@ -55,13 +55,10 @@ class ContactArrayValidator implements Rule
 
             // If label is provided, it must be valid
             if (isset($item['label']) && ! empty(trim($item['label']))) {
-                // Validate label values
-                $validLabels = ['work', 'home', 'other'];
-                if ($this->type === 'telefoon') {
-                    $validLabels[] = 'mobile';
-                }
+                // Validate label values using ContactLabel enum
+                $validLabels = array_map(fn($c) => $c->value, \App\Enums\ContactLabel::cases());
 
-                if (! in_array($item['label'], $validLabels)) {
+                if (! in_array($item['label'], $validLabels, true)) {
                     $validLabelsStr = implode(', ', $validLabels);
                     $this->message = "Het {$this->type} label moet een van de volgende waarden zijn: {$validLabelsStr}.";
 

--- a/database/migrations/2025_09_24_111549_drop_unique_message_id_on_emails_table.php
+++ b/database/migrations/2025_09_24_111549_drop_unique_message_id_on_emails_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::table('emails', function (Blueprint $table) {
@@ -17,9 +14,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::table('emails', function (Blueprint $table) {

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -4,6 +4,7 @@ namespace Webkul\Admin\Http\Controllers\Contact\Persons;
 
 use App\Enums\ContactLabel;
 use App\Models\Address;
+use BackedEnum;
 use Dotenv\Exception\ValidationException;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -227,17 +228,16 @@ class PersonController extends Controller
         // Normalize contact arrays before validation
         $this->normalizeContactArrays($request);
 
-        logger()->info('update person 1');
         try {
             $request->validate(PersonValidationService::getWebValidationRules($request));
-        } catch (Exception $exception) {
-            logger()->error('Person update validation failed', [
+        } catch (Exception $e) {
+            // for missing error displaying in the UI
+            logger()->warning('Person update validation failed', [
                 'person_id' => $id,
-                'errors' => $exception->errors(),
+                'errors' => $e->errors(),
             ]);
-            throw $exception;
+            throw $e;
         }
-        logger()->info('update person 2');
         // Normalize contact arrays before validation
         $this->normalizeContactArrays($request);
         Event::dispatch('contacts.person.update.before', $id);
@@ -246,10 +246,10 @@ class PersonController extends Controller
         $data['entity_type'] = 'persons';
 
         // Normalize enum-like fields to strings for persistence
-        if (isset($data['salutation']) && $data['salutation'] instanceof \BackedEnum) {
+        if (isset($data['salutation']) && $data['salutation'] instanceof BackedEnum) {
             $data['salutation'] = $data['salutation']->value;
         }
-        if (isset($data['gender']) && $data['gender'] instanceof \BackedEnum) {
+        if (isset($data['gender']) && $data['gender'] instanceof BackedEnum) {
             $data['gender'] = $data['gender']->value;
         }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -3,6 +3,7 @@
 namespace Webkul\Admin\Http\Controllers\Contact\Persons;
 
 use App\Models\Address;
+use Dotenv\Exception\ValidationException;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -225,7 +226,17 @@ class PersonController extends Controller
         // Normalize contact arrays before validation
         $this->normalizeContactArrays($request);
 
-        $request->validate(PersonValidationService::getWebValidationRules($request));
+        logger()->info('update person 1');
+        try {
+            $request->validate(PersonValidationService::getWebValidationRules($request));
+        } catch (Exception $exception) {
+            logger()->error('Person update validation failed', [
+                'person_id' => $id,
+                'errors' => $exception->errors(),
+            ]);
+            throw $exception;
+        }
+        logger()->info('update person 2');
         // Normalize contact arrays before validation
         $this->normalizeContactArrays($request);
         Event::dispatch('contacts.person.update.before', $id);
@@ -245,9 +256,6 @@ class PersonController extends Controller
         if (isset($data['entity'])) {
             unset($data['entity']);
         }
-
-        // Debug: Log the incoming data
-        Log::info('Person update request data:', $data);
 
         // Handle empty date fields
         if (isset($data['date_of_birth']) && empty($data['date_of_birth'])) {
@@ -301,9 +309,6 @@ class PersonController extends Controller
                 return $email;
             }, $data['emails']);
         }
-
-        // Debug: Log the processed data
-        Log::info('Person update processed data:', $data);
 
         $person = $this->personRepository->update($data, $id);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Controllers\Contact\Persons;
 
+use App\Enums\ContactLabel;
 use App\Models\Address;
 use Dotenv\Exception\ValidationException;
 use Exception;
@@ -1401,7 +1402,7 @@ class PersonController extends Controller
                 if (is_array($email)) {
                     // Ensure label exists and normalize it
                     if (!isset($email['label']) || empty($email['label'])) {
-                        $requestData['emails'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
+                        $requestData['emails'][$index]['label'] = ContactLabel::default()->value;
                     } else {
                         $requestData['emails'][$index]['label'] = $this->normalizeLabel($email['label']);
                     }
@@ -1422,7 +1423,7 @@ class PersonController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['phones'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
+                        $requestData['phones'][$index]['label'] = ContactLabel::default()->value;
                     } else {
                         $requestData['phones'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1443,7 +1444,7 @@ class PersonController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['contact_numbers'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
+                        $requestData['contact_numbers'][$index]['label'] = ContactLabel::default()->value;
                     } else {
                         $requestData['contact_numbers'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1488,19 +1489,19 @@ class PersonController extends Controller
     private function normalizeLabel(string $label): string
     {
         if (empty($label)) {
-            return \App\Enums\ContactLabel::default()->value;
+            return ContactLabel::default()->value;
         }
 
         $normalizedLabel = strtolower(trim($label));
 
         return match ($normalizedLabel) {
-            'eigen' => \App\Enums\ContactLabel::Eigen->value,
-            'relatie' => \App\Enums\ContactLabel::Relatie->value,
-            'anders' => \App\Enums\ContactLabel::Anders->value,
+            'eigen' => ContactLabel::Eigen->value,
+            'relatie' => ContactLabel::Relatie->value,
+            'anders' => ContactLabel::Anders->value,
             // legacy values mapped to enum
-            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => \App\Enums\ContactLabel::Eigen->value,
-            'other' => \App\Enums\ContactLabel::Anders->value,
-            default => \App\Enums\ContactLabel::default()->value,
+            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => ContactLabel::Eigen->value,
+            'other' => ContactLabel::Anders->value,
+            default => ContactLabel::default()->value,
         };
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -1401,7 +1401,7 @@ class PersonController extends Controller
                 if (is_array($email)) {
                     // Ensure label exists and normalize it
                     if (!isset($email['label']) || empty($email['label'])) {
-                        $requestData['emails'][$index]['label'] = 'work';
+                        $requestData['emails'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
                     } else {
                         $requestData['emails'][$index]['label'] = $this->normalizeLabel($email['label']);
                     }
@@ -1422,7 +1422,7 @@ class PersonController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['phones'][$index]['label'] = 'work';
+                        $requestData['phones'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
                     } else {
                         $requestData['phones'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1443,7 +1443,7 @@ class PersonController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['contact_numbers'][$index]['label'] = 'work';
+                        $requestData['contact_numbers'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
                     } else {
                         $requestData['contact_numbers'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1488,22 +1488,19 @@ class PersonController extends Controller
     private function normalizeLabel(string $label): string
     {
         if (empty($label)) {
-            return 'work';
+            return \App\Enums\ContactLabel::default()->value;
         }
 
-        // Convert to lowercase and map common variations
         $normalizedLabel = strtolower(trim($label));
-        $labelMap = [
-            'work' => 'work',
-            'werk' => 'work',
-            'home' => 'home',
-            'thuis' => 'home',
-            'mobile' => 'mobile',
-            'mobiel' => 'mobile',
-            'other' => 'other',
-            'anders' => 'other'
-        ];
 
-        return $labelMap[$normalizedLabel] ?? 'work';
+        return match ($normalizedLabel) {
+            'eigen' => \App\Enums\ContactLabel::Eigen->value,
+            'relatie' => \App\Enums\ContactLabel::Relatie->value,
+            'anders' => \App\Enums\ContactLabel::Anders->value,
+            // legacy values mapped to enum
+            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => \App\Enums\ContactLabel::Eigen->value,
+            'other' => \App\Enums\ContactLabel::Anders->value,
+            default => \App\Enums\ContactLabel::default()->value,
+        };
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -1311,7 +1311,7 @@ class LeadController extends Controller
                 if (is_array($email)) {
                     // Ensure label exists and normalize it
                     if (!isset($email['label']) || empty($email['label'])) {
-                        $requestData['emails'][$index]['label'] = 'work';
+                        $requestData['emails'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
                     } else {
                         $requestData['emails'][$index]['label'] = $this->normalizeLabel($email['label']);
                     }
@@ -1332,7 +1332,7 @@ class LeadController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['phones'][$index]['label'] = 'work';
+                        $requestData['phones'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
                     } else {
                         $requestData['phones'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1377,23 +1377,20 @@ class LeadController extends Controller
     private function normalizeLabel(string $label): string
     {
         if (empty($label)) {
-            return 'work';
+            return \App\Enums\ContactLabel::default()->value;
         }
 
         // Convert to lowercase and map common variations
         $normalizedLabel = strtolower(trim($label));
-        $labelMap = [
-            'work' => 'work',
-            'werk' => 'work',
-            'home' => 'home',
-            'thuis' => 'home',
-            'mobile' => 'mobile',
-            'mobiel' => 'mobile',
-            'other' => 'other',
-            'anders' => 'other'
-        ];
-
-        return $labelMap[$normalizedLabel] ?? 'work';
+        return match ($normalizedLabel) {
+            'eigen' => \App\Enums\ContactLabel::Eigen->value,
+            'relatie' => \App\Enums\ContactLabel::Relatie->value,
+            'anders' => \App\Enums\ContactLabel::Anders->value,
+            // legacy mappings
+            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => \App\Enums\ContactLabel::Eigen->value,
+            'other' => \App\Enums\ContactLabel::Anders->value,
+            default => \App\Enums\ContactLabel::default()->value,
+        };
     }
 
     // moved contact validation to LeadValidationService

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -541,9 +541,16 @@ class LeadController extends Controller
     public function update(LeadForm $request, int $id): RedirectResponse|JsonResponse
     {
         try {
-            $this->validate($request, LeadValidationService::getWebValidationRules($request, false));
+            logger()->info('update lead 1');
+            try {
+                $this->validate($request, LeadValidationService::getWebValidationRules($request, false));
+            } catch (ValidationException $exception) {
+                logger()->warn('Validation error during lead update', ['errors' => $exception->errors()]);
+                throw $exception;
+            }
             // Additional rule now embedded in LeadValidationService rules
             Event::dispatch('lead.update.before', $id);
+            logger()->info('update lead 2');
 
             $data = $request->all();
             // Handle empty date field

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Controllers\Lead;
 
+use App\Enums\ContactLabel;
 use App\Enums\LostReason;
 use App\Enums\ActivityStatus;
 use App\Enums\PipelineDefaultKeys;
@@ -16,6 +17,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 use Prettus\Repository\Criteria\RequestCriteria;
@@ -667,7 +669,7 @@ class LeadController extends Controller
     {
         $this->validate(request(), [
             'lead_pipeline_stage_id' => 'required|exists:lead_pipeline_stages,id',
-            'lost_reason' => ['nullable', new \Illuminate\Validation\Rules\Enum(LostReason::class)],
+            'lost_reason' => ['nullable', new Enum(LostReason::class)],
             'closed_at' => 'nullable|date',
         ]);
 
@@ -1318,7 +1320,7 @@ class LeadController extends Controller
                 if (is_array($email)) {
                     // Ensure label exists and normalize it
                     if (!isset($email['label']) || empty($email['label'])) {
-                        $requestData['emails'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
+                        $requestData['emails'][$index]['label'] = ContactLabel::default()->value;
                     } else {
                         $requestData['emails'][$index]['label'] = $this->normalizeLabel($email['label']);
                     }
@@ -1339,7 +1341,7 @@ class LeadController extends Controller
                 if (is_array($phone)) {
                     // Ensure label exists and normalize it
                     if (!isset($phone['label']) || empty($phone['label'])) {
-                        $requestData['phones'][$index]['label'] = \App\Enums\ContactLabel::default()->value;
+                        $requestData['phones'][$index]['label'] = ContactLabel::default()->value;
                     } else {
                         $requestData['phones'][$index]['label'] = $this->normalizeLabel($phone['label']);
                     }
@@ -1384,19 +1386,19 @@ class LeadController extends Controller
     private function normalizeLabel(string $label): string
     {
         if (empty($label)) {
-            return \App\Enums\ContactLabel::default()->value;
+            return ContactLabel::default()->value;
         }
 
         // Convert to lowercase and map common variations
         $normalizedLabel = strtolower(trim($label));
         return match ($normalizedLabel) {
-            'eigen' => \App\Enums\ContactLabel::Eigen->value,
-            'relatie' => \App\Enums\ContactLabel::Relatie->value,
-            'anders' => \App\Enums\ContactLabel::Anders->value,
+            'eigen' => ContactLabel::Eigen->value,
+            'relatie' => ContactLabel::Relatie->value,
+            'anders' => ContactLabel::Anders->value,
             // legacy mappings
-            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => \App\Enums\ContactLabel::Eigen->value,
-            'other' => \App\Enums\ContactLabel::Anders->value,
-            default => \App\Enums\ContactLabel::default()->value,
+            'work', 'werk', 'home', 'thuis', 'mobile', 'mobiel' => ContactLabel::Eigen->value,
+            'other' => ContactLabel::Anders->value,
+            default => ContactLabel::default()->value,
         };
     }
 
@@ -1507,7 +1509,7 @@ class LeadController extends Controller
     public function markAsLost(int $id): JsonResponse
     {
         $this->validate(request(), [
-            'lost_reason' => ['required', new \Illuminate\Validation\Rules\Enum(LostReason::class)],
+            'lost_reason' => ['required', new Enum(LostReason::class)],
             'closed_at' => 'nullable|date',
         ]);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -543,16 +543,15 @@ class LeadController extends Controller
     public function update(LeadForm $request, int $id): RedirectResponse|JsonResponse
     {
         try {
-            logger()->info('update lead 1');
             try {
                 $this->validate($request, LeadValidationService::getWebValidationRules($request, false));
             } catch (ValidationException $exception) {
-                logger()->warn('Validation error during lead update', ['errors' => $exception->errors()]);
+                // for missing error displaying in the UI
+                logger()->warning('Validation error during lead update', ['errors' => $exception->errors()]);
                 throw $exception;
             }
             // Additional rule now embedded in LeadValidationService rules
             Event::dispatch('lead.update.before', $id);
-            logger()->info('update lead 2');
 
             $data = $request->all();
             // Handle empty date field

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/email.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/email.blade.php
@@ -12,8 +12,9 @@
 
             <div class="relative">
                 <select class="custom-select w-full rounded rounded-l-none border bg-white px-2.5 py-2 text-sm font-normal text-gray-800 hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 ltr:mr-6 ltr:pr-8 rtl:ml-6 rtl:pl-8">
-                    <option value="work" selected>@lang('admin::app.common.custom-attributes.work')</option>
-                    <option value="home">@lang('admin::app.common.custom-attributes.home')</option>
+                    <option value="eigen" selected>Eigen</option>
+                    <option value="relatie">Relatie</option>
+                    <option value="anders">Anders</option>
                 </select>
             </div>
         </div>
@@ -55,8 +56,7 @@
                         v-model="email['label']"
                         ::disabled="isDisabled"
                     >
-                        <option value="work">@lang('admin::app.common.custom-attributes.work')</option>
-                        <option value="home">@lang('admin::app.common.custom-attributes.home')</option>
+                        <option v-for="opt in labelOptions" :key="opt.value" :value="opt.value">@{{ opt.label }}</option>
                     </x-admin::form.control-group.control>
                 </div>
 
@@ -91,7 +91,9 @@
 
             data() {
                 return {
-                    emails: this.value || [{'value': '', 'label': 'work'}],
+                    emails: this.value || [{'value': '', 'label': '{{ \App\Enums\ContactLabel::default()->value }}'}],
+                    labelOptions: @json(\App\Enums\ContactLabel::options()),
+                    defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}',
                 };
             },
 
@@ -101,7 +103,7 @@
                         JSON.stringify(newValue)
                         !== JSON.stringify(oldValue)
                     ) {
-                        this.emails = newValue || [{'value': '', 'label': 'work'}];
+                        this.emails = newValue || [{'value': '', 'label': this.defaultLabel}];
                     }
                 },
             },
@@ -124,7 +126,7 @@
                 add() {
                     this.emails.push({
                         'value': '',
-                        'label': 'work'
+                        'label': this.defaultLabel
                     });
                 },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
@@ -12,8 +12,9 @@
 
             <div class="relative">
                 <select class="custom-select w-full rounded rounded-l-none border bg-white px-2.5 py-2 text-sm font-normal text-gray-800 hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 ltr:mr-6 ltr:pr-8 rtl:ml-6 rtl:pl-8">
-                    <option value="work" selected>@lang('admin::app.common.custom-attributes.work')</option>
-                    <option value="home">@lang('admin::app.common.custom-attributes.home')</option>
+                    <option value="eigen" selected>Eigen</option>
+                    <option value="relatie">Relatie</option>
+                    <option value="anders">Anders</option>
                 </select>
             </div>
         </div>
@@ -55,8 +56,7 @@
                         v-model="contactNumber['label']"
                         ::disabled="isDisabled"
                     >
-                        <option value="work">@lang('admin::app.common.custom-attributes.work')</option>
-                        <option value="home">@lang('admin::app.common.custom-attributes.home')</option>
+                        <option v-for="opt in labelOptions" :key="opt.value" :value="opt.value">@{{ opt.label }}</option>
                     </x-admin::form.control-group.control>
                 </div>
 
@@ -91,14 +91,16 @@
 
             data() {
                 return {
-                    contactNumbers: this.value || [{'value': '', 'label': 'work'}],
+                    contactNumbers: this.value || [{'value': '', 'label': '{{ \App\Enums\ContactLabel::default()->value }}'}],
+                    labelOptions: @json(\App\Enums\ContactLabel::options()),
+                    defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}',
                 };
             },
 
             watch: {
                 value(newValue, oldValue) {
                     if (JSON.stringify(newValue) !== JSON.stringify(oldValue)) {
-                        this.contactNumbers = newValue || [{'value': '', 'label': 'work'}];
+                        this.contactNumbers = newValue || [{'value': '', 'label': this.defaultLabel}];
                     }
                 },
             },
@@ -119,7 +121,7 @@
                 if (! this.contactNumbers || ! this.contactNumbers.length) {
                     this.contactNumbers = [{
                         'value': '',
-                        'label': 'work'
+                        'label': this.defaultLabel
                     }];
                 }
             },
@@ -128,7 +130,7 @@
                 add() {
                     this.contactNumbers.push({
                         'value': '',
-                        'label': 'work'
+                        'label': this.defaultLabel
                     });
                 },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -15,6 +15,9 @@
     @verbatim
         <script type="text/x-template" id="v-emails-component-template">
             <div>
+                <div v-if="topLevelErrors.length" class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                    <div v-for="(msg, i) in topLevelErrors" :key="i">{{ msg }}</div>
+                </div>
                 <div class="space-y-3">
                     <div
                         v-for="(email, index) in emails"
@@ -127,6 +130,13 @@
                         this.$emit('input', newEmails);
                     },
                     deep: true
+                }
+            },
+
+            computed: {
+                topLevelErrors() {
+                    const msgs = this.errors && this.errors[this.name];
+                    return Array.isArray(msgs) ? msgs : [];
                 }
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -39,9 +39,11 @@
                             v-model="email.label"
                             class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                         >
-                            <option value="eigen">Eigen</option>
-                            <option value="relatie">Relatie</option>
-                            <option value="anders">Anders</option>
+                            <option
+                                v-for="opt in labelOptions"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >@{{ opt.label }}</option>
                         </select>
 
                         <div class="flex items-center space-x-2">
@@ -105,7 +107,9 @@
 
                 data() {
                     return {
-                        emails: this.processEmails(this.value)
+                        emails: this.processEmails(this.value),
+                        labelOptions: @json(\App\Enums\ContactLabel::options()),
+                        defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}'
                     }
                 },
 
@@ -139,14 +143,14 @@
 
                         // If no valid emails, return a default empty email
                         if (validEmails.length === 0) {
-                            return [{ value: '', label: 'eigen', is_default: true }];
+                            return [{ value: '', label: this.defaultLabel, is_default: true }];
                         }
 
                         return validEmails;
                     },
 
                     addEmail() {
-                        this.emails.push({ value: '', label: 'eigen', is_default: false });
+                        this.emails.push({ value: '', label: this.defaultLabel, is_default: false });
                     },
 
                     removeEmail(index) {
@@ -226,7 +230,7 @@
 
     // If no valid emails, create a default empty email
     if (empty($emails)) {
-        $emails = [['value' => '', 'label' => 'work', 'is_default' => true]];
+        $emails = [['value' => '', 'label' => \App\Enums\ContactLabel::default()->value, 'is_default' => true]];
     }
 
     // Normaliseer is_default naar boolean

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -43,7 +43,7 @@
                                 v-for="opt in labelOptions"
                                 :key="opt.value"
                                 :value="opt.value"
-                            >@{{ opt.label }}</option>
+                            >{{ opt.label }}</option>
                         </select>
 
                         <div class="flex items-center space-x-2">

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -85,134 +85,137 @@
                 </button>
             </div>
         </script>
-
-        <script type="module">
-            app.component('v-emails-component', {
-                template: '#v-emails-component-template',
-
-                props: {
-                    name: {
-                        type: String,
-                        required: true
-                    },
-                    value: {
-                        type: Array,
-                        default: () => []
-                    },
-                    errors: {
-                        type: Object,
-                        default: () => ({})
-                    }
-                },
-
-                data() {
-                    return {
-                        emails: this.processEmails(this.value),
-                        labelOptions: @json(\App\Enums\ContactLabel::options()),
-                        defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}'
-                    }
-                },
-
-                mounted() {
-                    this.ensureDefaultEmail();
-                },
-
-                watch: {
-                    emails: {
-                        handler(newEmails) {
-                            this.$emit('input', newEmails);
-                        },
-                        deep: true
-                    }
-                },
-
-                methods: {
-                    processEmails(emails) {
-                        // Ensure emails is an array
-                        if (!Array.isArray(emails)) {
-                            emails = [];
-                        }
-
-                        // Filter out empty values and process the emails
-                        let validEmails = emails
-                            .filter(email => email && email.value && email.value.trim() !== '')
-                            .map(email => ({
-                                ...email,
-                                is_default: email.is_default === true || email.is_default === 'on' || email.is_default === '1'
-                            }));
-
-                        // If no valid emails, return a default empty email
-                        if (validEmails.length === 0) {
-                            return [{ value: '', label: this.defaultLabel, is_default: true }];
-                        }
-
-                        return validEmails;
-                    },
-
-                    addEmail() {
-                        this.emails.push({ value: '', label: this.defaultLabel, is_default: false });
-                    },
-
-                    removeEmail(index) {
-                        if (this.emails.length > 1) {
-                            const wasDefault = this.emails[index].is_default === true || this.emails[index].is_default === 'on';
-                            this.emails.splice(index, 1);
-
-                            // If we removed the default email, make the first one default
-                            if (wasDefault && this.emails.length > 0) {
-                                this.emails[0].is_default = true;
-                            }
-                        }
-                    },
-
-                    handleDefaultChange(index, event) {
-                        const isChecked = event.target.checked;
-
-                        // Uncheck all other checkboxes
-                        this.emails.forEach((email, i) => {
-                            if (i !== index) {
-                                email.is_default = false;
-                            }
-                        });
-
-                        // Set the current email's default status
-                        this.emails[index].is_default = isChecked;
-
-                        // If no email is checked, make the first one default
-                        if (!isChecked && this.emails.length > 0) {
-                            this.emails[0].is_default = true;
-                        }
-                    },
-
-                    ensureDefaultEmail() {
-                        // If no email is marked as default, make the first one default
-                        const hasDefault = this.emails.some(email =>
-                            email.is_default === true || email.is_default === 'on' || email.is_default === '1'
-                        );
-                        if (!hasDefault && this.emails.length > 0) {
-                            this.emails[0].is_default = true;
-                        }
-                    },
-
-                    getInputClass(index) {
-                        const baseClass = 'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 dark:bg-gray-700 dark:text-white';
-                        const hasError = this.getEmailError(index);
-
-                        if (hasError) {
-                            return baseClass + ' border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-600';
-                        } else {
-                            return baseClass + ' border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600';
-                        }
-                    },
-
-                    getEmailError(index) {
-                        const errorKey = this.name + '.' + index + '.value';
-                        return this.errors[errorKey] ? this.errors[errorKey][0] : null;
-                    }
-                }
-            });
-        </script>
     @endverbatim
+
+    <script type="module">
+        const CONTACT_LABEL_OPTIONS = @json(\App\Enums\ContactLabel::options());
+        const CONTACT_LABEL_DEFAULT = @json(\App\Enums\ContactLabel::default()->value);
+
+        app.component('v-emails-component', {
+            template: '#v-emails-component-template',
+
+            props: {
+                name: {
+                    type: String,
+                    required: true
+                },
+                value: {
+                    type: Array,
+                    default: () => []
+                },
+                errors: {
+                    type: Object,
+                    default: () => ({})
+                }
+            },
+
+            data() {
+                return {
+                    emails: this.processEmails(this.value),
+                    labelOptions: CONTACT_LABEL_OPTIONS,
+                    defaultLabel: CONTACT_LABEL_DEFAULT,
+                }
+            },
+
+            mounted() {
+                this.ensureDefaultEmail();
+            },
+
+            watch: {
+                emails: {
+                    handler(newEmails) {
+                        this.$emit('input', newEmails);
+                    },
+                    deep: true
+                }
+            },
+
+            methods: {
+                processEmails(emails) {
+                    // Ensure emails is an array
+                    if (!Array.isArray(emails)) {
+                        emails = [];
+                    }
+
+                    // Filter out empty values and process the emails
+                    let validEmails = emails
+                        .filter(email => email && email.value && email.value.trim() !== '')
+                        .map(email => ({
+                            ...email,
+                            is_default: email.is_default === true || email.is_default === 'on' || email.is_default === '1'
+                        }));
+
+                    // If no valid emails, return a default empty email
+                    if (validEmails.length === 0) {
+                        return [{ value: '', label: this.defaultLabel, is_default: true }];
+                    }
+
+                    return validEmails;
+                },
+
+                addEmail() {
+                    this.emails.push({ value: '', label: this.defaultLabel, is_default: false });
+                },
+
+                removeEmail(index) {
+                    if (this.emails.length > 1) {
+                        const wasDefault = this.emails[index].is_default === true || this.emails[index].is_default === 'on';
+                        this.emails.splice(index, 1);
+
+                        // If we removed the default email, make the first one default
+                        if (wasDefault && this.emails.length > 0) {
+                            this.emails[0].is_default = true;
+                        }
+                    }
+                },
+
+                handleDefaultChange(index, event) {
+                    const isChecked = event.target.checked;
+
+                    // Uncheck all other checkboxes
+                    this.emails.forEach((email, i) => {
+                        if (i !== index) {
+                            email.is_default = false;
+                        }
+                    });
+
+                    // Set the current email's default status
+                    this.emails[index].is_default = isChecked;
+
+                    // If no email is checked, make the first one default
+                    if (!isChecked && this.emails.length > 0) {
+                        this.emails[0].is_default = true;
+                    }
+                },
+
+                ensureDefaultEmail() {
+                    // If no email is marked as default, make the first one default
+                    const hasDefault = this.emails.some(email =>
+                        email.is_default === true || email.is_default === 'on' || email.is_default === '1'
+                    );
+                    if (!hasDefault && this.emails.length > 0) {
+                        this.emails[0].is_default = true;
+                    }
+                },
+
+                getInputClass(index) {
+                    const baseClass = 'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 dark:bg-gray-700 dark:text-white';
+                    const hasError = this.getEmailError(index);
+
+                    if (hasError) {
+                        return baseClass + ' border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-600';
+                    } else {
+                        return baseClass + ' border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600';
+                    }
+                },
+
+                getEmailError(index) {
+                    const errorKey = this.name + '.' + index + '.value';
+                    return this.errors[errorKey] ? this.errors[errorKey][0] : null;
+                }
+            }
+        });
+    </script>
 @endPushOnce
 
 @php

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -39,9 +39,9 @@
                             v-model="email.label"
                             class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                         >
-                            <option value="work">Werk</option>
-                            <option value="home">Thuis</option>
-                            <option value="other">Anders</option>
+                            <option value="eigen">Eigen</option>
+                            <option value="relatie">Relatie</option>
+                            <option value="anders">Anders</option>
                         </select>
 
                         <div class="flex items-center space-x-2">
@@ -139,14 +139,14 @@
 
                         // If no valid emails, return a default empty email
                         if (validEmails.length === 0) {
-                            return [{ value: '', label: 'work', is_default: true }];
+                            return [{ value: '', label: 'eigen', is_default: true }];
                         }
 
                         return validEmails;
                     },
 
                     addEmail() {
-                        this.emails.push({ value: '', label: 'work', is_default: false });
+                        this.emails.push({ value: '', label: 'eigen', is_default: false });
                     },
 
                     removeEmail(index) {

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -85,134 +85,137 @@
                 </button>
             </div>
         </script>
-
-        <script type="module">
-            app.component('v-phones-component', {
-                template: '#v-phones-component-template',
-
-                props: {
-                    name: {
-                        type: String,
-                        required: true
-                    },
-                    value: {
-                        type: Array,
-                        default: () => []
-                    },
-                    errors: {
-                        type: Object,
-                        default: () => ({})
-                    }
-                },
-
-                data() {
-                    return {
-                        phones: this.processPhones(this.value),
-                        labelOptions: @json(\App\Enums\ContactLabel::options()),
-                        defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}'
-                    }
-                },
-
-                mounted() {
-                    this.ensureDefaultPhone();
-                },
-
-                watch: {
-                    phones: {
-                        handler(newPhones) {
-                            this.$emit('input', newPhones);
-                        },
-                        deep: true
-                    }
-                },
-
-                methods: {
-                    processPhones(phones) {
-                        // Ensure phones is an array
-                        if (!Array.isArray(phones)) {
-                            phones = [];
-                        }
-
-                        // Filter out empty values and process the phones
-                        let validPhones = phones
-                            .filter(phone => phone && phone.value && phone.value.trim() !== '')
-                            .map(phone => ({
-                                ...phone,
-                                is_default: phone.is_default === true || phone.is_default === 'on' || phone.is_default === '1'
-                            }));
-
-                        // If no valid phones, return a default empty phone
-                        if (validPhones.length === 0) {
-                            return [{ value: '', label: this.defaultLabel, is_default: true }];
-                        }
-
-                        return validPhones;
-                    },
-
-                    addPhone() {
-                        this.phones.push({ value: '', label: this.defaultLabel, is_default: false });
-                    },
-
-                    removePhone(index) {
-                        if (this.phones.length > 1) {
-                            const wasDefault = this.phones[index].is_default === true || this.phones[index].is_default === 'on';
-                            this.phones.splice(index, 1);
-
-                            // If we removed the default phone, make the first one default
-                            if (wasDefault && this.phones.length > 0) {
-                                this.phones[0].is_default = true;
-                            }
-                        }
-                    },
-
-                    handleDefaultChange(index, event) {
-                        const isChecked = event.target.checked;
-
-                        // Uncheck all other checkboxes
-                        this.phones.forEach((phone, i) => {
-                            if (i !== index) {
-                                phone.is_default = false;
-                            }
-                        });
-
-                        // Set the current phone's default status
-                        this.phones[index].is_default = isChecked;
-
-                        // If no phone is checked, make the first one default
-                        if (!isChecked && this.phones.length > 0) {
-                            this.phones[0].is_default = true;
-                        }
-                    },
-
-                    ensureDefaultPhone() {
-                        // If no phone is marked as default, make the first one default
-                        const hasDefault = this.phones.some(phone =>
-                            phone.is_default === true || phone.is_default === 'on' || phone.is_default === '1'
-                        );
-                        if (!hasDefault && this.phones.length > 0) {
-                            this.phones[0].is_default = true;
-                        }
-                    },
-
-                    getInputClass(index) {
-                        const baseClass = 'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 dark:bg-gray-700 dark:text-white';
-                        const hasError = this.getPhoneError(index);
-
-                        if (hasError) {
-                            return baseClass + ' border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-600';
-                        } else {
-                            return baseClass + ' border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600';
-                        }
-                    },
-
-                    getPhoneError(index) {
-                        const errorKey = this.name + '.' + index + '.value';
-                        return this.errors[errorKey] ? this.errors[errorKey][0] : null;
-                    }
-                }
-            });
-        </script>
     @endverbatim
+
+    <script type="module">
+        const CONTACT_LABEL_OPTIONS = @json(\App\Enums\ContactLabel::options());
+        const CONTACT_LABEL_DEFAULT = @json(\App\Enums\ContactLabel::default()->value);
+
+        app.component('v-phones-component', {
+            template: '#v-phones-component-template',
+
+            props: {
+                name: {
+                    type: String,
+                    required: true
+                },
+                value: {
+                    type: Array,
+                    default: () => []
+                },
+                errors: {
+                    type: Object,
+                    default: () => ({})
+                }
+            },
+
+            data() {
+                return {
+                    phones: this.processPhones(this.value),
+                    labelOptions: CONTACT_LABEL_OPTIONS,
+                    defaultLabel: CONTACT_LABEL_DEFAULT,
+                }
+            },
+
+            mounted() {
+                this.ensureDefaultPhone();
+            },
+
+            watch: {
+                phones: {
+                    handler(newPhones) {
+                        this.$emit('input', newPhones);
+                    },
+                    deep: true
+                }
+            },
+
+            methods: {
+                processPhones(phones) {
+                    // Ensure phones is an array
+                    if (!Array.isArray(phones)) {
+                        phones = [];
+                    }
+
+                    // Filter out empty values and process the phones
+                    let validPhones = phones
+                        .filter(phone => phone && phone.value && phone.value.trim() !== '')
+                        .map(phone => ({
+                            ...phone,
+                            is_default: phone.is_default === true || phone.is_default === 'on' || phone.is_default === '1'
+                        }));
+
+                    // If no valid phones, return a default empty phone
+                    if (validPhones.length === 0) {
+                        return [{ value: '', label: this.defaultLabel, is_default: true }];
+                    }
+
+                    return validPhones;
+                },
+
+                addPhone() {
+                    this.phones.push({ value: '', label: this.defaultLabel, is_default: false });
+                },
+
+                removePhone(index) {
+                    if (this.phones.length > 1) {
+                        const wasDefault = this.phones[index].is_default === true || this.phones[index].is_default === 'on';
+                        this.phones.splice(index, 1);
+
+                        // If we removed the default phone, make the first one default
+                        if (wasDefault && this.phones.length > 0) {
+                            this.phones[0].is_default = true;
+                        }
+                    }
+                },
+
+                handleDefaultChange(index, event) {
+                    const isChecked = event.target.checked;
+
+                    // Uncheck all other checkboxes
+                    this.phones.forEach((phone, i) => {
+                        if (i !== index) {
+                            phone.is_default = false;
+                        }
+                    });
+
+                    // Set the current phone's default status
+                    this.phones[index].is_default = isChecked;
+
+                    // If no phone is checked, make the first one default
+                    if (!isChecked && this.phones.length > 0) {
+                        this.phones[0].is_default = true;
+                    }
+                },
+
+                ensureDefaultPhone() {
+                    // If no phone is marked as default, make the first one default
+                    const hasDefault = this.phones.some(phone =>
+                        phone.is_default === true || phone.is_default === 'on' || phone.is_default === '1'
+                    );
+                    if (!hasDefault && this.phones.length > 0) {
+                        this.phones[0].is_default = true;
+                    }
+                },
+
+                getInputClass(index) {
+                    const baseClass = 'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 dark:bg-gray-700 dark:text-white';
+                    const hasError = this.getPhoneError(index);
+
+                    if (hasError) {
+                        return baseClass + ' border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-600';
+                    } else {
+                        return baseClass + ' border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600';
+                    }
+                },
+
+                getPhoneError(index) {
+                    const errorKey = this.name + '.' + index + '.value';
+                    return this.errors[errorKey] ? this.errors[errorKey][0] : null;
+                }
+            }
+        });
+    </script>
 @endPushOnce
 
 @php

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -39,10 +39,9 @@
                             v-model="phone.label"
                             class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                         >
-                            <option value="work">Werk</option>
-                            <option value="home">Thuis</option>
-                            <option value="mobile">Mobiel</option>
-                            <option value="other">Anders</option>
+                            <option value="eigen">Eigen</option>
+                            <option value="relatie">Relatie</option>
+                            <option value="anders">Anders</option>
                         </select>
 
                         <div class="flex items-center space-x-2">
@@ -140,14 +139,14 @@
 
                         // If no valid phones, return a default empty phone
                         if (validPhones.length === 0) {
-                            return [{ value: '', label: 'work', is_default: true }];
+                            return [{ value: '', label: 'eigen', is_default: true }];
                         }
 
                         return validPhones;
                     },
 
                     addPhone() {
-                        this.phones.push({ value: '', label: 'work', is_default: false });
+                        this.phones.push({ value: '', label: 'eigen', is_default: false });
                     },
 
                     removePhone(index) {

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -39,9 +39,11 @@
                             v-model="phone.label"
                             class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                         >
-                            <option value="eigen">Eigen</option>
-                            <option value="relatie">Relatie</option>
-                            <option value="anders">Anders</option>
+                            <option
+                                v-for="opt in labelOptions"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >@{{ opt.label }}</option>
                         </select>
 
                         <div class="flex items-center space-x-2">
@@ -105,7 +107,9 @@
 
                 data() {
                     return {
-                        phones: this.processPhones(this.value)
+                        phones: this.processPhones(this.value),
+                        labelOptions: @json(\App\Enums\ContactLabel::options()),
+                        defaultLabel: '{{ \App\Enums\ContactLabel::default()->value }}'
                     }
                 },
 
@@ -139,14 +143,14 @@
 
                         // If no valid phones, return a default empty phone
                         if (validPhones.length === 0) {
-                            return [{ value: '', label: 'eigen', is_default: true }];
+                            return [{ value: '', label: this.defaultLabel, is_default: true }];
                         }
 
                         return validPhones;
                     },
 
                     addPhone() {
-                        this.phones.push({ value: '', label: 'eigen', is_default: false });
+                        this.phones.push({ value: '', label: this.defaultLabel, is_default: false });
                     },
 
                     removePhone(index) {
@@ -226,7 +230,7 @@
 
     // If no valid phones, create a default empty phone
     if (empty($phones)) {
-        $phones = [['value' => '', 'label' => 'work', 'is_default' => true]];
+        $phones = [['value' => '', 'label' => \App\Enums\ContactLabel::default()->value, 'is_default' => true]];
     }
 
     // Normaliseer is_default naar boolean

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -44,7 +44,7 @@
                                 v-for="opt in labelOptions"
                                 :key="opt.value"
                                 :value="opt.value"
-                            >@{{ opt.label }}
+                            >{{ opt.label }}
                             </option>
                         </select>
 

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -16,6 +16,9 @@
     @verbatim
         <script type="text/x-template" id="v-phones-component-template">
             <div>
+                <div v-if="topLevelErrors.length" class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                    <div v-for="(msg, i) in topLevelErrors" :key="i">{{ msg }}</div>
+                </div>
                 <div class="space-y-3">
                     <div
                         v-for="(phone, index) in phones"
@@ -131,6 +134,13 @@
                         this.$emit('input', newPhones);
                     },
                     deep: true
+                }
+            },
+
+            computed: {
+                topLevelErrors() {
+                    const msgs = this.errors && this.errors[this.name];
+                    return Array.isArray(msgs) ? msgs : [];
                 }
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -218,29 +218,4 @@
     </script>
 @endPushOnce
 
-@php
-    $phones = $value ?? [];
-
-    // Ensure $phones is an array
-    if (!is_array($phones)) {
-        $phones = [];
-    }
-
-    // Filter out empty phone numbers
-    $phones = array_filter($phones, function($phone) {
-        return isset($phone['value']) && !empty(trim($phone['value']));
-    });
-
-    // If no valid phones, create a default empty phone
-    if (empty($phones)) {
-        $phones = [['value' => '', 'label' => \App\Enums\ContactLabel::default()->value, 'is_default' => true]];
-    }
-
-    // Normaliseer is_default naar boolean
-    foreach ($phones as &$phone) {
-        if (isset($phone['is_default'])) {
-            $phone['is_default'] = $phone['is_default'] === true || $phone['is_default'] === 'on' || $phone['is_default'] === '1';
-        }
-    }
-    unset($phone);
-@endphp
+@php /* moved normalization to Vue component; server no-op */ @endphp

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -1,3 +1,4 @@
+@php use App\Enums\ContactLabel; @endphp
 {!! view_render_event('admin.phones.before') !!}
 
 <div class="flex flex-col gap-4">
@@ -43,7 +44,8 @@
                                 v-for="opt in labelOptions"
                                 :key="opt.value"
                                 :value="opt.value"
-                            >@{{ opt.label }}</option>
+                            >@{{ opt.label }}
+                            </option>
                         </select>
 
                         <div class="flex items-center space-x-2">
@@ -67,7 +69,8 @@
                         >
                             <span class="sr-only">Remove Phone</span>
                             <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M6 18L18 6M6 6l12 12"></path>
                             </svg>
                         </button>
                     </div>
@@ -79,7 +82,8 @@
                     class="mt-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
                 >
                     <svg class="-ml-1 mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                     </svg>
                     Voeg telefoonnummer toe
                 </button>
@@ -88,8 +92,8 @@
     @endverbatim
 
     <script type="module">
-        const CONTACT_LABEL_OPTIONS = @json(\App\Enums\ContactLabel::options());
-        const CONTACT_LABEL_DEFAULT = @json(\App\Enums\ContactLabel::default()->value);
+        const CONTACT_LABEL_OPTIONS = @json(ContactLabel::options());
+        const CONTACT_LABEL_DEFAULT = @json(ContactLabel::default()->value);
 
         app.component('v-phones-component', {
             template: '#v-phones-component-template',
@@ -147,14 +151,14 @@
 
                     // If no valid phones, return a default empty phone
                     if (validPhones.length === 0) {
-                        return [{ value: '', label: this.defaultLabel, is_default: true }];
+                        return [{value: '', label: this.defaultLabel, is_default: true}];
                     }
 
                     return validPhones;
                 },
 
                 addPhone() {
-                    this.phones.push({ value: '', label: this.defaultLabel, is_default: false });
+                    this.phones.push({value: '', label: this.defaultLabel, is_default: false});
                 },
 
                 removePhone(index) {

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/edit.blade.php
@@ -86,13 +86,6 @@
                         @lang('admin::app.leads.common.emails.title')
                     </h3>
                 </div>
-                @if ($errors->has('emails'))
-                    <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
-                        @foreach ($errors->get('emails') as $msg)
-                            <div>{{ $msg }}</div>
-                        @endforeach
-                    </div>
-                @endif
                 @include('admin::components.emails', ['name' => 'emails', 'value' => old('emails', $person->emails ?? [])])
             </div>
 
@@ -103,13 +96,6 @@
                         Telefoonnummers
                     </h3>
                 </div>
-                @if ($errors->has('phones'))
-                    <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
-                        @foreach ($errors->get('phones') as $msg)
-                            <div>{{ $msg }}</div>
-                        @endforeach
-                    </div>
-                @endif
                 @include('admin::components.phones', ['name' => 'phones', 'value' => old('phones', $person->phones ?? [])])
             </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/edit.blade.php
@@ -86,7 +86,13 @@
                         @lang('admin::app.leads.common.emails.title')
                     </h3>
                 </div>
-
+                @if ($errors->has('emails'))
+                    <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                        @foreach ($errors->get('emails') as $msg)
+                            <div>{{ $msg }}</div>
+                        @endforeach
+                    </div>
+                @endif
                 @include('admin::components.emails', ['name' => 'emails', 'value' => old('emails', $person->emails ?? [])])
             </div>
 
@@ -97,7 +103,13 @@
                         Telefoonnummers
                     </h3>
                 </div>
-
+                @if ($errors->has('phones'))
+                    <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                        @foreach ($errors->get('phones') as $msg)
+                            <div>{{ $msg }}</div>
+                        @endforeach
+                    </div>
+                @endif
                 @include('admin::components.phones', ['name' => 'phones', 'value' => old('phones', $person->phones ?? [])])
             </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/common/sections/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/common/sections/emails.blade.php
@@ -9,6 +9,13 @@
     </div>
 
     <div class="{{ $widthClass ?? 'w-1/2 max-md:w-full' }}">
+        @if ($errors->has('emails'))
+            <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                @foreach ($errors->get('emails') as $msg)
+                    <div>{{ $msg }}</div>
+                @endforeach
+            </div>
+        @endif
         @include('admin::components.emails', ['name' => ($name ?? 'emails'), 'value' => ($value ?? [])])
     </div>
 </div>

--- a/packages/Webkul/Admin/src/Resources/views/leads/common/sections/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/common/sections/phones.blade.php
@@ -9,6 +9,13 @@
     </div>
 
     <div class="{{ $widthClass ?? 'w-1/2 max-md:w-full' }}">
+        @if ($errors->has('phones'))
+            <div class="mb-2 rounded border border-red-400 bg-red-100 px-3 py-2 text-red-800 dark:bg-red-900 dark:text-red-200">
+                @foreach ($errors->get('phones') as $msg)
+                    <div>{{ $msg }}</div>
+                @endforeach
+            </div>
+        @endif
         @include('admin::components.phones', ['name' => ($name ?? 'phones'), 'value' => ($value ?? [])])
     </div>
 </div>

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -668,7 +668,7 @@
                                     emailValueInputs[0].dispatchEvent(new Event('change', {bubbles: true}));
                                 }
                                 if (emailLabelInputs[0]) {
-                                    emailLabelInputs[0].value = (primaryEmail.label || 'work');
+                                    emailLabelInputs[0].value = (primaryEmail.label || 'eigen');
                                     emailLabelInputs[0].dispatchEvent(new Event('input', {bubbles: true}));
                                     emailLabelInputs[0].dispatchEvent(new Event('change', {bubbles: true}));
                                 }
@@ -688,7 +688,7 @@
                                     phoneValueInputs[0].dispatchEvent(new Event('change', {bubbles: true}));
                                 }
                                 if (phoneLabelInputs[0]) {
-                                    phoneLabelInputs[0].value = (primaryPhone.label || 'work');
+                                    phoneLabelInputs[0].value = (primaryPhone.label || 'eigen');
                                     phoneLabelInputs[0].dispatchEvent(new Event('input', {bubbles: true}));
                                     phoneLabelInputs[0].dispatchEvent(new Event('change', {bubbles: true}));
                                 }

--- a/tests/Feature/CallStatusControllerTest.php
+++ b/tests/Feature/CallStatusControllerTest.php
@@ -12,258 +12,258 @@ use Webkul\User\Models\User;
 uses(RefreshDatabase::class);
 
 test('spoken does not reschedule activity', function () {
-	$roleId = DB::table('roles')->insertGetId([
-		'name'            => 'Tester',
-		'description'     => 'Test role',
-		'permission_type' => 'all',
-		'permissions'     => json_encode([]),
-		'created_at'      => now(),
-		'updated_at'      => now(),
-	]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'Tester',
+        'description'     => 'Test role',
+        'permission_type' => 'all',
+        'permissions'     => json_encode([]),
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
 
-	$userId = DB::table('users')->insertGetId([
-		'name'       => 'Test User',
-		'email'      => 'test@example.com',
-		'password'   => bcrypt('secret'),
-		'status'     => 1,
-		'role_id'    => $roleId,
-		'created_at' => now(),
-		'updated_at' => now(),
-	]);
-	$user = User::find($userId);
-	$this->actingAs($user, 'user');
+    $userId = DB::table('users')->insertGetId([
+        'name'       => 'Test User',
+        'email'      => 'test@example.com',
+        'password'   => bcrypt('secret'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $user = User::find($userId);
+    $this->actingAs($user, 'user');
 
-	$activity = Activity::create([
-		'title'         => 'Call',
-		'type'          => 'call',
-		'schedule_from' => now(),
-		'schedule_to'   => now()->addDay(),
-		'user_id'       => $user->id,
-	]);
+    $activity = Activity::create([
+        'title'         => 'Call',
+        'type'          => 'call',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'user_id'       => $user->id,
+    ]);
 
-	$response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
-		'status'          => CallStatusEnum::SPOKEN->value,
-		'omschrijving'    => null,
-		'reschedule_days' => '',
-	]);
+    $response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
+        'status'          => CallStatusEnum::SPOKEN->value,
+        'omschrijving'    => null,
+        'reschedule_days' => '',
+    ]);
 
-	$response->assertOk();
-	$activity->refresh();
-	$this->assertTrue($activity->schedule_from->isToday());
+    $response->assertOk();
+    $activity->refresh();
+    $this->assertTrue($activity->schedule_from->isToday());
 });
 
 test('not spoken defaults to 7 days when empty', function () {
-	$roleId = DB::table('roles')->insertGetId([
-		'name'            => 'Tester 2',
-		'description'     => 'Test role 2',
-		'permission_type' => 'all',
-		'permissions'     => json_encode([]),
-		'created_at'      => now(),
-		'updated_at'      => now(),
-	]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'Tester 2',
+        'description'     => 'Test role 2',
+        'permission_type' => 'all',
+        'permissions'     => json_encode([]),
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
 
-	$userId = DB::table('users')->insertGetId([
-		'name'       => 'Test User 2',
-		'email'      => 'test2@example.com',
-		'password'   => bcrypt('secret'),
-		'status'     => 1,
-		'role_id'    => $roleId,
-		'created_at' => now(),
-		'updated_at' => now(),
-	]);
-	$user = User::find($userId);
-	$this->actingAs($user, 'user');
+    $userId = DB::table('users')->insertGetId([
+        'name'       => 'Test User 2',
+        'email'      => 'test2@example.com',
+        'password'   => bcrypt('secret'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $user = User::find($userId);
+    $this->actingAs($user, 'user');
 
-	$activity = Activity::create([
-		'title'         => 'Call 2',
-		'type'          => 'call',
-		'schedule_from' => now(),
-		'schedule_to'   => now()->addDay(),
-		'user_id'       => $user->id,
-	]);
+    $activity = Activity::create([
+        'title'         => 'Call 2',
+        'type'          => 'call',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'user_id'       => $user->id,
+    ]);
 
-	$response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
-		'status'          => CallStatusEnum::NOT_REACHABLE->value,
-		'omschrijving'    => null,
-		'reschedule_days' => '',
-	]);
+    $response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
+        'status'          => CallStatusEnum::NOT_REACHABLE->value,
+        'omschrijving'    => null,
+        'reschedule_days' => '',
+    ]);
 
-	$response->assertOk();
-	$activity->refresh();
-	$this->assertTrue($activity->schedule_from->isSameDay(now()->addDays(7)));
+    $response->assertOk();
+    $activity->refresh();
+    $this->assertTrue($activity->schedule_from->isSameDay(now()->addDays(7)));
 });
 
 test('call status with send_email returns email data', function () {
-	$roleId = DB::table('roles')->insertGetId([
-		'name'            => 'Tester 3',
-		'description'     => 'Test role 3',
-		'permission_type' => 'all',
-		'permissions'     => json_encode([]),
-		'created_at'      => now(),
-		'updated_at'      => now(),
-	]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'Tester 3',
+        'description'     => 'Test role 3',
+        'permission_type' => 'all',
+        'permissions'     => json_encode([]),
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
 
-	$userId = DB::table('users')->insertGetId([
-		'name'       => 'Test User 3',
-		'email'      => 'test3@example.com',
-		'password'   => bcrypt('secret'),
-		'status'     => 1,
-		'role_id'    => $roleId,
-		'created_at' => now(),
-		'updated_at' => now(),
-	]);
-	$user = User::find($userId);
-	$this->actingAs($user, 'user');
+    $userId = DB::table('users')->insertGetId([
+        'name'       => 'Test User 3',
+        'email'      => 'test3@example.com',
+        'password'   => bcrypt('secret'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $user = User::find($userId);
+    $this->actingAs($user, 'user');
 
-	// Create a lead with email
-	$lead = Lead::create([
-		'first_name' => 'John',
-		'last_name'  => 'Doe',
-		'emails'     => [
-			['value' => 'john.doe@example.com', 'is_default' => true],
-		],
-		'user_id'    => $user->id,
-	]);
+    // Create a lead with email
+    $lead = Lead::create([
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+        'emails'     => [
+            ['value' => 'john.doe@example.com', 'is_default' => true],
+        ],
+        'user_id'    => $user->id,
+    ]);
 
-	$activity = Activity::create([
-		'title'         => 'Call 3',
-		'type'          => 'call',
-		'schedule_from' => now(),
-		'schedule_to'   => now()->addDay(),
-		'user_id'       => $user->id,
-		'lead_id'       => $lead->id,
-	]);
+    $activity = Activity::create([
+        'title'         => 'Call 3',
+        'type'          => 'call',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'user_id'       => $user->id,
+        'lead_id'       => $lead->id,
+    ]);
 
-	$response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
-		'status'          => CallStatusEnum::SPOKEN->value,
-		'omschrijving'    => 'Test call status',
-		'reschedule_days' => '',
-		'send_email'      => true,
-	]);
+    $response = $this->postJson(route('admin.activities.call-statuses.store', $activity->id), [
+        'status'          => CallStatusEnum::SPOKEN->value,
+        'omschrijving'    => 'Test call status',
+        'reschedule_days' => '',
+        'send_email'      => true,
+    ]);
 
-	$response->assertOk();
-	$responseData = $response->json();
+    $response->assertOk();
+    $responseData = $response->json();
 
-	expect($responseData['send_email'])->toBeTrue();
-	expect($responseData['default_email'])->toBe('john.doe@example.com');
-	expect($responseData['activity_id'])->toBe($activity->id);
+    expect($responseData['send_email'])->toBeTrue();
+    expect($responseData['default_email'])->toBe('john.doe@example.com');
+    expect($responseData['activity_id'])->toBe($activity->id);
 });
 
 test('activity can be linked to email', function () {
-	$roleId = DB::table('roles')->insertGetId([
-		'name'            => 'Tester 4',
-		'description'     => 'Test role 4',
-		'permission_type' => 'all',
-		'permissions'     => json_encode([]),
-		'created_at'      => now(),
-		'updated_at'      => now(),
-	]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'Tester 4',
+        'description'     => 'Test role 4',
+        'permission_type' => 'all',
+        'permissions'     => json_encode([]),
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
 
-	$userId = DB::table('users')->insertGetId([
-		'name'       => 'Test User 4',
-		'email'      => 'test4@example.com',
-		'password'   => bcrypt('secret'),
-		'status'     => 1,
-		'role_id'    => $roleId,
-		'created_at' => now(),
-		'updated_at' => now(),
-	]);
-	$user = User::find($userId);
-	$this->actingAs($user, 'user');
+    $userId = DB::table('users')->insertGetId([
+        'name'       => 'Test User 4',
+        'email'      => 'test4@example.com',
+        'password'   => bcrypt('secret'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $user = User::find($userId);
+    $this->actingAs($user, 'user');
 
-	// Create an email
-	$email = Email::create([
-		'subject'   => 'Test Email',
-		'reply'     => 'Test email content',
-		'from'      => ['test@example.com'],
-		'reply_to'  => ['recipient@example.com'],
-		'user_type' => 'user',
-		'is_read'   => 0,
-		'source'    => 'test',
-		'message_id'=> (string) Str::uuid(),
-	]);
+    // Create an email
+    $email = Email::create([
+        'subject'   => 'Test Email',
+        'reply'     => 'Test email content',
+        'from'      => ['test@example.com'],
+        'reply_to'  => ['recipient@example.com'],
+        'user_type' => 'user',
+        'is_read'   => 0,
+        'source'    => 'test',
+        'message_id'=> (string) Str::uuid(),
+    ]);
 
-	// Create an activity
-	$activity = Activity::create([
-		'title'         => 'Test Activity',
-		'type'          => 'call',
-		'schedule_from' => now(),
-		'schedule_to'   => now()->addDay(),
-		'user_id'       => $user->id,
-	]);
+    // Create an activity
+    $activity = Activity::create([
+        'title'         => 'Test Activity',
+        'type'          => 'call',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'user_id'       => $user->id,
+    ]);
 
-	// Link email to activity (email belongs to one activity)
-	$email->activity_id = $activity->id;
-	$email->save();
+    // Link email to activity (email belongs to one activity)
+    $email->activity_id = $activity->id;
+    $email->save();
 
-	// Test the relationship
-	$this->assertTrue($email->activity->is($activity));
-	$this->assertTrue($activity->emails->contains($email));
+    // Test the relationship
+    $this->assertTrue($email->activity->is($activity));
+    $this->assertTrue($activity->emails->contains($email));
 });
 
 test('activity email relationship works correctly', function () {
-	$roleId = DB::table('roles')->insertGetId([
-		'name'            => 'Tester 5',
-		'description'     => 'Test role 5',
-		'permission_type' => 'all',
-		'permissions'     => json_encode([]),
-		'created_at'      => now(),
-		'updated_at'      => now(),
-	]);
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'Tester 5',
+        'description'     => 'Test role 5',
+        'permission_type' => 'all',
+        'permissions'     => json_encode([]),
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
 
-	$userId = DB::table('users')->insertGetId([
-		'name'       => 'Test User 5',
-		'email'      => 'test5@example.com',
-		'password'   => bcrypt('secret'),
-		'status'     => 1,
-		'role_id'    => $roleId,
-		'created_at' => now(),
-		'updated_at' => now(),
-	]);
-	$user = User::find($userId);
-	$this->actingAs($user, 'user');
+    $userId = DB::table('users')->insertGetId([
+        'name'       => 'Test User 5',
+        'email'      => 'test5@example.com',
+        'password'   => bcrypt('secret'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $user = User::find($userId);
+    $this->actingAs($user, 'user');
 
-	// Create an activity
-	$activity = Activity::create([
-		'title'         => 'Activity Container',
-		'type'          => 'call',
-		'schedule_from' => now(),
-		'schedule_to'   => now()->addDay(),
-		'user_id'       => $user->id,
-	]);
+    // Create an activity
+    $activity = Activity::create([
+        'title'         => 'Activity Container',
+        'type'          => 'call',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'user_id'       => $user->id,
+    ]);
 
-	// Create multiple emails linked to the same activity
-	$email1 = Email::create([
-		'subject'    => 'E1',
-		'reply'      => 'Body 1',
-		'from'       => ['sender1@example.com'],
-		'reply_to'   => ['recipient1@example.com'],
-		'user_type'  => 'user',
-		'is_read'    => 0,
-		'source'     => 'test',
-		'message_id' => (string) Str::uuid(),
-		'activity_id'=> $activity->id,
-	]);
+    // Create multiple emails linked to the same activity
+    $email1 = Email::create([
+        'subject'    => 'E1',
+        'reply'      => 'Body 1',
+        'from'       => ['sender1@example.com'],
+        'reply_to'   => ['recipient1@example.com'],
+        'user_type'  => 'user',
+        'is_read'    => 0,
+        'source'     => 'test',
+        'message_id' => (string) Str::uuid(),
+        'activity_id'=> $activity->id,
+    ]);
 
-	$email2 = Email::create([
-		'subject'    => 'E2',
-		'reply'      => 'Body 2',
-		'from'       => ['sender2@example.com'],
-		'reply_to'   => ['recipient2@example.com'],
-		'user_type'  => 'user',
-		'is_read'    => 0,
-		'source'     => 'test',
-		'message_id' => (string) Str::uuid(),
-		'activity_id'=> $activity->id,
-	]);
+    $email2 = Email::create([
+        'subject'    => 'E2',
+        'reply'      => 'Body 2',
+        'from'       => ['sender2@example.com'],
+        'reply_to'   => ['recipient2@example.com'],
+        'user_type'  => 'user',
+        'is_read'    => 0,
+        'source'     => 'test',
+        'message_id' => (string) Str::uuid(),
+        'activity_id'=> $activity->id,
+    ]);
 
-	// Reload relations
-	$activity->load('emails');
+    // Reload relations
+    $activity->load('emails');
 
-	// Test relationships
-	$this->assertCount(2, $activity->emails);
-	$this->assertTrue($activity->emails->contains($email1));
-	$this->assertTrue($activity->emails->contains($email2));
-	$this->assertTrue($email1->activity->is($activity));
-	$this->assertTrue($email2->activity->is($activity));
+    // Test relationships
+    $this->assertCount(2, $activity->emails);
+    $this->assertTrue($activity->emails->contains($email1));
+    $this->assertTrue($activity->emails->contains($email2));
+    $this->assertTrue($email1->activity->is($activity));
+    $this->assertTrue($email2->activity->is($activity));
 });

--- a/tests/Feature/ImportLeadsFromSugarCRMTest.php
+++ b/tests/Feature/ImportLeadsFromSugarCRMTest.php
@@ -510,7 +510,7 @@ test('imports lead created_at parsed correctly from sugarcrm', function () {
 
     $exit = Artisan::call('import:leads', [
         '--connection' => 'sugarcrm',
-         '--limit'      => 1,
+        '--limit'      => 1,
     ]);
     expect($exit)->toBe(0);
 


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This pull request updates the labels for email and phone contact information to "Eigen", "Relatie", and "Anders".

Key changes include:
-   **New `ContactLabel` Enum**: A new enum (`App\Enums\ContactLabel`) has been introduced to centralize and standardize these labels, including a helper method (`fromOld`) to map legacy labels (e.g., 'work', 'home', 'mobile', 'other') to the new enum values.
-   **UI Updates**: Email and phone input components in the UI (e.g., Lead/Person creation forms) now display the new labels and default to 'Eigen'.
-   **Import Logic**: Lead and Person import commands have been updated to utilize the `ContactLabel` enum, ensuring that imported contact labels are correctly mapped to the new standardized values.

This change provides a more consistent and localized labeling system for contact details.

## How To Test This?
1.  Navigate to the Lead or Person creation/edit forms.
2.  Add new email or phone entries.
3.  Verify that the label dropdowns for emails and phones now display "Eigen", "Relatie", and "Anders".
4.  Confirm that "Eigen" is the default selected label for new entries.
5.  (Optional, if an import setup is available) Perform an import of leads or persons from SugarCRM and verify that the imported email/phone labels are correctly mapped to the new enum values (e.g., 'work' should now be 'eigen').

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-dd4ada8c-b675-4642-b88f-aef2740a0da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd4ada8c-b675-4642-b88f-aef2740a0da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

