### PR TITLE
Import and validate lead data

### DIFF
--- a/app/Console/Commands/AbstractSugarCRMImport.php
+++ b/app/Console/Commands/AbstractSugarCRMImport.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Throwable;
+use Webkul\Core\Contracts\Validations\PhoneValidator;
 
 abstract class AbstractSugarCRMImport extends Command
 {
@@ -229,6 +230,34 @@ abstract class AbstractSugarCRMImport extends Command
         // 3) Collapse extra whitespace and trim common trailing punctuation leftover
         $value = preg_replace('/\s{2,}/u', ' ', $value ?? '');
         $value = trim($value, " \t\n\r\0\x0B-;:,.");
+
+        // 4) Normalize Dutch mobile 06 numbers to +316XXXXXXXX
+        $digitsOnly = preg_replace('/\D+/', '', $value);
+        if ($digitsOnly !== null && $digitsOnly !== '') {
+            // If it looks like a Dutch mobile starting with 06 and followed by 8 digits
+            if (preg_match('/^06(\d{8})$/', $digitsOnly, $m)) {
+                $value = '+316'.$m[1];
+                $detectedLabel = 'mobile';
+            } elseif (preg_match('/^06/', $digitsOnly)) {
+                // 06 present but not in valid 06XXXXXXXX format -> invalid
+                throw new Exception('Ongeldig 06-nummer: verwacht exact 8 cijfers na 06');
+            }
+        }
+
+        // 5) Validate using existing PhoneValidator rule only if E.164-like (+...) or normalized 06
+        if (str_starts_with($value, '+')) {
+            $validator = new PhoneValidator();
+            $failed = false;
+            $failMessage = '';
+            $validator->validate('phone', $value, function ($message) use (&$failed, &$failMessage) {
+                $failed = true;
+                $failMessage = (string) $message;
+            });
+
+            if ($failed) {
+                throw new Exception($failMessage ?: 'Ongeldig telefoonnummer');
+            }
+        }
 
         return [$detectedLabel, $value];
     }

--- a/app/Console/Commands/ImportLeadsFromSugarCRM.php
+++ b/app/Console/Commands/ImportLeadsFromSugarCRM.php
@@ -19,6 +19,7 @@ use Webkul\Contact\Models\Person;
 use Webkul\Lead\Models\Lead;
 use Webkul\Lead\Models\Stage;
 use Webkul\User\Models\User;
+use Webkul\Core\Contracts\Validations\EmailValidator;
 
 /**
  * Import leads from SugarCRM database with anamnesis data, call activities, email activities, meeting activities and email attachments
@@ -822,6 +823,15 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         $any = $record->email_any ?? null;
 
         if ($primary) {
+            // Validate primary email
+            $emailValidator = new EmailValidator();
+            $failed = false;
+            $emailValidator->validate('email', $primary, function ($message) use (&$failed) {
+                $failed = true;
+            });
+            if ($failed) {
+                throw new Exception('Ongeldig e-mailadres (primary) tijdens import');
+            }
             $emails[] = [
                 'label'      => 'work',
                 'value'      => $primary,
@@ -830,6 +840,15 @@ class ImportLeadsFromSugarCRM extends AbstractSugarCRMImport
         }
 
         if ($any && $any !== $primary) {
+            // Validate secondary email
+            $emailValidator = new EmailValidator();
+            $failed = false;
+            $emailValidator->validate('email', $any, function ($message) use (&$failed) {
+                $failed = true;
+            });
+            if ($failed) {
+                throw new Exception('Ongeldig e-mailadres (secundair) tijdens import');
+            }
             $emails[] = [
                 'label'      => 'work',
                 'value'      => $any,

--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Webkul\Attribute\Repositories\AttributeValueRepository;
 use Webkul\Contact\Models\Person;
+use Webkul\Core\Contracts\Validations\EmailValidator;
 
 class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
 {
@@ -243,8 +244,24 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
 
                 $emails = [];
                 if (! empty($record->email_primary)) {
+                    $emailValidator = new EmailValidator();
+                    $failed = false;
+                    $emailValidator->validate('email', $record->email_primary, function ($message) use (&$failed) {
+                        $failed = true;
+                    });
+                    if ($failed) {
+                        throw new Exception('Ongeldig e-mailadres (primary) tijdens import');
+                    }
                     $emails[] = ['label' => 'work', 'value' => $record->email_primary, 'is_default' => true];
                 } elseif (! empty($record->email_any)) {
+                    $emailValidator = new EmailValidator();
+                    $failed = false;
+                    $emailValidator->validate('email', $record->email_any, function ($message) use (&$failed) {
+                        $failed = true;
+                    });
+                    if ($failed) {
+                        throw new Exception('Ongeldig e-mailadres (secundair) tijdens import');
+                    }
                     $emails[] = ['label' => 'work', 'value' => $record->email_any, 'is_default' => true];
                 }
 


### PR DESCRIPTION
## Issue Reference

## Description
This PR enhances the import process for Leads and Persons by integrating existing phone and email validators.

**Phone Validation:**
- Dutch 06 numbers are now normalized to `+316XXXXXXXX`.
- An exception is thrown if an `06` number is detected but does not conform to the `06XXXXXXXX` format.
- The `PhoneValidator` is applied to numbers starting with `+` (E.164 format or normalized 06 numbers), throwing an exception on validation failure.
- Existing non-E.164 landline formats are preserved.

**Email Validation:**
- The `EmailValidator` has been integrated into `ImportLeadsFromSugarCRM::formatEmails` and `ImportPersonsFromSugarCRM` to validate primary and secondary email addresses.
- An exception is thrown if an invalid email address is encountered during import.

## How To Test This?
1.  Prepare SugarCRM import data with:
    *   A lead/person record containing a phone number like `0612345678`.
    *   A lead/person record containing an invalid 06 number, e.g., `06123`.
    *   A lead/person record containing a valid E.164 phone number, e.g., `+31612345678`.
    *   A lead/person record containing an invalid E.164 phone number, e.g., `+316123`.
    *   A lead/person record containing a valid email address, e.g., `test@example.com`.
    *   A lead/person record containing an invalid email address, e.g., `invalid-email`.
2.  Run the `php artisan import:leads-from-sugarcrm` and `php artisan import:persons-from-sugarcrm` commands.
3.  Verify that:
    *   `0612345678` is imported as `+31612345678`.
    *   Imports with invalid 06 numbers or invalid E.164 numbers throw an exception.
    *   Imports with invalid email addresses throw an exception.
    *   Valid phone and email addresses are imported successfully.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering

---
<a href="https://cursor.com/background-agent?bcId=bc-4c1fbc9f-f439-4a02-bb91-5bf134ad188a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c1fbc9f-f439-4a02-bb91-5bf134ad188a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

