### PR TITLE
Automate log-viewer asset publishing in docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,12 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
+        "post-install-cmd": [
+            "@php artisan vendor:publish --tag=log-viewer-assets --force || true"
+        ],
+        "post-update-cmd": [
+            "@php artisan vendor:publish --tag=log-viewer-assets --force || true"
+        ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],


### PR DESCRIPTION
## Issue Reference
Log-viewer assets are not available in the development environment, leading to an error message.

## Description
This PR automates the publishing of `log-viewer` assets during `composer install` and `composer update`. This resolves the issue where assets were missing in the development environment due to Docker bind mounts overwriting files published during the image build process.

The previous attempt to publish assets in the Dockerfile was ineffective because the local `docker-compose.yml` uses a different build context and a volume mount (`.:/var/www/html`) that overwrites any assets placed during the image build.

## How To Test This?
1. Ensure your development environment is running.
2. Execute `composer install` (or `./vendor/bin/sail composer install -o`) inside your application container.
3. Access the log-viewer interface. The asset error should no longer appear, and the log-viewer should function correctly.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-a10a1936-cdd2-43e3-a179-5920acdd40a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a10a1936-cdd2-43e3-a179-5920acdd40a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

