### PR TITLE
Fix lead person removal bug

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/common/multi-contactmatcher.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/common/multi-contactmatcher.blade.php
@@ -230,6 +230,13 @@
                 :name="'person_ids[' + index + ']'" 
                 :value="person.id" 
             />
+            <!-- Ensure key exists when list is empty so backend can detach all -->
+            <input
+                v-if="selectedPersons.length === 0"
+                type="hidden"
+                name="person_ids[]"
+                value=""
+            />
         </div>
     </script>
 


### PR DESCRIPTION
## Issue Reference
Fixes bug where removing the last person from a lead did not detach them upon saving.

## Description
Previously, when all persons were removed from a lead using the multi-contact matcher, the form would not submit any `person_ids` field. This led the backend to incorrectly assume no changes were made to the persons, thus failing to detach the last remaining person.

This change adds a hidden input field that explicitly sends an empty `person_ids[]` array when `selectedPersons` is empty. This ensures the backend's `LeadRepository::update` method receives the `person_ids` key with an empty array, triggering the `syncPersons([])` call to correctly detach all associated persons.

## How To Test This?
1. Go to a lead's edit page that has at least one person associated.
2. Remove all persons using the multi-contact matcher.
3. Save the lead.
4. Verify that the lead no longer has any persons associated with it.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-b7e98905-fd12-4f8e-a9ae-fdf04d7bd694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7e98905-fd12-4f8e-a9ae-fdf04d7bd694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

