### PR TITLE
Fix lead status transition validation bug

### DIFF
--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERROR<?php
+<?php
 
 namespace App\Services;
 
@@ -52,7 +52,7 @@ class LeadStatusTransitionValidator
             [
                 'min_persons'     => 1,
                 'required_fields' => ['first_name', 'last_name'],
-                'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+                'message'         => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
             ]
         );
 

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -15,11 +15,30 @@ class LeadStatusTransitionValidator
      * Key format: "from_stage_code->to_stage_code"
      */
     private static array $transitionRules = [
-        // Validatie: van nieuwe-aanvraag-kwalificeren naar klant-adviseren-start
-        // Minimaal 1 persoon moet gekoppeld zijn aan de lead
+        // Privatescan: van nieuwe-aanvraag-kwalificeren naar klant-adviseren-start
+        // - Minimaal 1 persoon vereist
+        // - Voor- en achternaam verplicht
         'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
-            'min_persons' => 1,
-            'message'     => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'min_persons'     => 1,
+            'required_fields' => ['first_name', 'last_name'],
+            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ],
+
+        // Hernia: van nieuwe-aanvraag-kwalificeren-hernia naar de eerste klant-adviseren stappen
+        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-start-hernia' => [
+            'min_persons'     => 1,
+            'required_fields' => ['first_name', 'last_name'],
+            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ],
+        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-will-mri-hernia' => [
+            'min_persons'     => 1,
+            'required_fields' => ['first_name', 'last_name'],
+            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        ],
+        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-wachten-op-mri-hernia' => [
+            'min_persons'     => 1,
+            'required_fields' => ['first_name', 'last_name'],
+            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ],
     ];
 

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -22,44 +22,6 @@ class LeadStatusTransitionValidator
     private static bool $defaultsInitialized = false;
 
     /**
-     * Ensure default rules are present (lazy initialization).
-     */
-    private static function ensureDefaultRules(): void
-    {
-        if (self::$defaultsInitialized) {
-            return;
-        }
-
-        // Privatescan: nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
-        self::addTransitionRule(
-            'nieuwe-aanvraag-kwalificeren',
-            'klant-adviseren-start',
-            [
-                'min_persons'     => 1,
-                'required_fields' => ['first_name', 'last_name'],
-                'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-            ]
-        );
-
-        // Hernia: nieuwe-aanvraag-kwalificeren-hernia -> meerdere klant-adviseren-* doelen
-        self::addTransitionsRule(
-            'nieuwe-aanvraag-kwalificeren-hernia',
-            [
-                'klant-adviseren-start-hernia',
-                'klant-adviseren-will-mri-hernia',
-                'klant-adviseren-wachten-op-mri-hernia',
-            ],
-            [
-                'min_persons'     => 1,
-                'required_fields' => ['first_name', 'last_name'],
-                'message'         => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-            ]
-        );
-
-        self::$defaultsInitialized = true;
-    }
-
-    /**
      * Valideer een status transitie voor een lead.
      *
      * @throws ValidationException
@@ -154,6 +116,7 @@ class LeadStatusTransitionValidator
     public static function getAllTransitionRules(): array
     {
         self::ensureDefaultRules();
+
         return self::$transitionRules;
     }
 
@@ -166,6 +129,45 @@ class LeadStatusTransitionValidator
         $transitionKey = $fromStageCode.'->'.$toStageCode;
 
         return isset(self::$transitionRules[$transitionKey]);
+    }
+
+    /**
+     * Ensure default rules are present (lazy initialization).
+     */
+    private static function ensureDefaultRules(): void
+    {
+        if (self::$defaultsInitialized) {
+            return;
+        }
+
+        // Privatescan: nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
+        self::addTransitionRule(
+            'nieuwe-aanvraag-kwalificeren',
+            'klant-adviseren-start',
+            [
+                'min_persons'     => 1,
+                'required_fields' => ['first_name', 'last_name'],
+                'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+        );
+
+        // Hernia: nieuwe-aanvraag-kwalificeren-hernia -> meerdere klant-adviseren-* doelen
+        self::addTransitionsRule(
+            'nieuwe-aanvraag-kwalificeren-hernia',
+            [
+                'klant-adviseren-start-hernia',
+                'klant-adviseren-will-mri-hernia',
+                'klant-adviseren-wachten-op-mri-hernia',
+            ],
+            [
+                'min_persons'     => 1,
+                'required_fields' => ['first_name', 'last_name'],
+                'message'         => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+
+        );
+
+        self::$defaultsInitialized = true;
     }
 
     /**

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Exception;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Webkul\Lead\Models\Lead;
@@ -20,12 +21,6 @@ class LeadStatusTransitionValidator
             'min_persons' => 1,
             'message'     => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ],
-
-        // Andere voorbeelden kunnen hier worden toegevoegd:
-        // 'klant-adviseren-start->klant-adviseren-opvolgen' => [
-        //     'required_fields' => ['first_name', 'last_name', 'emails'],
-        //     'message' => 'Voor deze status zijn naam en email verplicht.',
-        // ],
     ];
 
     /**
@@ -141,7 +136,7 @@ class LeadStatusTransitionValidator
             $result = $validationFunction($lead);
 
             return is_array($result) ? $result : [];
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return ['Validatie fout: '.$e->getMessage()];
         }
     }

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -1,4 +1,4 @@
-<?php
+THIS SHOULD BE A LINTER ERROR<?php
 
 namespace App\Services;
 
@@ -14,33 +14,50 @@ class LeadStatusTransitionValidator
      * Validatie regels per status transitie.
      * Key format: "from_stage_code->to_stage_code"
      */
-    private static array $transitionRules = [
-        // Privatescan: van nieuwe-aanvraag-kwalificeren naar klant-adviseren-start
-        // - Minimaal 1 persoon vereist
-        // - Voor- en achternaam verplicht
-        'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
-            'min_persons'     => 1,
-            'required_fields' => ['first_name', 'last_name'],
-            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-        ],
+    private static array $transitionRules = [];
 
-        // Hernia: van nieuwe-aanvraag-kwalificeren-hernia naar de eerste klant-adviseren stappen
-        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-start-hernia' => [
-            'min_persons'     => 1,
-            'required_fields' => ['first_name', 'last_name'],
-            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-        ],
-        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-will-mri-hernia' => [
-            'min_persons'     => 1,
-            'required_fields' => ['first_name', 'last_name'],
-            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-        ],
-        'nieuwe-aanvraag-kwalificeren-hernia->klant-adviseren-wachten-op-mri-hernia' => [
-            'min_persons'     => 1,
-            'required_fields' => ['first_name', 'last_name'],
-            'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-        ],
-    ];
+    /**
+     * Indicates whether default transition rules have been registered.
+     */
+    private static bool $defaultsInitialized = false;
+
+    /**
+     * Ensure default rules are present (lazy initialization).
+     */
+    private static function ensureDefaultRules(): void
+    {
+        if (self::$defaultsInitialized) {
+            return;
+        }
+
+        // Privatescan: nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
+        self::addTransitionRule(
+            'nieuwe-aanvraag-kwalificeren',
+            'klant-adviseren-start',
+            [
+                'min_persons'     => 1,
+                'required_fields' => ['first_name', 'last_name'],
+                'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+        );
+
+        // Hernia: nieuwe-aanvraag-kwalificeren-hernia -> meerdere klant-adviseren-* doelen
+        self::addTransitionsRule(
+            'nieuwe-aanvraag-kwalificeren-hernia',
+            [
+                'klant-adviseren-start-hernia',
+                'klant-adviseren-will-mri-hernia',
+                'klant-adviseren-wachten-op-mri-hernia',
+            ],
+            [
+                'min_persons'     => 1,
+                'required_fields' => ['first_name', 'last_name'],
+                'message'         => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            ]
+        );
+
+        self::$defaultsInitialized = true;
+    }
 
     /**
      * Valideer een status transitie voor een lead.
@@ -49,6 +66,9 @@ class LeadStatusTransitionValidator
      */
     public static function validateTransition(Lead $lead, int $newStageId): void
     {
+        // Lazily register default rules
+        self::ensureDefaultRules();
+
         // Avoid relying on a potentially stale Eloquent relation; read current stage by ID
         $currentStage = $lead->lead_pipeline_stage_id
             ? Stage::find($lead->lead_pipeline_stage_id)
@@ -133,6 +153,7 @@ class LeadStatusTransitionValidator
      */
     public static function getAllTransitionRules(): array
     {
+        self::ensureDefaultRules();
         return self::$transitionRules;
     }
 
@@ -141,6 +162,7 @@ class LeadStatusTransitionValidator
      */
     public static function hasTransitionRule(string $fromStageCode, string $toStageCode): bool
     {
+        self::ensureDefaultRules();
         $transitionKey = $fromStageCode.'->'.$toStageCode;
 
         return isset(self::$transitionRules[$transitionKey]);

--- a/app/Services/LeadStatusTransitionValidator.php
+++ b/app/Services/LeadStatusTransitionValidator.php
@@ -14,14 +14,15 @@ class LeadStatusTransitionValidator
      * Key format: "from_stage_code->to_stage_code"
      */
     private static array $transitionRules = [
-        // Voorbeeld: van klant-adviseren-start naar klant-adviseren-opvolgen
-        'klant-adviseren-start->klant-adviseren-opvolgen' => [
+        // Validatie: van nieuwe-aanvraag-kwalificeren naar klant-adviseren-start
+        // Minimaal 1 persoon moet gekoppeld zijn aan de lead
+        'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
             'min_persons' => 1,
-            'message'     => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'message'     => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ],
 
         // Andere voorbeelden kunnen hier worden toegevoegd:
-        // 'nieuwe-aanvraag-kwalificeren->klant-adviseren-start' => [
+        // 'klant-adviseren-start->klant-adviseren-opvolgen' => [
         //     'required_fields' => ['first_name', 'last_name', 'emails'],
         //     'message' => 'Voor deze status zijn naam en email verplicht.',
         // ],

--- a/docs/modules/technology_stack/pages/lead_status_transition_validation.adoc
+++ b/docs/modules/technology_stack/pages/lead_status_transition_validation.adoc
@@ -25,29 +25,38 @@ Het `Lead` model is uitgebreid met validatie:
 - `update()` methode controleert automatisch status transities
 - `updateStage()` methode voor directe stage updates met validatie
 
-##### 3. PipelineSeeder Configuration
+##### 3. Centrale configuratie (geen seeding nodig)
 
-Validatieregels worden geconfigureerd in de `PipelineSeeder` via de `configureStatusTransitionValidations()` methode.
+Validatieregels zijn gecentraliseerd in `LeadStatusTransitionValidator` en worden lazy geïnitialiseerd. Er is geen seeding meer nodig voor de basisregels.
 
 #### Configuratie
 
 ##### Basis Configuratie
 
-Validatieregels worden gedefinieerd in de `PipelineSeeder`:
+De default regels worden in de service zelf geregistreerd (lazy). Wil je runtime extra regels toevoegen of wijzigen, gebruik dan onderstaande API in je applicatiestart of specifieke flows:
 
 ```php
-private function configureStatusTransitionValidations(): void
-{
-    // Voorbeeld: Minimaal 1 persoon vereist
-    LeadStatusTransitionValidator::addTransitionRule(
-        'klant-adviseren-start',
-        'klant-adviseren-opvolgen',
-        [
-            'min_persons' => 1,
-            'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-        ]
-    );
-}
+// Voorbeeld: Minimaal 1 persoon vereist op eerste transitie (privatescan)
+LeadStatusTransitionValidator::addTransitionRule(
+    'nieuwe-aanvraag-kwalificeren',
+    'klant-adviseren-start',
+    [
+        'min_persons' => 1,
+        'required_fields' => ['first_name', 'last_name'],
+        'message' => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+    ]
+);
+
+// Voorbeeld: Zelfde logica voor meerdere hernia-doelstages in één keer
+LeadStatusTransitionValidator::addTransitionsRule(
+    'nieuwe-aanvraag-kwalificeren-hernia',
+    ['klant-adviseren-start-hernia', 'klant-adviseren-will-mri-hernia', 'klant-adviseren-wachten-op-mri-hernia'],
+    [
+        'min_persons' => 1,
+        'required_fields' => ['first_name', 'last_name'],
+        'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+    ]
+);
 ```
 
 ##### Ondersteunde Validatie Types
@@ -130,20 +139,20 @@ $hasRule = LeadStatusTransitionValidator::hasTransitionRule(
 
 #### Voorbeelden
 
-##### Voorbeeld 1: Minimaal 1 Persoon
+##### Voorbeeld 1: Minimaal 1 Persoon (privatescan)
 
 ```php
 LeadStatusTransitionValidator::addTransitionRule(
+    'nieuwe-aanvraag-kwalificeren',
     'klant-adviseren-start',
-    'klant-adviseren-opvolgen',
     [
         'min_persons' => 1,
-        'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+        'message' => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
     ]
 );
 ```
 
-##### Voorbeeld 2: Verplichte Velden
+##### Voorbeeld 2: Verplichte Velden (privatescan)
 
 ```php
 LeadStatusTransitionValidator::addTransitionRule(
@@ -152,6 +161,19 @@ LeadStatusTransitionValidator::addTransitionRule(
     [
         'required_fields' => ['first_name', 'last_name', 'emails'],
         'message' => 'Voor de status "Klant adviseren" zijn naam en email verplicht.',
+    ]
+);
+```
+
+##### Voorbeeld 3: Meerdere doelstages (hernia)
+```php
+LeadStatusTransitionValidator::addTransitionsRule(
+    'nieuwe-aanvraag-kwalificeren-hernia',
+    ['klant-adviseren-start-hernia', 'klant-adviseren-will-mri-hernia', 'klant-adviseren-wachten-op-mri-hernia'],
+    [
+        'min_persons' => 1,
+        'required_fields' => ['first_name', 'last_name'],
+        'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
     ]
 );
 ```

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -239,30 +239,4 @@
     </script>
 @endPushOnce
 
-@php
-    $emails = $value ?? [];
-
-    // Ensure $emails is an array
-    if (!is_array($emails)) {
-        $emails = [];
-    }
-
-    // Filter out empty email addresses
-    $emails = array_filter($emails, function($email) {
-        return isset($email['value']) && !empty(trim($email['value']));
-    });
-
-    // If no valid emails, create a default empty email
-    if (empty($emails)) {
-        $emails = [['value' => '', 'label' => \App\Enums\ContactLabel::default()->value, 'is_default' => true]];
-    }
-
-    // Normaliseer is_default naar boolean
-    foreach ($emails as &$email) {
-        if (isset($email['is_default'])) {
-            $email['is_default'] = $email['is_default'] === true || $email['is_default'] === 'on' || $email['is_default'] === '1';
-        }
-    }
-    unset($email);
-@endphp
-
+ 

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -130,6 +130,13 @@
                         this.$emit('input', newEmails);
                     },
                     deep: true
+                },
+                // Re-process when parent updates value asynchronously
+                value: {
+                    handler(newVal) {
+                        this.emails = this.processEmails(newVal);
+                    },
+                    deep: true
                 }
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -122,7 +122,6 @@
 
             mounted() {
                 this.ensureDefaultEmail();
-                this.normalizeMissingLabels();
             },
 
             watch: {
@@ -211,12 +210,7 @@
                     }
                 },
 
-                normalizeMissingLabels() {
-                    this.emails = (this.emails || []).map(e => ({
-                        ...e,
-                        label: (e.label && String(e.label).trim() !== '') ? e.label : this.defaultLabel,
-                    }));
-                },
+                
 
                 getInputClass(index) {
                     const baseClass = 'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 dark:bg-gray-700 dark:text-white';

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -152,6 +152,8 @@
                         .filter(email => email && email.value && email.value.trim() !== '')
                         .map(email => ({
                             ...email,
+                            // default missing/empty label to CONTACT_LABEL_DEFAULT for proper select display
+                            label: (email.label && String(email.label).trim() !== '') ? email.label : this.defaultLabel,
                             is_default: email.is_default === true || email.is_default === 'on' || email.is_default === '1'
                         }));
 

--- a/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/emails.blade.php
@@ -122,6 +122,7 @@
 
             mounted() {
                 this.ensureDefaultEmail();
+                this.normalizeMissingLabels();
             },
 
             watch: {
@@ -208,6 +209,13 @@
                     if (!hasDefault && this.emails.length > 0) {
                         this.emails[0].is_default = true;
                     }
+                },
+
+                normalizeMissingLabels() {
+                    this.emails = (this.emails || []).map(e => ({
+                        ...e,
+                        label: (e.label && String(e.label).trim() !== '') ? e.label : this.defaultLabel,
+                    }));
                 },
 
                 getInputClass(index) {

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -156,6 +156,8 @@
                         .filter(phone => phone && phone.value && phone.value.trim() !== '')
                         .map(phone => ({
                             ...phone,
+                            // default missing/empty label to CONTACT_LABEL_DEFAULT for proper select display
+                            label: (phone.label && String(phone.label).trim() !== '') ? phone.label : this.defaultLabel,
                             is_default: phone.is_default === true || phone.is_default === 'on' || phone.is_default === '1'
                         }));
 

--- a/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/phones.blade.php
@@ -134,6 +134,13 @@
                         this.$emit('input', newPhones);
                     },
                     deep: true
+                },
+                // Re-process when parent updates value asynchronously
+                value: {
+                    handler(newVal) {
+                        this.phones = this.processPhones(newVal);
+                    },
+                    deep: true
                 }
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -1,4 +1,4 @@
-@php use App\Models\Department;use App\Models\User; @endphp
+@php use App\Enums\ContactLabel;use App\Models\Department;use App\Models\User; @endphp
 <x-admin::layouts>
     <x-slot:title>
         @lang('admin::app.leads.create.title')
@@ -290,7 +290,7 @@
                                             $__emailsVal = array_map(function($e) {
                                                 if (!is_array($e)) { $e = []; }
                                                 if (!isset($e['label']) || trim((string)$e['label']) === '') {
-                                                    $e['label'] = \App\Enums\ContactLabel::default()->value;
+                                                    $e['label'] = ContactLabel::default()->value;
                                                 }
                                                 return $e;
                                             }, $__emailsVal);
@@ -306,7 +306,7 @@
                                             $__phonesVal = array_map(function($p) {
                                                 if (!is_array($p)) { $p = []; }
                                                 if (!isset($p['label']) || trim((string)$p['label']) === '') {
-                                                    $p['label'] = \App\Enums\ContactLabel::default()->value;
+                                                    $p['label'] = ContactLabel::default()->value;
                                                 }
                                                 return $p;
                                             }, $__phonesVal);

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -284,12 +284,34 @@
 
                                     <!-- Emails -->
                                     <div class="mt-4">
-                                        @include('admin::leads.common.sections.emails', ['name' => 'emails', 'value' => old('emails', $prefilledLeadPerson['emails'] ?? []), 'widthClass' => 'w-full'])
+                                        @php
+                                            $__emailsVal = old('emails', $prefilledLeadPerson['emails'] ?? []);
+                                            if (!is_array($__emailsVal)) { $__emailsVal = []; }
+                                            $__emailsVal = array_map(function($e) {
+                                                if (!is_array($e)) { $e = []; }
+                                                if (!isset($e['label']) || trim((string)$e['label']) === '') {
+                                                    $e['label'] = \App\Enums\ContactLabel::default()->value;
+                                                }
+                                                return $e;
+                                            }, $__emailsVal);
+                                        @endphp
+                                        @include('admin::leads.common.sections.emails', ['name' => 'emails', 'value' => $__emailsVal, 'widthClass' => 'w-full'])
                                     </div>
 
                                     <!-- Phones -->
                                     <div class="mt-4">
-                                        @include('admin::leads.common.sections.phones', ['name' => 'phones', 'value' => old('phones', $prefilledLeadPerson['phones'] ?? []), 'widthClass' => 'w-full'])
+                                        @php
+                                            $__phonesVal = old('phones', $prefilledLeadPerson['phones'] ?? []);
+                                            if (!is_array($__phonesVal)) { $__phonesVal = []; }
+                                            $__phonesVal = array_map(function($p) {
+                                                if (!is_array($p)) { $p = []; }
+                                                if (!isset($p['label']) || trim((string)$p['label']) === '') {
+                                                    $p['label'] = \App\Enums\ContactLabel::default()->value;
+                                                }
+                                                return $p;
+                                            }, $__phonesVal);
+                                        @endphp
+                                        @include('admin::leads.common.sections.phones', ['name' => 'phones', 'value' => $__phonesVal, 'widthClass' => 'w-full'])
                                     </div>
 
                                     <!-- Address -->

--- a/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
@@ -226,10 +226,5 @@ class PipelineSeeder extends BaseSeeder
         if (PipelineStageDefaultKeys::PIPELINE_FIRST_STAGE_HERNIA_ID->value != $firstStageHerniaLeadPipeline) {
             throw new Exception('Pipeline stage is niet geldig voor hernia: ' . $firstStageHerniaLeadPipeline);
         }
-
-        // Status transition validations are now centralized in LeadStatusTransitionValidator
-        // and no longer configured via seeder.
     }
-
-    // Legacy seeder-based transition configuration removed.
 }

--- a/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Lead/PipelineSeeder.php
@@ -227,72 +227,9 @@ class PipelineSeeder extends BaseSeeder
             throw new Exception('Pipeline stage is niet geldig voor hernia: ' . $firstStageHerniaLeadPipeline);
         }
 
-        // Configure status transition validations
-        $this->configureStatusTransitionValidations();
+        // Status transition validations are now centralized in LeadStatusTransitionValidator
+        // and no longer configured via seeder.
     }
 
-    /**
-     * Configure status transition validations.
-     *
-     * @return void
-     */
-    private function configureStatusTransitionValidations(): void
-    {
-        // Voorbeeld: Validatie voor klant-adviseren-start -> klant-adviseren-opvolgen
-        // Minimaal 1 persoon moet gekoppeld zijn aan de lead
-        LeadStatusTransitionValidator::addTransitionRule(
-            'nieuwe-aanvraag-kwalificeren',
-            'klant-adviseren-start',
-            [
-                'min_persons' => 1,
-                'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-            ]
-        );
-        LeadStatusTransitionValidator::addTransitionsRule(
-            'nieuwe-aanvraag-kwalificeren-hernia',
-            ['klant-adviseren-start-hernia', 'klant-adviseren-will-mri-hernia', 'klant-adviseren-wachten-op-mri-hernia'],
-            [
-                'min_persons' => 1,
-                'message' => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
-            ]
-        );
-
-        // Andere voorbeelden kunnen hier worden toegevoegd:
-
-        // Voorbeeld: Validatie voor nieuwe-aanvraag-kwalificeren -> klant-adviseren-start
-        // Lead moet naam hebben
-        LeadStatusTransitionValidator::addTransitionRule(
-            'nieuwe-aanvraag-kwalificeren',
-            'klant-adviseren-start',
-            [
-                'required_fields' => ['first_name', 'last_name'],
-                'message' => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
-            ]
-        );
-
-        LeadStatusTransitionValidator::addTransitionRule(
-            'nieuwe-aanvraag-kwalificeren-hernia',
-            'klant-adviseren-start-hernia',
-            [
-                'required_fields' => ['first_name', 'last_name'],
-                'message' => 'Voor de status "Klant adviseren" zijn voor- en achternaam verplicht.',
-            ]
-        );
-
-        // Voorbeeld: Custom validatie voor won status
-        // LeadStatusTransitionValidator::addTransitionRule(
-        //     'klant-adviseren-opvolgen',
-        //     'won',
-        //     [
-        //         'custom_validation' => function($lead) {
-        //             $errors = [];
-        //             if (!$lead->quotes()->count()) {
-        //                 $errors[] = 'Er moet minimaal 1 offerte zijn voor deze lead.';
-        //             }
-        //             return $errors;
-        //         },
-        //         'message' => 'Voor het winnen van een lead moet er minimaal 1 offerte zijn.',
-        //     ]
-        // );
-    }
+    // Legacy seeder-based transition configuration removed.
 }

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -20,25 +20,17 @@ beforeEach(function () {
     ]);
 
     // Create test stages
-    test()->initialStage = Stage::create([
-        'code'             => 'nieuwe-aanvraag-kwalificeren',
-        'name'             => 'Nieuwe aanvraag kwalificeren',
-        'probability'      => 100,
-        'sort_order'       => 0,
-        'lead_pipeline_id' => test()->pipeline->id,
-    ]);
-
     test()->startStage = Stage::create([
-        'code'             => 'klant-adviseren-start',
-        'name'             => 'Klant adviseren',
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag',
         'probability'      => 100,
         'sort_order'       => 1,
         'lead_pipeline_id' => test()->pipeline->id,
     ]);
 
     test()->followUpStage = Stage::create([
-        'code'             => 'klant-adviseren-opvolgen',
-        'name'             => 'Klant adviseren opvolgen',
+        'code'             => 'klant-adviseren-start',
+        'name'             => 'Klant adviseren start',
         'probability'      => 100,
         'sort_order'       => 2,
         'lead_pipeline_id' => test()->pipeline->id,
@@ -49,21 +41,21 @@ beforeEach(function () {
         'first_name'             => 'John',
         'last_name'              => 'Doe',
         'lead_pipeline_id'       => test()->pipeline->id,
-        'lead_pipeline_stage_id' => test()->initialStage->id,
+        'lead_pipeline_stage_id' => test()->startStage->id,
         'user_id'                => test()->user->id,
     ]);
 
-    // Configure the validation rule for the first transition (min persons)
+    // Configure the validation rules
     LeadStatusTransitionValidator::addTransitionRule(
-        'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
+        'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
-            'message'     => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'message'     => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ]
     );
 
-    // Additional example rule for required fields on the same transition
+    // Configure validation rule for first stage transition
     LeadStatusTransitionValidator::addTransitionRule(
         'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
@@ -75,10 +67,12 @@ beforeEach(function () {
 });
 
 test('it blocks transition when no persons are attached', function () {
-    // Lead has no persons attached and is in initial stage
+    // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
+        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
         ->toThrow(ValidationException::class);
+
+    // Attempt to transition should fail
 });
 
 test('it allows transition when persons are attached', function () {
@@ -96,7 +90,7 @@ test('it allows transition when persons are attached', function () {
     expect(test()->lead->persons_count)->toBe(1);
 
     // Transition should succeed
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
 });
 
 test('it allows transition when multiple persons are attached', function () {
@@ -119,7 +113,7 @@ test('it allows transition when multiple persons are attached', function () {
     expect(test()->lead->persons_count)->toBe(2);
 
     // Transition should succeed
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
 });
 
 test('it ignores validation for transitions without rules', function () {
@@ -140,7 +134,7 @@ test('it ignores validation for transitions without rules', function () {
 test('it works with lead model update method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->startStage->id]))
+        ->and(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
@@ -149,26 +143,26 @@ test('it works with lead model update method', function () {
 test('it works with lead model update stage method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => test()->lead->updateStage(test()->startStage->id))
+        ->and(fn () => test()->lead->updateStage(test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
 });
 
 test('it can add and remove transition rules', function () {
-    // Remove the existing rule for the first transition
+    // Remove the existing rule
     LeadStatusTransitionValidator::removeTransitionRule(
-        'nieuwe-aanvraag-kwalificeren',
-        'klant-adviseren-start'
+        'klant-adviseren-start',
+        'klant-adviseren-opvolgen'
     );
 
     // Now transition should succeed even without persons
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
 
     // Add the rule back
     LeadStatusTransitionValidator::addTransitionRule(
-        'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
+        'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
             'message'     => 'Test message',
@@ -176,16 +170,28 @@ test('it can add and remove transition rules', function () {
     );
 
     // Now transition should fail again
-    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
+    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
         ->toThrow(ValidationException::class);
 });
 
 test('it validates required fields for first stage transition', function () {
-    // Create a lead without first_name and last_name at initial stage
+    // Create a lead without first_name and last_name
     $incompleteLead = Lead::create([
         'lead_pipeline_id'       => test()->pipeline->id,
-        'lead_pipeline_stage_id' => test()->initialStage->id,
+        'lead_pipeline_stage_id' => test()->startStage->id,
     ]);
+
+    // Create a new stage for the first transition
+    $newStage = Stage::create([
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag kwalificeren',
+        'probability'      => 100,
+        'sort_order'       => 0,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
+
+    // Set the lead to the first stage
+    $incompleteLead->update(['lead_pipeline_stage_id' => $newStage->id]);
 
     // Attempt to transition should fail due to missing required fields
     expect(fn () => LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id))

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -20,6 +20,14 @@ beforeEach(function () {
     ]);
 
     // Create test stages
+    test()->initialStage = Stage::create([
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag kwalificeren',
+        'probability'      => 100,
+        'sort_order'       => 0,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
+
     test()->startStage = Stage::create([
         'code'             => 'klant-adviseren-start',
         'name'             => 'Klant adviseren',
@@ -41,21 +49,21 @@ beforeEach(function () {
         'first_name'             => 'John',
         'last_name'              => 'Doe',
         'lead_pipeline_id'       => test()->pipeline->id,
-        'lead_pipeline_stage_id' => test()->startStage->id,
+        'lead_pipeline_stage_id' => test()->initialStage->id,
         'user_id'                => test()->user->id,
     ]);
 
-    // Configure the validation rules
+    // Configure the validation rule for the first transition (min persons)
     LeadStatusTransitionValidator::addTransitionRule(
+        'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
-        'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
-            'message'     => 'Voor de status "Klant adviseren opvolgen" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
+            'message'     => 'Voor de status "Klant adviseren" moet minimaal 1 persoon aan de lead gekoppeld zijn.',
         ]
     );
 
-    // Configure validation rule for first stage transition
+    // Additional example rule for required fields on the same transition
     LeadStatusTransitionValidator::addTransitionRule(
         'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
@@ -67,12 +75,10 @@ beforeEach(function () {
 });
 
 test('it blocks transition when no persons are attached', function () {
-    // Lead has no persons attached
+    // Lead has no persons attached and is in initial stage
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
         ->toThrow(ValidationException::class);
-
-    // Attempt to transition should fail
 });
 
 test('it allows transition when persons are attached', function () {
@@ -90,7 +96,7 @@ test('it allows transition when persons are attached', function () {
     expect(test()->lead->persons_count)->toBe(1);
 
     // Transition should succeed
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
 });
 
 test('it allows transition when multiple persons are attached', function () {
@@ -113,7 +119,7 @@ test('it allows transition when multiple persons are attached', function () {
     expect(test()->lead->persons_count)->toBe(2);
 
     // Transition should succeed
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
 });
 
 test('it ignores validation for transitions without rules', function () {
@@ -134,7 +140,7 @@ test('it ignores validation for transitions without rules', function () {
 test('it works with lead model update method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->followUpStage->id]))
+        ->and(fn () => test()->lead->update(['lead_pipeline_stage_id' => test()->startStage->id]))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
@@ -143,26 +149,26 @@ test('it works with lead model update method', function () {
 test('it works with lead model update stage method', function () {
     // Lead has no persons attached
     expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => test()->lead->updateStage(test()->followUpStage->id))
+        ->and(fn () => test()->lead->updateStage(test()->startStage->id))
         ->toThrow(ValidationException::class);
 
     // Attempt to update stage should fail
 });
 
 test('it can add and remove transition rules', function () {
-    // Remove the existing rule
+    // Remove the existing rule for the first transition
     LeadStatusTransitionValidator::removeTransitionRule(
-        'klant-adviseren-start',
-        'klant-adviseren-opvolgen'
+        'nieuwe-aanvraag-kwalificeren',
+        'klant-adviseren-start'
     );
 
     // Now transition should succeed even without persons
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id);
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
 
     // Add the rule back
     LeadStatusTransitionValidator::addTransitionRule(
+        'nieuwe-aanvraag-kwalificeren',
         'klant-adviseren-start',
-        'klant-adviseren-opvolgen',
         [
             'min_persons' => 1,
             'message'     => 'Test message',
@@ -170,28 +176,16 @@ test('it can add and remove transition rules', function () {
     );
 
     // Now transition should fail again
-    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->followUpStage->id))
+    expect(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
         ->toThrow(ValidationException::class);
 });
 
 test('it validates required fields for first stage transition', function () {
-    // Create a lead without first_name and last_name
+    // Create a lead without first_name and last_name at initial stage
     $incompleteLead = Lead::create([
         'lead_pipeline_id'       => test()->pipeline->id,
-        'lead_pipeline_stage_id' => test()->startStage->id,
+        'lead_pipeline_stage_id' => test()->initialStage->id,
     ]);
-
-    // Create a new stage for the first transition
-    $newStage = Stage::create([
-        'code'             => 'nieuwe-aanvraag-kwalificeren',
-        'name'             => 'Nieuwe aanvraag kwalificeren',
-        'probability'      => 100,
-        'sort_order'       => 0,
-        'lead_pipeline_id' => test()->pipeline->id,
-    ]);
-
-    // Set the lead to the first stage
-    $incompleteLead->update(['lead_pipeline_stage_id' => $newStage->id]);
 
     // Attempt to transition should fail due to missing required fields
     expect(fn () => LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id))
@@ -205,48 +199,4 @@ test('it validates required fields for first stage transition', function () {
 
     // Transition should now succeed
     LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id);
-});
-
-test('it blocks transition from nieuwe-aanvraag-kwalificeren to klant-adviseren-start when no persons', function () {
-    // Create the initial stage and set lead to it
-    $initialStage = Stage::create([
-        'code'             => 'nieuwe-aanvraag-kwalificeren',
-        'name'             => 'Nieuwe aanvraag kwalificeren',
-        'probability'      => 100,
-        'sort_order'       => 0,
-        'lead_pipeline_id' => test()->pipeline->id,
-    ]);
-
-    // Move lead to initial stage
-    test()->lead->update(['lead_pipeline_stage_id' => $initialStage->id]);
-
-    // Ensure no persons are attached
-    expect(test()->lead->persons_count)->toBe(0)
-        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
-        ->toThrow(ValidationException::class);
-});
-
-test('it allows transition from nieuwe-aanvraag-kwalificeren to klant-adviseren-start when person attached', function () {
-    // Create the initial stage and set lead to it
-    $initialStage = Stage::create([
-        'code'             => 'nieuwe-aanvraag-kwalificeren',
-        'name'             => 'Nieuwe aanvraag kwalificeren',
-        'probability'      => 100,
-        'sort_order'       => 0,
-        'lead_pipeline_id' => test()->pipeline->id,
-    ]);
-
-    // Move lead to initial stage
-    test()->lead->update(['lead_pipeline_stage_id' => $initialStage->id]);
-
-    // Attach a person
-    $person = Person::create([
-        'name'   => 'Alice Example',
-        'emails' => [['value' => 'alice@example.com', 'is_default' => true]],
-    ]);
-    test()->lead->attachPersons([$person->id]);
-    test()->lead->refresh();
-
-    // Should validate successfully now
-    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
 });

--- a/tests/Feature/LeadStatusTransitionValidationTest.php
+++ b/tests/Feature/LeadStatusTransitionValidationTest.php
@@ -206,3 +206,47 @@ test('it validates required fields for first stage transition', function () {
     // Transition should now succeed
     LeadStatusTransitionValidator::validateTransition($incompleteLead, test()->startStage->id);
 });
+
+test('it blocks transition from nieuwe-aanvraag-kwalificeren to klant-adviseren-start when no persons', function () {
+    // Create the initial stage and set lead to it
+    $initialStage = Stage::create([
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag kwalificeren',
+        'probability'      => 100,
+        'sort_order'       => 0,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
+
+    // Move lead to initial stage
+    test()->lead->update(['lead_pipeline_stage_id' => $initialStage->id]);
+
+    // Ensure no persons are attached
+    expect(test()->lead->persons_count)->toBe(0)
+        ->and(fn () => LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id))
+        ->toThrow(ValidationException::class);
+});
+
+test('it allows transition from nieuwe-aanvraag-kwalificeren to klant-adviseren-start when person attached', function () {
+    // Create the initial stage and set lead to it
+    $initialStage = Stage::create([
+        'code'             => 'nieuwe-aanvraag-kwalificeren',
+        'name'             => 'Nieuwe aanvraag kwalificeren',
+        'probability'      => 100,
+        'sort_order'       => 0,
+        'lead_pipeline_id' => test()->pipeline->id,
+    ]);
+
+    // Move lead to initial stage
+    test()->lead->update(['lead_pipeline_stage_id' => $initialStage->id]);
+
+    // Attach a person
+    $person = Person::create([
+        'name'   => 'Alice Example',
+        'emails' => [['value' => 'alice@example.com', 'is_default' => true]],
+    ]);
+    test()->lead->attachPersons([$person->id]);
+    test()->lead->refresh();
+
+    // Should validate successfully now
+    LeadStatusTransitionValidator::validateTransition(test()->lead, test()->startStage->id);
+});


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Corrected the `min_persons` validation rule in `LeadStatusTransitionValidator` to trigger on the transition from `nieuwe-aanvraag-kwalificeren` to `klant-adviseren-start`. Previously, this rule was incorrectly applied to the `klant-adviseren-start` to `klant-adviseren-opvolgen` transition, causing the validation to occur at a later stage than intended.

## How To Test This?
1. Create a new lead without any persons attached.
2. Navigate to the Kanban board.
3. Attempt to drag the lead from the 'nieuwe-aanvraag-kwalificeren' stage to the 'klant-adviseren-start' stage.
4. Verify that a validation message appears, stating that at least 1 person must be linked to the lead.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-40a675da-aebd-4b09-85b0-6afd4169975f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40a675da-aebd-4b09-85b0-6afd4169975f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

