### PR TITLE
Create resource management entity and screen

### DIFF
--- a/app/DataGrids/Settings/ClinicDataGrid.php
+++ b/app/DataGrids/Settings/ClinicDataGrid.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\DataGrids\Settings;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Webkul\DataGrid\DataGrid;
+
+class ClinicDataGrid extends DataGrid
+{
+    public function prepareQueryBuilder(): Builder
+    {
+        $queryBuilder = DB::table('clinics')
+            ->addSelect(
+                'clinics.id',
+                'clinics.name'
+            );
+
+        $this->addFilter('id', 'clinics.id');
+
+        return $queryBuilder;
+    }
+
+    public function prepareColumns(): void
+    {
+        $this->addColumn([
+            'index'      => 'id',
+            'label'      => trans('admin::app.settings.clinics.index.datagrid.id'),
+            'type'       => 'string',
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+
+        $this->addColumn([
+            'index'      => 'name',
+            'type'       => 'string',
+            'label'      => trans('admin::app.settings.clinics.index.datagrid.name'),
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+    }
+
+    public function prepareActions(): void
+    {
+        if (bouncer()->hasPermission('settings.clinics.edit')) {
+            $this->addAction([
+                'index'  => 'edit',
+                'icon'   => 'icon-edit',
+                'title'  => trans('admin::app.settings.clinics.index.datagrid.edit'),
+                'method' => 'GET',
+                'url'    => fn ($row) => route('admin.settings.clinics.edit', $row->id),
+            ]);
+        }
+
+        if (bouncer()->hasPermission('settings.clinics.delete')) {
+            $this->addAction([
+                'index'  => 'delete',
+                'icon'   => 'icon-delete',
+                'title'  => trans('admin::app.settings.clinics.index.datagrid.delete'),
+                'method' => 'DELETE',
+                'url'    => fn ($row) => route('admin.settings.clinics.delete', $row->id),
+            ]);
+        }
+    }
+}

--- a/app/DataGrids/Settings/ResourceDataGrid.php
+++ b/app/DataGrids/Settings/ResourceDataGrid.php
@@ -75,4 +75,3 @@ class ResourceDataGrid extends DataGrid
         }
     }
 }
-

--- a/app/DataGrids/Settings/ResourceDataGrid.php
+++ b/app/DataGrids/Settings/ResourceDataGrid.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\DataGrids\Settings;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Webkul\DataGrid\DataGrid;
+
+class ResourceDataGrid extends DataGrid
+{
+    public function prepareQueryBuilder(): Builder
+    {
+        $queryBuilder = DB::table('resources')
+            ->addSelect(
+                'resources.id',
+                'resources.type',
+                'resources.name'
+            );
+
+        $this->addFilter('id', 'resources.id');
+
+        return $queryBuilder;
+    }
+
+    public function prepareColumns(): void
+    {
+        $this->addColumn([
+            'index'      => 'id',
+            'label'      => trans('admin::app.settings.resources.index.datagrid.id'),
+            'type'       => 'string',
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+
+        $this->addColumn([
+            'index'      => 'type',
+            'type'       => 'string',
+            'label'      => trans('admin::app.settings.resources.index.datagrid.type'),
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+
+        $this->addColumn([
+            'index'      => 'name',
+            'type'       => 'string',
+            'label'      => trans('admin::app.settings.resources.index.datagrid.name'),
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+    }
+
+    public function prepareActions(): void
+    {
+        if (bouncer()->hasPermission('settings.resources.edit')) {
+            $this->addAction([
+                'index'  => 'edit',
+                'icon'   => 'icon-edit',
+                'title'  => trans('admin::app.settings.resources.index.datagrid.edit'),
+                'method' => 'GET',
+                'url'    => fn ($row) => route('admin.settings.resources.edit', $row->id),
+            ]);
+        }
+
+        if (bouncer()->hasPermission('settings.resources.delete')) {
+            $this->addAction([
+                'index'  => 'delete',
+                'icon'   => 'icon-delete',
+                'title'  => trans('admin::app.settings.resources.index.datagrid.delete'),
+                'method' => 'DELETE',
+                'url'    => fn ($row) => route('admin.settings.resources.delete', $row->id),
+            ]);
+        }
+    }
+}
+

--- a/app/Http/Controllers/Admin/Settings/ClinicController.php
+++ b/app/Http/Controllers/Admin/Settings/ClinicController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Settings;
+
+use App\DataGrids\Settings\ClinicDataGrid;
+use App\Repositories\ClinicRepository;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
+use Webkul\Admin\Http\Controllers\Controller;
+
+class ClinicController extends Controller
+{
+    public function __construct(protected ClinicRepository $clinicRepository) {}
+
+    public function index(): View|JsonResponse
+    {
+        if (request()->ajax() || request()->wantsJson()) {
+            return datagrid(ClinicDataGrid::class)->process();
+        }
+
+        return view('admin::settings.clinics.index');
+    }
+
+    public function create(): View
+    {
+        return view('admin::settings.clinics.create');
+    }
+
+    public function store(): RedirectResponse
+    {
+        $this->validate(request(), [
+            'name'   => 'required|unique:clinics,name|max:100',
+            'emails' => 'nullable|array',
+            'phones' => 'nullable|array',
+        ]);
+
+        Event::dispatch('settings.clinic.create.before');
+
+        $clinic = $this->clinicRepository->create([
+            'name'   => request('name'),
+            'emails' => request('emails'),
+            'phones' => request('phones'),
+        ]);
+
+        Event::dispatch('settings.clinic.create.after', $clinic);
+
+        return redirect()
+            ->route('admin.settings.clinics.index')
+            ->with('success', trans('admin::app.settings.clinics.index.create-success'));
+    }
+
+    public function edit(int $id): View
+    {
+        $clinic = $this->clinicRepository->findOrFail($id);
+
+        return view('admin::settings.clinics.edit', compact('clinic'));
+    }
+
+    public function update(int $id): RedirectResponse
+    {
+        $this->validate(request(), [
+            'name'   => 'required|max:100|unique:clinics,name,'.$id,
+            'emails' => 'nullable|array',
+            'phones' => 'nullable|array',
+        ]);
+
+        Event::dispatch('settings.clinic.update.before', $id);
+
+        $clinic = $this->clinicRepository->update([
+            'name'   => request('name'),
+            'emails' => request('emails'),
+            'phones' => request('phones'),
+        ], $id);
+
+        Event::dispatch('settings.clinic.update.after', $clinic);
+
+        return redirect()
+            ->route('admin.settings.clinics.index')
+            ->with('success', trans('admin::app.settings.clinics.index.update-success'));
+    }
+
+    public function destroy(?int $id = null): JsonResponse|RedirectResponse
+    {
+        // Allow id from request for routes that do not pass parameter
+        $id = $id ?? (int) request('id');
+        if (! $id) {
+            $indices = request('indices');
+            if (is_array($indices) && count($indices) > 0) {
+                $id = (int) $indices[0];
+            }
+        }
+
+        if (! $id) {
+            return redirect()
+                ->route('admin.settings.clinics.index')
+                ->with('error', 'Geen geldig ID opgegeven.');
+        }
+
+        $clinic = $this->clinicRepository->findOrFail($id);
+
+        try {
+            Event::dispatch('settings.clinic.delete.before', $id);
+
+            $clinic->delete();
+
+            Event::dispatch('settings.clinic.delete.after', $id);
+
+            if (request()->ajax() || request()->wantsJson()) {
+                return response()->json([
+                    'message' => trans('admin::app.settings.clinics.index.destroy-success'),
+                ], 200);
+            }
+
+            return redirect()
+                ->route('admin.settings.clinics.index')
+                ->with('success', trans('admin::app.settings.clinics.index.destroy-success'));
+        } catch (Exception $exception) {
+            if (request()->ajax() || request()->wantsJson()) {
+                return response()->json([
+                    'message' => trans('admin::app.settings.clinics.index.delete-failed'),
+                ], 400);
+            }
+
+            return redirect()
+                ->route('admin.settings.clinics.index')
+                ->with('error', trans('admin::app.settings.clinics.index.delete-failed'));
+        }
+    }
+}

--- a/app/Http/Controllers/Admin/Settings/ClinicController.php
+++ b/app/Http/Controllers/Admin/Settings/ClinicController.php
@@ -31,7 +31,7 @@ class ClinicController extends Controller
 
     public function store(): RedirectResponse
     {
-        $this->validate(request(), [
+        request()->validate(request(), [
             'name'   => 'required|unique:clinics,name|max:100',
             'emails' => 'nullable|array',
             'phones' => 'nullable|array',
@@ -61,7 +61,7 @@ class ClinicController extends Controller
 
     public function update(int $id): RedirectResponse
     {
-        $this->validate(request(), [
+        request()->validate(request(), [
             'name'   => 'required|max:100|unique:clinics,name,'.$id,
             'emails' => 'nullable|array',
             'phones' => 'nullable|array',

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -7,6 +7,7 @@ use App\Repositories\ResourceRepository;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
@@ -29,20 +30,16 @@ class ResourceController extends Controller
         return view('admin::settings.resources.create');
     }
 
-    public function store(): RedirectResponse|JsonResponse
+    public function store(Request $request): RedirectResponse|JsonResponse
     {
-        $this->validate(request(), [
+        $request->validate([
             'type' => 'required|string|max:100',
             'name' => 'required|unique:resources,name|max:100',
         ]);
 
         Event::dispatch('settings.resource.create.before');
 
-        $resource = $this->resourceRepository->create([
-            'type'      => request('type'),
-            'name'      => request('name'),
-            'clinic_id' => request('clinic_id'),
-        ]);
+        $resource = $this->resourceRepository->create($request->all());
 
         Event::dispatch('settings.resource.create.after', $resource);
 
@@ -55,35 +52,31 @@ class ResourceController extends Controller
             ->with('success', trans('admin::app.settings.resources.index.create-success'));
     }
 
-    public function edit(int $id): View|JsonResponse
+    public function edit(Request $request, int $id): View|JsonResponse
     {
         $resource = $this->resourceRepository->findOrFail($id);
 
-        if (request()->ajax() || request()->wantsJson()) {
+        if ($request->ajax() || $request->wantsJson()) {
             return response()->json(['data' => $resource]);
         }
 
         return view('admin::settings.resources.edit', compact('resource'));
     }
 
-    public function update(int $id): RedirectResponse|JsonResponse
+    public function update(Request $request, int $id): RedirectResponse|JsonResponse
     {
-        $this->validate(request(), [
+        $request->validate([
             'type' => 'required|string|max:100',
             'name' => 'required|max:100|unique:resources,name,'.$id,
         ]);
 
         Event::dispatch('settings.resource.update.before', $id);
 
-        $resource = $this->resourceRepository->update([
-            'type'      => request('type'),
-            'name'      => request('name'),
-            'clinic_id' => request('clinic_id'),
-        ], $id);
+        $resource = $this->resourceRepository->update($request->all(), $id);
 
         Event::dispatch('settings.resource.update.after', $resource);
 
-        if (request()->ajax() || request()->wantsJson()) {
+        if ($request->ajax() || $request->wantsJson()) {
             return response()->json(['data' => $resource, 'message' => trans('admin::app.settings.resources.index.update-success')]);
         }
 
@@ -92,11 +85,10 @@ class ResourceController extends Controller
             ->with('success', trans('admin::app.settings.resources.index.update-success'));
     }
 
-    public function destroy(?int $id = null): JsonResponse|RedirectResponse
+    public function destroy(Request $request, ?int $id = null): JsonResponse|RedirectResponse
     {
-        $id = $id ?? (int) request('id');
         if (! $id) {
-            $indices = request('indices');
+            $indices = $request['indices'];
             if (is_array($indices) && count($indices) > 0) {
                 $id = (int) $indices[0];
             }
@@ -117,7 +109,7 @@ class ResourceController extends Controller
 
             Event::dispatch('settings.resource.delete.after', $id);
 
-            if (request()->ajax() || request()->wantsJson()) {
+            if ($request->ajax() || $request->wantsJson()) {
                 return response()->json([
                     'message' => trans('admin::app.settings.resources.index.destroy-success'),
                 ], 200);
@@ -127,7 +119,7 @@ class ResourceController extends Controller
                 ->route('admin.settings.resources.index')
                 ->with('success', trans('admin::app.settings.resources.index.destroy-success'));
         } catch (Exception $exception) {
-            if (request()->ajax() || request()->wantsJson()) {
+            if ($request->ajax() || $request->wantsJson()) {
                 return response()->json([
                     'message' => trans('admin::app.settings.resources.index.delete-failed'),
                 ], 400);
@@ -139,4 +131,3 @@ class ResourceController extends Controller
         }
     }
 }
-

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Settings;
+
+use App\DataGrids\Settings\ResourceDataGrid;
+use App\Repositories\ResourceRepository;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
+use Webkul\Admin\Http\Controllers\Controller;
+
+class ResourceController extends Controller
+{
+    public function __construct(protected ResourceRepository $resourceRepository) {}
+
+    public function index(): View|JsonResponse
+    {
+        if (request()->ajax() || request()->wantsJson()) {
+            return datagrid(ResourceDataGrid::class)->process();
+        }
+
+        return view('admin::settings.resources.index');
+    }
+
+    public function create(): View
+    {
+        return view('admin::settings.resources.create');
+    }
+
+    public function store(): RedirectResponse|JsonResponse
+    {
+        $this->validate(request(), [
+            'type' => 'required|string|max:100',
+            'name' => 'required|unique:resources,name|max:100',
+        ]);
+
+        Event::dispatch('settings.resource.create.before');
+
+        $resource = $this->resourceRepository->create([
+            'type'      => request('type'),
+            'name'      => request('name'),
+            'clinic_id' => request('clinic_id'),
+        ]);
+
+        Event::dispatch('settings.resource.create.after', $resource);
+
+        if (request()->ajax() || request()->wantsJson()) {
+            return response()->json(['data' => $resource, 'message' => trans('admin::app.settings.resources.index.create-success')]);
+        }
+
+        return redirect()
+            ->route('admin.settings.resources.index')
+            ->with('success', trans('admin::app.settings.resources.index.create-success'));
+    }
+
+    public function edit(int $id): View|JsonResponse
+    {
+        $resource = $this->resourceRepository->findOrFail($id);
+
+        if (request()->ajax() || request()->wantsJson()) {
+            return response()->json(['data' => $resource]);
+        }
+
+        return view('admin::settings.resources.edit', compact('resource'));
+    }
+
+    public function update(int $id): RedirectResponse|JsonResponse
+    {
+        $this->validate(request(), [
+            'type' => 'required|string|max:100',
+            'name' => 'required|max:100|unique:resources,name,'.$id,
+        ]);
+
+        Event::dispatch('settings.resource.update.before', $id);
+
+        $resource = $this->resourceRepository->update([
+            'type'      => request('type'),
+            'name'      => request('name'),
+            'clinic_id' => request('clinic_id'),
+        ], $id);
+
+        Event::dispatch('settings.resource.update.after', $resource);
+
+        if (request()->ajax() || request()->wantsJson()) {
+            return response()->json(['data' => $resource, 'message' => trans('admin::app.settings.resources.index.update-success')]);
+        }
+
+        return redirect()
+            ->route('admin.settings.resources.index')
+            ->with('success', trans('admin::app.settings.resources.index.update-success'));
+    }
+
+    public function destroy(?int $id = null): JsonResponse|RedirectResponse
+    {
+        $id = $id ?? (int) request('id');
+        if (! $id) {
+            $indices = request('indices');
+            if (is_array($indices) && count($indices) > 0) {
+                $id = (int) $indices[0];
+            }
+        }
+
+        if (! $id) {
+            return redirect()
+                ->route('admin.settings.resources.index')
+                ->with('error', 'Geen geldig ID opgegeven.');
+        }
+
+        $resource = $this->resourceRepository->findOrFail($id);
+
+        try {
+            Event::dispatch('settings.resource.delete.before', $id);
+
+            $resource->delete();
+
+            Event::dispatch('settings.resource.delete.after', $id);
+
+            if (request()->ajax() || request()->wantsJson()) {
+                return response()->json([
+                    'message' => trans('admin::app.settings.resources.index.destroy-success'),
+                ], 200);
+            }
+
+            return redirect()
+                ->route('admin.settings.resources.index')
+                ->with('success', trans('admin::app.settings.resources.index.destroy-success'));
+        } catch (Exception $exception) {
+            if (request()->ajax() || request()->wantsJson()) {
+                return response()->json([
+                    'message' => trans('admin::app.settings.resources.index.delete-failed'),
+                ], 400);
+            }
+
+            return redirect()
+                ->route('admin.settings.resources.index')
+                ->with('error', trans('admin::app.settings.resources.index.delete-failed'));
+        }
+    }
+}
+

--- a/app/Models/Clinic.php
+++ b/app/Models/Clinic.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasAuditTrail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Clinic extends Model
+{
+    use HasAuditTrail, HasFactory;
+
+    protected $table = 'clinics';
+
+    protected $fillable = [
+        'name',
+        'emails',
+        'phones',
+        'address_id',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'emails'     => 'array',
+        'phones'     => 'array',
+        'created_by' => 'integer',
+        'updated_by' => 'integer',
+    ];
+
+    public function address()
+    {
+        return $this->belongsTo(Address::class);
+    }
+}

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasAuditTrail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Resource extends Model
+{
+    use HasAuditTrail, HasFactory;
+
+    protected $table = 'resources';
+
+    protected $fillable = [
+        'type',
+        'name',
+        'clinic_id',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'clinic_id' => 'integer',
+        'created_by' => 'integer',
+        'updated_by' => 'integer',
+    ];
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
+    }
+}
+

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -21,7 +21,7 @@ class Resource extends Model
     ];
 
     protected $casts = [
-        'clinic_id' => 'integer',
+        'clinic_id'  => 'integer',
         'created_by' => 'integer',
         'updated_by' => 'integer',
     ];
@@ -31,4 +31,3 @@ class Resource extends Model
         return $this->belongsTo(Clinic::class);
     }
 }
-

--- a/app/Repositories/ClinicRepository.php
+++ b/app/Repositories/ClinicRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Clinic;
+use Webkul\Core\Eloquent\Repository;
+
+class ClinicRepository extends Repository
+{
+    public function model(): string
+    {
+        return Clinic::class;
+    }
+}

--- a/app/Repositories/ResourceRepository.php
+++ b/app/Repositories/ResourceRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Resource;
+use Webkul\Core\Eloquent\Repository;
+
+class ResourceRepository extends Repository
+{
+    public function model(): string
+    {
+        return Resource::class;
+    }
+}
+

--- a/app/Repositories/ResourceRepository.php
+++ b/app/Repositories/ResourceRepository.php
@@ -12,4 +12,3 @@ class ResourceRepository extends Repository
         return Resource::class;
     }
 }
-

--- a/database/factories/ClinicFactory.php
+++ b/database/factories/ClinicFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Clinic;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClinicFactory extends Factory
+{
+    protected $model = Clinic::class;
+
+    public function definition(): array
+    {
+        return [
+            'name'   => $this->faker->unique()->company(),
+            'emails' => [$this->faker->unique()->companyEmail()],
+            'phones' => [$this->faker->phoneNumber()],
+        ];
+    }
+}

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -18,4 +18,3 @@ class ResourceFactory extends Factory
         ];
     }
 }
-

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Resource;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ResourceFactory extends Factory
+{
+    protected $model = Resource::class;
+
+    public function definition(): array
+    {
+        return [
+            'type'      => $this->faker->randomElement(['staff', 'machine', 'room']),
+            'name'      => $this->faker->unique()->words(2, true),
+            'clinic_id' => null,
+        ];
+    }
+}
+

--- a/database/migrations/2025_09_25_120000_create_clinics_table.php
+++ b/database/migrations/2025_09_25_120000_create_clinics_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Helpers\AuditTrailMigrationHelper;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clinics', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->json('emails')->nullable();
+            $table->json('phones')->nullable();
+            $table->unsignedBigInteger('address_id')->nullable();
+            $table->timestamps();
+            AuditTrailMigrationHelper::addAuditTrailColumns($table);
+
+            $table->unique('name');
+
+            $table->foreign('address_id')->references('id')->on('addresses')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clinics');
+    }
+};

--- a/database/migrations/2025_09_25_130000_create_resources_table.php
+++ b/database/migrations/2025_09_25_130000_create_resources_table.php
@@ -27,4 +27,3 @@ return new class extends Migration
         Schema::dropIfExists('resources');
     }
 };
-

--- a/database/migrations/2025_09_25_130000_create_resources_table.php
+++ b/database/migrations/2025_09_25_130000_create_resources_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Helpers\AuditTrailMigrationHelper;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('resources', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('type');
+            $table->string('name');
+            $table->unsignedBigInteger('clinic_id')->nullable();
+            $table->timestamps();
+            AuditTrailMigrationHelper::addAuditTrailColumns($table);
+
+            $table->index('name');
+            $table->foreign('clinic_id')->references('id')->on('clinics')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('resources');
+    }
+};
+

--- a/docs/modules/functional_design/pages/db_structure.adoc
+++ b/docs/modules/functional_design/pages/db_structure.adoc
@@ -174,7 +174,17 @@ TABLE(Product, "product") {
   description: text
   price: decimal
   product_type: enum
-  resource_type: enum
+  created_by: bigint
+  updated_by: bigint
+  FOREIGN_KEY(resource_type_id): bigint
+}
+
+TABLE(ResourceType, "resourcetype") {
+  PRIMARY_KEY(id): bigint
+  name: string
+  description: text
+  created_at: datetime
+  updated_at: datetime
   created_by: bigint
   updated_by: bigint
 }
@@ -193,11 +203,12 @@ TABLE(Resource, "resource") {
   PRIMARY_KEY(id): bigint
   type: string
   name: string
-  type: enum
   created_at: datetime
   updated_at: datetime
   created_by: bigint
   updated_by: bigint
+  FOREIGN_KEY(clinic_id): bigint
+  FOREIGN_KEY(resource_type_id): bigint
 }
 
 TABLE(Clinic, "clinic") {
@@ -448,11 +459,14 @@ Address "0..1" -- "1" Organization
 
 Product "n" -- "0..*" ProductGroup
 Product "n" -- "0..*" PartnerProduct
+Product "1" -- "1" ResourceType
 ProductCategory "0..1" -- "n" ProductCategory : "parent"
 Clinic "0..*" -- "n" Resource
 Clinic "0..*" -- "n" PartnerProduct
 Clinic "0..1" -- "1" Address
 PartnerProduct "1" -- "1" Resource
+
+Resource "1" -- "1" ResourceType
 
 Anamnesis "n" -- "1" Lead
 Anamnesis "n" -- "1" Person

--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -300,6 +300,26 @@ return [
         'route' => ['admin.settings.users.delete', 'admin.settings.users.mass_delete'],
         'sort'  => 3,
     ], [
+        'key'   => 'settings.clinics',
+        'name'  => 'Clinics',
+        'route' => 'admin.settings.clinics.index',
+        'sort'  => 4,
+    ], [
+        'key'   => 'settings.clinics.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => ['admin.settings.clinics.create', 'admin.settings.clinics.store'],
+        'sort'  => 1,
+    ], [
+        'key'   => 'settings.clinics.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => ['admin.settings.clinics.edit', 'admin.settings.clinics.update'],
+        'sort'  => 2,
+    ], [
+        'key'   => 'settings.clinics.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => ['admin.settings.clinics.delete'],
+        'sort'  => 3,
+    ], [
         'key'   => 'settings.lead',
         'name'  => 'admin::app.acl.lead',
         'route' => ['admin.settings.pipelines.index', 'admin.settings.sources.index', 'admin.settings.types.index'],

--- a/packages/Webkul/Admin/src/Config/menu.php
+++ b/packages/Webkul/Admin/src/Config/menu.php
@@ -191,6 +191,14 @@ return [
         'icon-class' => 'icon-settings-pipeline',
     ],
     [
+        'key'        => 'settings.resources',
+        'name'       => 'admin::app.layouts.resources',
+        'info'       => 'admin::app.layouts.resources-info',
+        'route'      => 'admin.settings.resources.index',
+        'sort'       => 5,
+        'icon-class' => 'icon-setting',
+    ],
+    [
         'key'        => 'settings.lead',
         'name'       => 'admin::app.layouts.lead',
         'info'       => 'admin::app.layouts.lead-info',

--- a/packages/Webkul/Admin/src/Config/menu.php
+++ b/packages/Webkul/Admin/src/Config/menu.php
@@ -176,6 +176,21 @@ return [
         'sort'       => 3,
         'icon-class' => 'icon-user',
     ], [
+        'key'        => 'settings.clinics',
+        'name'       => 'admin::app.layouts.clinics',
+        'info'       => 'admin::app.layouts.clinics-info',
+        'route'      => 'admin.settings.clinics.index',
+        'sort'       => 4,
+        'icon-class' => 'icon-setting',
+    ], [
+        'key'        => 'settings.clinics.admin',
+        'name'       => 'admin::app.layouts.clinics',
+        'info'       => 'admin::app.layouts.clinics-info',
+        'route'      => 'admin.settings.clinics.index',
+        'sort'       => 1,
+        'icon-class' => 'icon-settings-pipeline',
+    ],
+    [
         'key'        => 'settings.lead',
         'name'       => 'admin::app.layouts.lead',
         'info'       => 'admin::app.layouts.lead-info',

--- a/packages/Webkul/Admin/src/Config/menu.php
+++ b/packages/Webkul/Admin/src/Config/menu.php
@@ -191,11 +191,12 @@ return [
         'icon-class' => 'icon-settings-pipeline',
     ],
     [
-        'key'        => 'settings.resources',
+        'key'        => 'settings.clinics.reources',
         'name'       => 'admin::app.layouts.resources',
         'info'       => 'admin::app.layouts.resources-info',
         'route'      => 'admin.settings.resources.index',
-        'sort'       => 5,
+        'sort'       => 2
+        ,
         'icon-class' => 'icon-setting',
     ],
     [

--- a/packages/Webkul/Admin/src/DataGrids/Settings/ClinicDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/ClinicDataGrid.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\DataGrids\Settings;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Webkul\DataGrid\DataGrid;
+
+class ClinicDataGrid extends DataGrid
+{
+    public function prepareQueryBuilder(): Builder
+    {
+        $queryBuilder = DB::table('clinics')
+            ->addSelect(
+                'clinics.id',
+                'clinics.name'
+            );
+
+        $this->addFilter('id', 'clinics.id');
+
+        return $queryBuilder;
+    }
+
+    public function prepareColumns(): void
+    {
+        $this->addColumn([
+            'index'      => 'id',
+            'label'      => trans('admin::app.settings.clinics.index.datagrid.id'),
+            'type'       => 'string',
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+
+        $this->addColumn([
+            'index'      => 'name',
+            'type'       => 'string',
+            'label'      => trans('admin::app.settings.clinics.index.datagrid.name'),
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+    }
+
+    public function prepareActions(): void
+    {
+        if (bouncer()->hasPermission('settings.clinics.edit')) {
+            $this->addAction([
+                'index'  => 'edit',
+                'icon'   => 'icon-edit',
+                'title'  => trans('admin::app.settings.clinics.index.datagrid.edit'),
+                'method' => 'GET',
+                'url'    => fn ($row) => route('admin.settings.clinics.edit', $row->id),
+            ]);
+        }
+
+        if (bouncer()->hasPermission('settings.clinics.delete')) {
+            $this->addAction([
+                'index'  => 'delete',
+                'icon'   => 'icon-delete',
+                'title'  => trans('admin::app.settings.clinics.index.datagrid.delete'),
+                'method' => 'DELETE',
+                'url'    => fn ($row) => route('admin.settings.clinics.delete', $row->id),
+            ]);
+        }
+    }
+}
+

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/ClinicController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/ClinicController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Webkul\Admin\Http\Controllers\Settings;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
+use Webkul\Admin\DataGrids\Settings\ClinicDataGrid;
+use Webkul\Admin\Http\Controllers\Controller;
+use Webkul\Core\Repositories\ClinicRepository;
+
+class ClinicController extends Controller
+{
+    public function __construct(protected ClinicRepository $clinicRepository) {}
+
+    public function index(): View|JsonResponse
+    {
+        if (request()->ajax()) {
+            return datagrid(ClinicDataGrid::class)->process();
+        }
+
+        return view('admin::settings.clinics.index');
+    }
+
+    public function store(): JsonResponse
+    {
+        $this->validate(request(), [
+            'name'   => 'required|unique:clinics,name|max:100',
+            'emails' => 'nullable|array',
+            'phones' => 'nullable|array',
+        ]);
+
+        Event::dispatch('settings.clinic.create.before');
+
+        $clinic = $this->clinicRepository->create([
+            'name'   => request('name'),
+            'emails' => request('emails'),
+            'phones' => request('phones'),
+        ]);
+
+        Event::dispatch('settings.clinic.create.after', $clinic);
+
+        return new JsonResponse([
+            'data'    => $clinic,
+            'message' => trans('admin::app.settings.clinics.index.create-success'),
+        ]);
+    }
+
+    public function edit(int $id): JsonResource
+    {
+        $clinic = $this->clinicRepository->findOrFail($id);
+
+        return new JsonResource([
+            'data' => $clinic,
+        ]);
+    }
+
+    public function update(int $id): JsonResponse
+    {
+        $this->validate(request(), [
+            'name'   => 'required|max:100|unique:clinics,name,'.$id,
+            'emails' => 'nullable|array',
+            'phones' => 'nullable|array',
+        ]);
+
+        Event::dispatch('settings.clinic.update.before', $id);
+
+        $clinic = $this->clinicRepository->update([
+            'name'   => request('name'),
+            'emails' => request('emails'),
+            'phones' => request('phones'),
+        ], $id);
+
+        Event::dispatch('settings.clinic.update.after', $clinic);
+
+        return new JsonResponse([
+            'data'    => $clinic,
+            'message' => trans('admin::app.settings.clinics.index.update-success'),
+        ]);
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $clinic = $this->clinicRepository->findOrFail($id);
+
+        try {
+            Event::dispatch('settings.clinic.delete.before', $id);
+
+            $clinic->delete($id);
+
+            Event::dispatch('settings.clinic.delete.after', $id);
+
+            return new JsonResponse([
+                'message' => trans('admin::app.settings.clinics.index.destroy-success'),
+            ], 200);
+        } catch (Exception $exception) {
+            return new JsonResponse([
+                'message' => trans('admin::app.settings.clinics.index.delete-failed'),
+            ], 400);
+        }
+    }
+}
+

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -759,6 +759,38 @@ return [
     'settings' => [
         'title' => 'Settings',
 
+        'clinics' => [
+            'index' => [
+                'title'           => 'Clinics',
+                'create-btn'      => 'Add Clinic',
+                'create-success'  => 'Clinic created successfully.',
+                'update-success'  => 'Clinic updated successfully.',
+                'destroy-success' => 'Clinic deleted successfully.',
+                'delete-failed'   => 'Failed to delete clinic.',
+
+                'datagrid' => [
+                    'id'     => 'ID',
+                    'name'   => 'Name',
+                    'edit'   => 'Edit',
+                    'delete' => 'Delete',
+                ],
+
+                'edit' => [
+                    'title' => 'Edit Clinic',
+                ],
+
+                'create' => [
+                    'title'       => 'Create Clinic',
+                    'name'        => 'Name',
+                    'emails'      => 'Emails (JSON array)',
+                    'emails-help' => 'Example: ["info@example.com", "support@example.com"]',
+                    'phones'      => 'Phones (JSON array)',
+                    'phones-help' => 'Example: ["+31 10 000 0000"]',
+                    'save-btn'    => 'Save',
+                ],
+            ],
+        ],
+
         'groups' => [
             'index' => [
                 'create-btn'        => 'Create Group',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -791,6 +791,36 @@ return [
             ],
         ],
 
+        'resources' => [
+            'index' => [
+                'title'           => 'Resources',
+                'create-btn'      => 'Add Resource',
+                'create-success'  => 'Resource created successfully.',
+                'update-success'  => 'Resource updated successfully.',
+                'destroy-success' => 'Resource deleted successfully.',
+                'delete-failed'   => 'Failed to delete resource.',
+
+                'datagrid' => [
+                    'id'     => 'ID',
+                    'type'   => 'Type',
+                    'name'   => 'Name',
+                    'edit'   => 'Edit',
+                    'delete' => 'Delete',
+                ],
+
+                'edit' => [
+                    'title' => 'Edit Resource',
+                ],
+
+                'create' => [
+                    'title'       => 'Create Resource',
+                    'type'        => 'Type',
+                    'name'        => 'Name',
+                    'save-btn'    => 'Save',
+                ],
+            ],
+        ],
+
         'groups' => [
             'index' => [
                 'create-btn'        => 'Create Group',
@@ -2442,6 +2472,10 @@ return [
         'products'             => 'Products',
         'product-groups'       => 'Product Groups',  // Nieuwe taal key
         'workflow-leads'       => 'Backoffice',
+        'clinics'              => 'Clinics',
+        'clinics-info'         => 'Add, edit or delete clinics from CRM',
+        'resources'            => 'Resources',
+        'resources-info'       => 'Add, edit or delete resources from CRM',
     ],
 
     'user' => [

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -1669,6 +1669,37 @@ return [
                 'update-success' => 'Import updated successfully.',
             ],
         ],
+        'clinics' => [
+            'index' => [
+                'title' => 'Klinieken',
+                'create-btn' => 'Kliniek toevoegen',
+                'create-success' => 'Kliniek succesvol aangemaakt.',
+                'update-success' => 'Kliniek succesvol bijgewerkt.',
+                'destroy-success' => 'Kliniek succesvol verwijderd.',
+                'delete-failed' => 'Verwijderen van kliniek mislukt.',
+
+                'datagrid' => [
+                    'id' => 'ID',
+                    'name' => 'Naam',
+                    'edit' => 'Bewerken',
+                    'delete' => 'Verwijderen',
+                ],
+
+                'edit' => [
+                    'title' => 'Kliniek bewerken',
+                ],
+
+                'create' => [
+                    'title' => 'Kliniek aanmaken',
+                    'name' => 'Naam',
+                    'emails' => 'E-mails (JSON array)',
+                    'emails-help' => 'Voorbeeld: ["info@voorbeeld.nl", "support@voorbeeld.nl"]',
+                    'phones' => 'Telefoons (JSON array)',
+                    'phones-help' => 'Voorbeeld: ["+31 10 000 0000"]',
+                    'save-btn' => 'Opslaan',
+                ],
+            ],
+        ],
     ],
 
     'activities' => [
@@ -2333,6 +2364,8 @@ return [
         'product-groups' => 'Productgroepen',
         'products' => 'Producten',
         'workflow-leads' => 'Sales',
+        'clinics' => 'Klinieken',
+        'clinics-info' => 'Beheer klinieken',
     ],
 
     'user' => [

--- a/packages/Webkul/Admin/src/Resources/views/settings/clinics/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/clinics/create.blade.php
@@ -1,0 +1,69 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.clinics.index.create.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.clinics.store')" method="POST">
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.clinics" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.clinics.index.create.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.clinics.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.clinics.index.create.name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="name"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.clinics.index.create.name')"
+                        :placeholder="trans('admin::app.settings.clinics.index.create.name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="name" />
+                </x-admin::form.control-group>
+
+                <!-- Emails -->
+                @php
+                    $__emailsVal = old('emails', []);
+                    if (!is_array($__emailsVal)) { $__emailsVal = []; }
+                @endphp
+                @include('admin::leads.common.sections.emails', ['name' => 'emails', 'value' => $__emailsVal, 'widthClass' => 'w-full'])
+
+                <!-- Phones -->
+                @php
+                    $__phonesVal = old('phones', []);
+                    if (!is_array($__phonesVal)) { $__phonesVal = []; }
+                @endphp
+                @include('admin::leads.common.sections.phones', ['name' => 'phones', 'value' => $__phonesVal, 'widthClass' => 'w-full'])
+            </div>
+
+            <!-- Address Section -->
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <div class="mb-4">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+                        @lang('admin::app.contacts.organizations.create.address')
+                    </h3>
+                </div>
+
+                @include('admin::components.address', ['entity' => null])
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/clinics/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/clinics/edit.blade.php
@@ -1,0 +1,71 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.clinics.index.edit.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.clinics.update', $clinic->id)" method="POST">
+        @method('PUT')
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.clinics" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.clinics.index.edit.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.clinics.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.clinics.index.create.name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="name"
+                        value="{{ old('name', $clinic->name) }}"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.clinics.index.create.name')"
+                        :placeholder="trans('admin::app.settings.clinics.index.create.name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="name" />
+                </x-admin::form.control-group>
+
+                <!-- Emails -->
+                @php
+                    $__emailsVal = old('emails', $clinic->emails ?? []);
+                    if (!is_array($__emailsVal)) { $__emailsVal = []; }
+                @endphp
+                @include('admin::leads.common.sections.emails', ['name' => 'emails', 'value' => $__emailsVal, 'widthClass' => 'w-full'])
+
+                <!-- Phones -->
+                @php
+                    $__phonesVal = old('phones', $clinic->phones ?? []);
+                    if (!is_array($__phonesVal)) { $__phonesVal = []; }
+                @endphp
+                @include('admin::leads.common.sections.phones', ['name' => 'phones', 'value' => $__phonesVal, 'widthClass' => 'w-full'])
+            </div>
+
+            <!-- Address Section -->
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <div class="mb-4">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+                        @lang('admin::app.contacts.organizations.create.address')
+                    </h3>
+                </div>
+
+                @include('admin::components.address', ['entity' => $clinic->address ?? null])
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/clinics/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/clinics/index.blade.php
@@ -1,0 +1,29 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.clinics.index.title')
+    </x-slot>
+
+    <div class="flex flex-col gap-4">
+        <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+            <div class="flex flex-col gap-2">
+                <x-admin::breadcrumbs name="settings.clinics" />
+
+                <div class="text-xl font-bold dark:text-gray-300">
+                    @lang('admin::app.settings.clinics.index.title')
+                </div>
+            </div>
+
+            <div class="flex items-center gap-x-2.5">
+                @if (bouncer()->hasPermission('settings.clinics.create'))
+                    <a href="{{ route('admin.settings.clinics.create') }}" class="primary-button">
+                        @lang('admin::app.settings.clinics.index.create-btn')
+                    </a>
+                @endif
+            </div>
+        </div>
+
+        <x-admin::datagrid :src="route('admin.settings.clinics.index')" ref="datagrid" />
+    </div>
+
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
@@ -1,0 +1,60 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.resources.index.create.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.resources.store')" method="POST">
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.resources" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.resources.index.create.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.resources.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.type')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="type"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.resources.index.create.type')"
+                        :placeholder="trans('admin::app.settings.resources.index.create.type')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="type" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="name"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.resources.index.create.name')"
+                        :placeholder="trans('admin::app.settings.resources.index.create.name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="name" />
+                </x-admin::form.control-group>
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
@@ -1,0 +1,63 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.resources.index.edit.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.resources.update', $resource->id)" method="POST">
+        @method('PUT')
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.resources" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.resources.index.edit.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.resources.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.type')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="type"
+                        value="{{ old('type', $resource->type) }}"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.resources.index.create.type')"
+                        :placeholder="trans('admin::app.settings.resources.index.create.type')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="type" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="name"
+                        value="{{ old('name', $resource->name) }}"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.resources.index.create.name')"
+                        :placeholder="trans('admin::app.settings.resources.index.create.name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="name" />
+                </x-admin::form.control-group>
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/index.blade.php
@@ -1,0 +1,29 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.resources.index.title')
+    </x-slot>
+
+    <div class="flex flex-col gap-4">
+        <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+            <div class="flex flex-col gap-2">
+                <x-admin::breadcrumbs name="settings.resources" />
+
+                <div class="text-xl font-bold dark:text-gray-300">
+                    @lang('admin::app.settings.resources.index.title')
+                </div>
+            </div>
+
+            <div class="flex items-center gap-x-2.5">
+                @if (bouncer()->hasPermission('settings.resources.create'))
+                    <a href="{{ route('admin.settings.resources.create') }}" class="primary-button">
+                        @lang('admin::app.settings.resources.index.create-btn')
+                    </a>
+                @endif
+            </div>
+        </div>
+
+        <x-admin::datagrid :src="route('admin.settings.resources.index')" ref="datagrid" />
+    </div>
+
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
@@ -21,6 +21,7 @@ use Webkul\Admin\Http\Controllers\Settings\Warehouse\WarehouseController;
 use Webkul\Admin\Http\Controllers\Settings\WebFormController;
 use Webkul\Admin\Http\Controllers\Settings\WebhookController;
 use Webkul\Admin\Http\Controllers\Settings\WorkflowController;
+use App\Http\Controllers\Admin\Settings\ClinicController;
 
 /**
  * Settings routes.
@@ -44,6 +45,20 @@ Route::prefix('settings')->group(function () {
         Route::put('edit/{id}', 'update')->name('admin.settings.groups.update');
 
         Route::delete('{id}', 'destroy')->name('admin.settings.groups.delete');
+    });
+
+    /**
+     * Clinic routes.
+     */
+    Route::controller(ClinicController::class)->prefix('clinics')->group(function () {
+        Route::get('', 'index')->name('admin.settings.clinics.index');
+        Route::get('create', 'create')->name('admin.settings.clinics.create');
+        Route::post('create', 'store')->name('admin.settings.clinics.store');
+        Route::get('edit/{id}', 'edit')->name('admin.settings.clinics.edit');
+        Route::put('edit/{id}', 'update')->name('admin.settings.clinics.update');
+        // Some datagrid actions may send DELETE to base path; support both
+        Route::delete('', 'destroy')->name('admin.settings.clinics.delete');
+        Route::delete('{id}', 'destroy')->name('admin.settings.clinics.delete');
     });
 
     /**

--- a/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
@@ -22,6 +22,7 @@ use Webkul\Admin\Http\Controllers\Settings\WebFormController;
 use Webkul\Admin\Http\Controllers\Settings\WebhookController;
 use Webkul\Admin\Http\Controllers\Settings\WorkflowController;
 use App\Http\Controllers\Admin\Settings\ClinicController;
+use App\Http\Controllers\Admin\Settings\ResourceController;
 
 /**
  * Settings routes.
@@ -59,6 +60,19 @@ Route::prefix('settings')->group(function () {
         // Some datagrid actions may send DELETE to base path; support both
         Route::delete('', 'destroy')->name('admin.settings.clinics.delete');
         Route::delete('{id}', 'destroy')->name('admin.settings.clinics.delete');
+    });
+
+    /**
+     * Resource routes.
+     */
+    Route::controller(ResourceController::class)->prefix('resources')->group(function () {
+        Route::get('', 'index')->name('admin.settings.resources.index');
+        Route::get('create', 'create')->name('admin.settings.resources.create');
+        Route::post('create', 'store')->name('admin.settings.resources.store');
+        Route::get('edit/{id}', 'edit')->name('admin.settings.resources.edit');
+        Route::put('edit/{id}', 'update')->name('admin.settings.resources.update');
+        Route::delete('', 'destroy')->name('admin.settings.resources.delete');
+        Route::delete('{id}', 'destroy')->name('admin.settings.resources.delete');
     });
 
     /**

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -471,6 +471,18 @@ Breadcrumbs::for('settings.locations.edit', function (BreadcrumbTrail $trail, $l
     $trail->push(trans('admin::app.settings.locations.edit-title'), route('admin.settings.locations.edit', $location->id));
 });
 
+// Settings > Resources
+Breadcrumbs::for('settings.resources', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings');
+    $trail->push(trans('admin::app.layouts.resources'), route('admin.settings.resources.index'));
+});
+
+// Settings > Resources > Create
+Breadcrumbs::for('settings.resources.create', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings.resources');
+    $trail->push(trans('admin::app.settings.resources.index.create.title'), route('admin.settings.resources.create'));
+});
+
 // Dashboard > Settings > Data Transfers
 Breadcrumbs::for('settings.data_transfers', function (BreadcrumbTrail $trail) {
     $trail->parent('settings');

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -208,6 +208,18 @@ Breadcrumbs::for('settings.groups', function (BreadcrumbTrail $trail) {
     $trail->push(trans('admin::app.layouts.groups'), route('admin.settings.groups.index'));
 });
 
+// Settings > Clinics
+Breadcrumbs::for('settings.clinics', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings');
+    $trail->push(trans('admin::app.layouts.clinics'), route('admin.settings.clinics.index'));
+});
+
+// Settings > Clinics > Create
+Breadcrumbs::for('settings.clinics.create', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings.clinics');
+    $trail->push(trans('admin::app.settings.clinics.index.create.title'), route('admin.settings.clinics.create'));
+});
+
 // Dashboard > Groups > Create Group
 Breadcrumbs::for('settings.groups.create', function (BreadcrumbTrail $trail) {
     $trail->parent('settings.groups');

--- a/tests/Feature/Settings/ClinicCrudTest.php
+++ b/tests/Feature/Settings/ClinicCrudTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Clinic;
+use Webkul\Installer\Http\Middleware\CanInstall;
+use Webkul\User\Models\User;
+
+beforeEach(function () {
+    config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
+    test()->withoutMiddleware(CanInstall::class);
+});
+
+function makeUser(array $attrs = []): User
+{
+    return User::factory()->create(array_merge(['status' => 1], $attrs));
+}
+
+function getDatagridIds($response): array
+{
+    $payload = $response->json();
+    $records = $payload['records'] ?? [];
+
+    return collect($records)->pluck('id')->all();
+}
+
+test('clinics index returns datagrid json', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $c1 = Clinic::factory()->create();
+    $c2 = Clinic::factory()->create();
+
+    $response = $this->getJson(route('admin.settings.clinics.index'));
+    $response->assertOk();
+
+    $ids = getDatagridIds($response);
+    expect($ids)->toContain($c1->id, $c2->id);
+});
+
+test('can create clinic', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $payload = [
+        'name'   => 'Test Clinic',
+        'emails' => ['info@testclinic.tld'],
+        'phones' => ['+31 10 123 4567'],
+    ];
+
+    $response = $this->postJson(route('admin.settings.clinics.store'), $payload);
+    $response->assertOk()->assertJsonPath('data.name', 'Test Clinic');
+
+    $this->assertDatabaseHas('clinics', [
+        'name' => 'Test Clinic',
+    ]);
+});
+
+test('can update clinic', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $clinic = Clinic::factory()->create();
+
+    $payload = [
+        'name'    => 'Updated Clinic',
+        'emails'  => ['contact@updated.tld'],
+        'phones'  => ['+31 10 222 3333'],
+        '_method' => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.settings.clinics.update', ['id' => $clinic->id]), $payload);
+    $response->assertOk()->assertJsonPath('data.name', 'Updated Clinic');
+
+    $this->assertDatabaseHas('clinics', [
+        'id'   => $clinic->id,
+        'name' => 'Updated Clinic',
+    ]);
+});
+
+test('can delete clinic', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $clinic = Clinic::factory()->create();
+
+    $response = $this->deleteJson(route('admin.settings.clinics.delete', ['id' => $clinic->id]));
+    $response->assertOk();
+
+    $this->assertDatabaseMissing('clinics', [
+        'id' => $clinic->id,
+    ]);
+});

--- a/tests/Feature/Settings/ResourceCrudTest.php
+++ b/tests/Feature/Settings/ResourceCrudTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Resource;
+use Webkul\Installer\Http\Middleware\CanInstall;
+use Webkul\User\Models\User;
+
+beforeEach(function () {
+    config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
+    test()->withoutMiddleware(CanInstall::class);
+});
+
+function makeUser(array $attrs = []): User
+{
+    return User::factory()->create(array_merge(['status' => 1], $attrs));
+}
+
+function getDatagridIds($response): array
+{
+    $payload = $response->json();
+    $records = $payload['records'] ?? [];
+
+    return collect($records)->pluck('id')->all();
+}
+
+test('resources index returns datagrid json', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $r1 = Resource::factory()->create();
+    $r2 = Resource::factory()->create();
+
+    $response = $this->getJson(route('admin.settings.resources.index'));
+    $response->assertOk();
+
+    $ids = getDatagridIds($response);
+    expect($ids)->toContain($r1->id, $r2->id);
+});
+
+test('can create resource', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $payload = [
+        'type' => 'staff',
+        'name' => 'Test Resource',
+    ];
+
+    $response = $this->postJson(route('admin.settings.resources.store'), $payload);
+    $response->assertOk()->assertJsonPath('data.name', 'Test Resource');
+
+    $this->assertDatabaseHas('resources', [
+        'name' => 'Test Resource',
+    ]);
+});
+
+test('can update resource', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $resource = Resource::factory()->create();
+
+    $payload = [
+        'type'    => 'room',
+        'name'    => 'Updated Resource',
+        '_method' => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.settings.resources.update', ['id' => $resource->id]), $payload);
+    $response->assertOk()->assertJsonPath('data.name', 'Updated Resource');
+
+    $this->assertDatabaseHas('resources', [
+        'id'   => $resource->id,
+        'name' => 'Updated Resource',
+    ]);
+});
+
+test('can delete resource', function () {
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+
+    $resource = Resource::factory()->create();
+
+    $response = $this->deleteJson(route('admin.settings.resources.delete', ['id' => $resource->id]));
+    $response->assertOk();
+
+    $this->assertDatabaseMissing('resources', [
+        'id' => $resource->id,
+    ]);
+});
+

--- a/tests/Feature/Settings/ResourceCrudTest.php
+++ b/tests/Feature/Settings/ResourceCrudTest.php
@@ -9,6 +9,9 @@ use Webkul\User\Models\User;
 beforeEach(function () {
     config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
     test()->withoutMiddleware(CanInstall::class);
+
+    $user = makeUser();
+    $this->actingAs($user, 'user');
 });
 
 function makeUser(array $attrs = []): User
@@ -25,9 +28,6 @@ function getDatagridIds($response): array
 }
 
 test('resources index returns datagrid json', function () {
-    $user = makeUser();
-    $this->actingAs($user, 'user');
-
     $r1 = Resource::factory()->create();
     $r2 = Resource::factory()->create();
 
@@ -39,9 +39,6 @@ test('resources index returns datagrid json', function () {
 });
 
 test('can create resource', function () {
-    $user = makeUser();
-    $this->actingAs($user, 'user');
-
     $payload = [
         'type' => 'staff',
         'name' => 'Test Resource',
@@ -56,9 +53,6 @@ test('can create resource', function () {
 });
 
 test('can update resource', function () {
-    $user = makeUser();
-    $this->actingAs($user, 'user');
-
     $resource = Resource::factory()->create();
 
     $payload = [
@@ -77,9 +71,6 @@ test('can update resource', function () {
 });
 
 test('can delete resource', function () {
-    $user = makeUser();
-    $this->actingAs($user, 'user');
-
     $resource = Resource::factory()->create();
 
     $response = $this->deleteJson(route('admin.settings.resources.delete', ['id' => $resource->id]));
@@ -89,4 +80,3 @@ test('can delete resource', function () {
         'id' => $resource->id,
     ]);
 });
-


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
<!--- Please describe your changes in detail. -->
This PR introduces the `Resource` entity and its complete CRUD management interface, mirroring the existing `Clinic` entity's structure and functionality.

Key changes include:
- Creation of the `Resource` model, migration (with `HasAuditTrail`), repository, datagrid, and controller.
- Implementation of admin views for `Resource` index, create, and edit.
- Integration of `Resource` into the admin navigation under `Settings`, positioned below `Clinic`.
- Addition of a `Resource` factory and a feature test for CRUD operations.
- The `resource_type` relationship is included in the database schema but is not yet actively managed in the application logic, as per the initial requirements.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Run `php artisan migrate` to apply the new `resources` table.
2. Log in to the admin panel.
3. Navigate to `Admin > Settings > Resources`.
4. Verify that you can create, view, edit, and delete resources through the UI.
5. Run `php artisan test --filter=ResourceCrudTest` to execute the new feature tests.

## Documentation
- [x] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
The `docs/modules/functional_design/pages/db_structure.adoc` file has been updated to reflect the new `Resource` and `ResourceType` entities and their relationships.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-c3bc64de-1c65-4e8a-9afe-68a7ca3ca997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3bc64de-1c65-4e8a-9afe-68a7ca3ca997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

