### PR TITLE
Refactor controllers and add resource type relation

### DIFF
--- a/app/Http/Controllers/Admin/Settings/ClinicController.php
+++ b/app/Http/Controllers/Admin/Settings/ClinicController.php
@@ -4,135 +4,58 @@ namespace App\Http\Controllers\Admin\Settings;
 
 use App\DataGrids\Settings\ClinicDataGrid;
 use App\Repositories\ClinicRepository;
-use Exception;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Event;
-use Illuminate\View\View;
-use Webkul\Admin\Http\Controllers\Controller;
 
-class ClinicController extends Controller
+class ClinicController extends SimpleEntityController
 {
-    public function __construct(protected ClinicRepository $clinicRepository) {}
-
-    public function index(Request $request): View|JsonResponse
+    public function __construct(protected ClinicRepository $clinicRepository)
     {
-        if ($request->ajax() || $request->wantsJson()) {
-            return datagrid(ClinicDataGrid::class)->process();
-        }
+        parent::__construct($clinicRepository);
 
-        return view('admin::settings.clinics.index');
+        $this->entityName       = 'clinic';
+        $this->datagridClass    = ClinicDataGrid::class;
+        $this->indexView        = 'admin::settings.clinics.index';
+        $this->createView       = 'admin::settings.clinics.create';
+        $this->editView         = 'admin::settings.clinics.edit';
+        $this->indexRoute       = 'admin.settings.clinics.index';
+        $this->permissionPrefix = 'settings.clinics';
     }
 
-    public function create(): View
-    {
-        return view('admin::settings.clinics.create');
-    }
-
-    public function store(Request $request): JsonResponse|RedirectResponse
+    protected function validateStore(Request $request): void
     {
         $request->validate([
             'name'   => 'required|unique:clinics,name|max:100',
             'emails' => 'nullable|array',
             'phones' => 'nullable|array',
         ]);
-
-        Event::dispatch('settings.clinic.create.before');
-
-        $clinic = $this->clinicRepository->create($request->all());
-
-        Event::dispatch('settings.clinic.create.after', $clinic);
-
-        if ($request->ajax() || $request->wantsJson()) {
-            return response()->json([
-                'data'    => $clinic,
-                'message' => trans('admin::app.settings.clinics.index.create-success'),
-            ], 200);
-        }
-
-        return redirect()
-            ->route('admin.settings.clinics.index')
-            ->with('success', trans('admin::app.settings.clinics.index.create-success'));
     }
 
-    public function edit(int $id): View
-    {
-        $clinic = $this->clinicRepository->findOrFail($id);
-
-        return view('admin::settings.clinics.edit', ['clinic' => $clinic]);
-    }
-
-    public function update(Request $request, int $id): RedirectResponse|JsonResponse
+    protected function validateUpdate(Request $request, int $id): void
     {
         $request->validate([
             'name'   => 'required|max:100|unique:clinics,name,'.$id,
             'emails' => 'nullable|array',
             'phones' => 'nullable|array',
         ]);
-
-        Event::dispatch('settings.clinic.update.before', $id);
-
-        $clinic = $this->clinicRepository->update($request->all(), $id);
-
-        Event::dispatch('settings.clinic.update.after', $clinic);
-
-        if ($request->ajax() || $request->wantsJson()) {
-            return response()->json([
-                'data'    => $clinic,
-                'message' => trans('admin::app.settings.clinics.index.update-success'),
-            ], 200);
-        }
-
-        return redirect()
-            ->route('admin.settings.clinics.index')
-            ->with('success', trans('admin::app.settings.clinics.index.update-success'));
     }
 
-    public function destroy(Request $request, ?int $id = null): JsonResponse|RedirectResponse
+    protected function getCreateSuccessMessage(): string
     {
-        // Allow id from request for routes that do not pass parameter
-        if (! $id) {
-            $indices = $request['indices'];
-            if (is_array($indices) && count($indices) > 0) {
-                $id = (int) $indices[0];
-            }
-        }
+        return trans('admin::app.settings.clinics.index.create-success');
+    }
 
-        if (! $id) {
-            return redirect()
-                ->route('admin.settings.clinics.index')
-                ->with('error', 'Geen geldig ID opgegeven.');
-        }
+    protected function getUpdateSuccessMessage(): string
+    {
+        return trans('admin::app.settings.clinics.index.update-success');
+    }
 
-        $clinic = $this->clinicRepository->findOrFail($id);
+    protected function getDestroySuccessMessage(): string
+    {
+        return trans('admin::app.settings.clinics.index.destroy-success');
+    }
 
-        try {
-            Event::dispatch('settings.clinic.delete.before', $id);
-
-            $clinic->delete();
-
-            Event::dispatch('settings.clinic.delete.after', $id);
-
-            if ($request->ajax() || $request->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.clinics.index.destroy-success'),
-                ], 200);
-            }
-
-            return redirect()
-                ->route('admin.settings.clinics.index')
-                ->with('success', trans('admin::app.settings.clinics.index.destroy-success'));
-        } catch (Exception $exception) {
-            if ($request->ajax() || $request->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.clinics.index.delete-failed'),
-                ], 400);
-            }
-
-            return redirect()
-                ->route('admin.settings.clinics.index')
-                ->with('error', trans('admin::app.settings.clinics.index.delete-failed'));
-        }
+    protected function getDeleteFailedMessage(): string
+    {
+        return trans('admin::app.settings.clinics.index.delete-failed');
     }
 }

--- a/app/Http/Controllers/Admin/Settings/ClinicController.php
+++ b/app/Http/Controllers/Admin/Settings/ClinicController.php
@@ -12,12 +12,12 @@ class ClinicController extends SimpleEntityController
     {
         parent::__construct($clinicRepository);
 
-        $this->entityName       = 'clinic';
-        $this->datagridClass    = ClinicDataGrid::class;
-        $this->indexView        = 'admin::settings.clinics.index';
-        $this->createView       = 'admin::settings.clinics.create';
-        $this->editView         = 'admin::settings.clinics.edit';
-        $this->indexRoute       = 'admin.settings.clinics.index';
+        $this->entityName = 'clinic';
+        $this->datagridClass = ClinicDataGrid::class;
+        $this->indexView = 'admin::settings.clinics.index';
+        $this->createView = 'admin::settings.clinics.create';
+        $this->editView = 'admin::settings.clinics.edit';
+        $this->indexRoute = 'admin.settings.clinics.index';
         $this->permissionPrefix = 'settings.clinics';
     }
 

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -42,7 +42,6 @@ class ResourceController extends SimpleEntityController
     protected function validateStore(Request $request): void
     {
         $request->validate([
-            'type'              => 'required|string|max:100',
             'name'              => 'required|unique:resources,name|max:100',
             'resource_type_id'  => 'required|exists:resource_types,id',
         ]);
@@ -51,7 +50,6 @@ class ResourceController extends SimpleEntityController
     protected function validateUpdate(Request $request, int $id): void
     {
         $request->validate([
-            'type'              => 'required|string|max:100',
             'name'              => 'required|max:100|unique:resources,name,'.$id,
             'resource_type_id'  => 'required|exists:resource_types,id',
         ]);

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -4,130 +4,76 @@ namespace App\Http\Controllers\Admin\Settings;
 
 use App\DataGrids\Settings\ResourceDataGrid;
 use App\Repositories\ResourceRepository;
-use Exception;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
+use App\Repositories\ResourceTypeRepository;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Event;
-use Illuminate\View\View;
-use Webkul\Admin\Http\Controllers\Controller;
 
-class ResourceController extends Controller
+class ResourceController extends SimpleEntityController
 {
-    public function __construct(protected ResourceRepository $resourceRepository) {}
+    public function __construct(
+        protected ResourceRepository $resourceRepository,
+        protected ResourceTypeRepository $resourceTypeRepository
+    ) {
+        parent::__construct($resourceRepository);
 
-    public function index(): View|JsonResponse
-    {
-        if (request()->ajax() || request()->wantsJson()) {
-            return datagrid(ResourceDataGrid::class)->process();
-        }
-
-        return view('admin::settings.resources.index');
+        $this->entityName       = 'resource';
+        $this->datagridClass    = ResourceDataGrid::class;
+        $this->indexView        = 'admin::settings.resources.index';
+        $this->createView       = 'admin::settings.resources.create';
+        $this->editView         = 'admin::settings.resources.edit';
+        $this->indexRoute       = 'admin.settings.resources.index';
+        $this->permissionPrefix = 'settings.resources';
     }
 
-    public function create(): View
+    protected function getCreateViewData(Request $request): array
     {
-        return view('admin::settings.resources.create');
+        return [
+            'resourceTypes' => $this->resourceTypeRepository->all(),
+        ];
     }
 
-    public function store(Request $request): RedirectResponse|JsonResponse
+    protected function getEditViewData(Request $request, \Illuminate\Database\Eloquent\Model $entity): array
+    {
+        return [
+            'resource'      => $entity,
+            'resourceTypes' => $this->resourceTypeRepository->all(),
+        ];
+    }
+
+    protected function validateStore(Request $request): void
     {
         $request->validate([
-            'type' => 'required|string|max:100',
-            'name' => 'required|unique:resources,name|max:100',
+            'type'              => 'required|string|max:100',
+            'name'              => 'required|unique:resources,name|max:100',
+            'resource_type_id'  => 'required|exists:resource_types,id',
         ]);
-
-        Event::dispatch('settings.resource.create.before');
-
-        $resource = $this->resourceRepository->create($request->all());
-
-        Event::dispatch('settings.resource.create.after', $resource);
-
-        if (request()->ajax() || request()->wantsJson()) {
-            return response()->json(['data' => $resource, 'message' => trans('admin::app.settings.resources.index.create-success')]);
-        }
-
-        return redirect()
-            ->route('admin.settings.resources.index')
-            ->with('success', trans('admin::app.settings.resources.index.create-success'));
     }
 
-    public function edit(Request $request, int $id): View|JsonResponse
-    {
-        $resource = $this->resourceRepository->findOrFail($id);
-
-        if ($request->ajax() || $request->wantsJson()) {
-            return response()->json(['data' => $resource]);
-        }
-
-        return view('admin::settings.resources.edit', ['resource' => $resource]);
-    }
-
-    public function update(Request $request, int $id): RedirectResponse|JsonResponse
+    protected function validateUpdate(Request $request, int $id): void
     {
         $request->validate([
-            'type' => 'required|string|max:100',
-            'name' => 'required|max:100|unique:resources,name,'.$id,
+            'type'              => 'required|string|max:100',
+            'name'              => 'required|max:100|unique:resources,name,'.$id,
+            'resource_type_id'  => 'required|exists:resource_types,id',
         ]);
-
-        Event::dispatch('settings.resource.update.before', $id);
-
-        $resource = $this->resourceRepository->update($request->all(), $id);
-
-        Event::dispatch('settings.resource.update.after', $resource);
-
-        if ($request->ajax() || $request->wantsJson()) {
-            return response()->json(['data' => $resource, 'message' => trans('admin::app.settings.resources.index.update-success')]);
-        }
-
-        return redirect()
-            ->route('admin.settings.resources.index')
-            ->with('success', trans('admin::app.settings.resources.index.update-success'));
     }
 
-    public function destroy(Request $request, ?int $id = null): JsonResponse|RedirectResponse
+    protected function getCreateSuccessMessage(): string
     {
-        if (! $id) {
-            $indices = $request['indices'];
-            if (is_array($indices) && count($indices) > 0) {
-                $id = (int) $indices[0];
-            }
-        }
+        return trans('admin::app.settings.resources.index.create-success');
+    }
 
-        if (! $id) {
-            return redirect()
-                ->route('admin.settings.resources.index')
-                ->with('error', 'Geen geldig ID opgegeven.');
-        }
+    protected function getUpdateSuccessMessage(): string
+    {
+        return trans('admin::app.settings.resources.index.update-success');
+    }
 
-        $resource = $this->resourceRepository->findOrFail($id);
+    protected function getDestroySuccessMessage(): string
+    {
+        return trans('admin::app.settings.resources.index.destroy-success');
+    }
 
-        try {
-            Event::dispatch('settings.resource.delete.before', $id);
-
-            $resource->delete();
-
-            Event::dispatch('settings.resource.delete.after', $id);
-
-            if ($request->ajax() || $request->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.resources.index.destroy-success'),
-                ], 200);
-            }
-
-            return redirect()
-                ->route('admin.settings.resources.index')
-                ->with('success', trans('admin::app.settings.resources.index.destroy-success'));
-        } catch (Exception $exception) {
-            if ($request->ajax() || $request->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.resources.index.delete-failed'),
-                ], 400);
-            }
-
-            return redirect()
-                ->route('admin.settings.resources.index')
-                ->with('error', trans('admin::app.settings.resources.index.delete-failed'));
-        }
+    protected function getDeleteFailedMessage(): string
+    {
+        return trans('admin::app.settings.resources.index.delete-failed');
     }
 }

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin\Settings;
 use App\DataGrids\Settings\ResourceDataGrid;
 use App\Repositories\ResourceRepository;
 use App\Repositories\ResourceTypeRepository;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
 class ResourceController extends SimpleEntityController
@@ -15,12 +16,12 @@ class ResourceController extends SimpleEntityController
     ) {
         parent::__construct($resourceRepository);
 
-        $this->entityName       = 'resource';
-        $this->datagridClass    = ResourceDataGrid::class;
-        $this->indexView        = 'admin::settings.resources.index';
-        $this->createView       = 'admin::settings.resources.create';
-        $this->editView         = 'admin::settings.resources.edit';
-        $this->indexRoute       = 'admin.settings.resources.index';
+        $this->entityName = 'resource';
+        $this->datagridClass = ResourceDataGrid::class;
+        $this->indexView = 'admin::settings.resources.index';
+        $this->createView = 'admin::settings.resources.create';
+        $this->editView = 'admin::settings.resources.edit';
+        $this->indexRoute = 'admin.settings.resources.index';
         $this->permissionPrefix = 'settings.resources';
     }
 
@@ -31,7 +32,7 @@ class ResourceController extends SimpleEntityController
         ];
     }
 
-    protected function getEditViewData(Request $request, \Illuminate\Database\Eloquent\Model $entity): array
+    protected function getEditViewData(Request $request, Model $entity): array
     {
         return [
             'resource'      => $entity,

--- a/app/Http/Controllers/Admin/Settings/ResourceTypeController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceTypeController.php
@@ -12,12 +12,12 @@ class ResourceTypeController extends SimpleEntityController
     {
         parent::__construct($resourceTypeRepository);
 
-        $this->entityName       = 'resource_type';
-        $this->datagridClass    = ResourceTypeDataGrid::class;
-        $this->indexView        = 'admin::settings.resource_types.index';
-        $this->createView       = 'admin::settings.resource_types.create';
-        $this->editView         = 'admin::settings.resource_types.edit';
-        $this->indexRoute       = 'admin.settings.resource_types.index';
+        $this->entityName = 'resource_type';
+        $this->datagridClass = ResourceTypeDataGrid::class;
+        $this->indexView = 'admin::settings.resource_types.index';
+        $this->createView = 'admin::settings.resource_types.create';
+        $this->editView = 'admin::settings.resource_types.edit';
+        $this->indexRoute = 'admin.settings.resource_types.index';
         $this->permissionPrefix = 'settings.resource_types';
     }
 

--- a/app/Http/Controllers/Admin/Settings/ResourceTypeController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceTypeController.php
@@ -4,118 +4,56 @@ namespace App\Http\Controllers\Admin\Settings;
 
 use App\DataGrids\Settings\ResourceTypeDataGrid;
 use App\Repositories\ResourceTypeRepository;
-use Exception;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Event;
-use Illuminate\View\View;
-use Webkul\Admin\Http\Controllers\Controller;
 
-class ResourceTypeController extends Controller
+class ResourceTypeController extends SimpleEntityController
 {
-    public function __construct(protected ResourceTypeRepository $resourceTypeRepository) {}
-
-    public function index(): View|JsonResponse
+    public function __construct(protected ResourceTypeRepository $resourceTypeRepository)
     {
-        if (request()->ajax() || request()->wantsJson()) {
-            return datagrid(ResourceTypeDataGrid::class)->process();
-        }
+        parent::__construct($resourceTypeRepository);
 
-        return view('admin::settings.resource_types.index');
+        $this->entityName       = 'resource_type';
+        $this->datagridClass    = ResourceTypeDataGrid::class;
+        $this->indexView        = 'admin::settings.resource_types.index';
+        $this->createView       = 'admin::settings.resource_types.create';
+        $this->editView         = 'admin::settings.resource_types.edit';
+        $this->indexRoute       = 'admin.settings.resource_types.index';
+        $this->permissionPrefix = 'settings.resource_types';
     }
 
-    public function create(): View
-    {
-        return view('admin::settings.resource_types.create');
-    }
-
-    public function store(Request $request): RedirectResponse
+    protected function validateStore(Request $request): void
     {
         $request->validate([
             'name'        => 'required|unique:resource_types,name|max:100',
             'description' => 'nullable|string',
         ]);
-
-        Event::dispatch('settings.resource_type.create.before');
-
-        $entity = $this->resourceTypeRepository->create($request->all());
-
-        Event::dispatch('settings.resource_type.create.after', $entity);
-
-        return redirect()
-            ->route('admin.settings.resource_types.index')
-            ->with('success', trans('admin::app.settings.resource_types.index.create-success'));
     }
 
-    public function edit(int $id): View
-    {
-        $resourceType = $this->resourceTypeRepository->findOrFail($id);
-
-        return view('admin::settings.resource_types.edit', ['resourceType' => $resourceType]);
-    }
-
-    public function update(Request $request, int $id): RedirectResponse
+    protected function validateUpdate(Request $request, int $id): void
     {
         $request->validate([
             'name'        => 'required|max:100|unique:resource_types,name,'.$id,
             'description' => 'nullable|string',
         ]);
-
-        Event::dispatch('settings.resource_type.update.before', $id);
-
-        $entity = $this->resourceTypeRepository->update($request->all(), $id);
-
-        Event::dispatch('settings.resource_type.update.after', $entity);
-
-        return redirect()
-            ->route('admin.settings.resource_types.index')
-            ->with('success', trans('admin::app.settings.resource_types.index.update-success'));
     }
 
-    public function destroy(Request $request, ?int $id = null): JsonResponse|RedirectResponse
+    protected function getCreateSuccessMessage(): string
     {
-        if (! $id) {
-            $indices = $request['indices'];
-            if (is_array($indices) && count($indices) > 0) {
-                $id = (int) $indices[0];
-            }
-        }
+        return trans('admin::app.settings.resource_types.index.create-success');
+    }
 
-        if (! $id) {
-            return redirect()
-                ->route('admin.settings.resource_types.index')
-                ->with('error', 'Geen geldig ID opgegeven.');
-        }
+    protected function getUpdateSuccessMessage(): string
+    {
+        return trans('admin::app.settings.resource_types.index.update-success');
+    }
 
-        $entity = $this->resourceTypeRepository->findOrFail($id);
+    protected function getDestroySuccessMessage(): string
+    {
+        return trans('admin::app.settings.resource_types.index.destroy-success');
+    }
 
-        try {
-            Event::dispatch('settings.resource_type.delete.before', $id);
-
-            $entity->delete();
-
-            Event::dispatch('settings.resource_type.delete.after', $id);
-
-            if (request()->ajax() || request()->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.resource_types.index.destroy-success'),
-                ], 200);
-            }
-
-            return redirect()
-                ->route('admin.settings.resource_types.index')
-                ->with('success', trans('admin::app.settings.resource_types.index.destroy-success'));
-        } catch (Exception $exception) {
-            if (request()->ajax() || request()->wantsJson()) {
-                return response()->json([
-                    'message' => trans('admin::app.settings.resource_types.index.delete-failed'),
-                ], 400);
-            }
-
-            return redirect()
-                ->route('admin.settings.resource_types.index')
-                ->with('error', trans('admin::app.settings.resource_types.index.delete-failed'));
-        }
+    protected function getDeleteFailedMessage(): string
+    {
+        return trans('admin::app.settings.resource_types.index.delete-failed');
     }
 }

--- a/app/Http/Controllers/Admin/Settings/SimpleEntityController.php
+++ b/app/Http/Controllers/Admin/Settings/SimpleEntityController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Admin\Settings;
 
-use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -178,4 +177,3 @@ abstract class SimpleEntityController extends Controller
 
     abstract protected function getDeleteFailedMessage(): string;
 }
-

--- a/app/Http/Controllers/Admin/Settings/SimpleEntityController.php
+++ b/app/Http/Controllers/Admin/Settings/SimpleEntityController.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Settings;
+
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
+use Webkul\Admin\Http\Controllers\Controller;
+
+abstract class SimpleEntityController extends Controller
+{
+    protected string $entityName;
+
+    protected string $datagridClass;
+
+    protected string $indexView;
+
+    protected string $createView;
+
+    protected string $editView;
+
+    protected string $indexRoute;
+
+    protected string $permissionPrefix;
+
+    public function __construct(protected $repository) {}
+
+    public function index(Request $request): View|JsonResponse
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return datagrid($this->datagridClass)->process();
+        }
+
+        return view($this->indexView, $this->getIndexViewData($request));
+    }
+
+    public function create(Request $request): View
+    {
+        return view($this->createView, $this->getCreateViewData($request));
+    }
+
+    public function store(Request $request): RedirectResponse|JsonResponse
+    {
+        $this->validateStore($request);
+
+        Event::dispatch("settings.{$this->entityName}.create.before");
+
+        $entity = $this->repository->create($this->transformPayload($request->all()));
+
+        Event::dispatch("settings.{$this->entityName}.create.after", $entity);
+
+        if ($request->ajax() || $request->wantsJson()) {
+            return response()->json([
+                'data'    => $entity,
+                'message' => $this->getCreateSuccessMessage(),
+            ], 200);
+        }
+
+        return redirect()
+            ->route($this->indexRoute)
+            ->with('success', $this->getCreateSuccessMessage());
+    }
+
+    public function edit(Request $request, int $id): View|JsonResponse
+    {
+        $entity = $this->repository->findOrFail($id);
+
+        if ($request->ajax() || $request->wantsJson()) {
+            return response()->json(['data' => $entity]);
+        }
+
+        return view($this->editView, $this->getEditViewData($request, $entity));
+    }
+
+    public function update(Request $request, int $id): RedirectResponse|JsonResponse
+    {
+        $this->validateUpdate($request, $id);
+
+        Event::dispatch("settings.{$this->entityName}.update.before", $id);
+
+        $entity = $this->repository->update($this->transformPayload($request->all(), $id), $id);
+
+        Event::dispatch("settings.{$this->entityName}.update.after", $entity);
+
+        if ($request->ajax() || $request->wantsJson()) {
+            return response()->json([
+                'data'    => $entity,
+                'message' => $this->getUpdateSuccessMessage(),
+            ]);
+        }
+
+        return redirect()
+            ->route($this->indexRoute)
+            ->with('success', $this->getUpdateSuccessMessage());
+    }
+
+    public function destroy(Request $request, ?int $id = null): RedirectResponse|JsonResponse
+    {
+        if (! $id) {
+            $indices = $request['indices'];
+            if (is_array($indices) && count($indices) > 0) {
+                $id = (int) $indices[0];
+            }
+        }
+
+        if (! $id) {
+            return redirect()
+                ->route($this->indexRoute)
+                ->with('error', 'Geen geldig ID opgegeven.');
+        }
+
+        $entity = $this->repository->findOrFail($id);
+
+        try {
+            Event::dispatch("settings.{$this->entityName}.delete.before", $id);
+
+            $entity->delete();
+
+            Event::dispatch("settings.{$this->entityName}.delete.after", $id);
+
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    'message' => $this->getDestroySuccessMessage(),
+                ], 200);
+            }
+
+            return redirect()
+                ->route($this->indexRoute)
+                ->with('success', $this->getDestroySuccessMessage());
+        } catch (\Exception $exception) {
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    'message' => $this->getDeleteFailedMessage(),
+                ], 400);
+            }
+
+            return redirect()
+                ->route($this->indexRoute)
+                ->with('error', $this->getDeleteFailedMessage());
+        }
+    }
+
+    protected function getIndexViewData(Request $request): array
+    {
+        return [];
+    }
+
+    protected function getCreateViewData(Request $request): array
+    {
+        return [];
+    }
+
+    protected function getEditViewData(Request $request, Model $entity): array
+    {
+        return [
+            $this->entityName => $entity,
+        ];
+    }
+
+    protected function transformPayload(array $payload, ?int $id = null): array
+    {
+        return $payload;
+    }
+
+    abstract protected function validateStore(Request $request): void;
+
+    abstract protected function validateUpdate(Request $request, int $id): void;
+
+    abstract protected function getCreateSuccessMessage(): string;
+
+    abstract protected function getUpdateSuccessMessage(): string;
+
+    abstract protected function getDestroySuccessMessage(): string;
+
+    abstract protected function getDeleteFailedMessage(): string;
+}
+

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -15,12 +15,14 @@ class Resource extends Model
     protected $fillable = [
         'type',
         'name',
+        'resource_type_id',
         'clinic_id',
         'created_by',
         'updated_by',
     ];
 
     protected $casts = [
+        'resource_type_id' => 'integer',
         'clinic_id'  => 'integer',
         'created_by' => 'integer',
         'updated_by' => 'integer',
@@ -29,5 +31,10 @@ class Resource extends Model
     public function clinic()
     {
         return $this->belongsTo(Clinic::class);
+    }
+
+    public function resourceType()
+    {
+        return $this->belongsTo(ResourceType::class);
     }
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -23,9 +23,9 @@ class Resource extends Model
 
     protected $casts = [
         'resource_type_id' => 'integer',
-        'clinic_id'  => 'integer',
-        'created_by' => 'integer',
-        'updated_by' => 'integer',
+        'clinic_id'        => 'integer',
+        'created_by'       => 'integer',
+        'updated_by'       => 'integer',
     ];
 
     public function clinic()

--- a/database/migrations/2025_09_25_130000_create_resources_table.php
+++ b/database/migrations/2025_09_25_130000_create_resources_table.php
@@ -13,11 +13,13 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->string('type');
             $table->string('name');
+            $table->unsignedBigInteger('resource_type_id');
             $table->unsignedBigInteger('clinic_id')->nullable();
             $table->timestamps();
             AuditTrailMigrationHelper::addAuditTrailColumns($table);
 
             $table->index('name');
+            $table->foreign('resource_type_id')->references('id')->on('resource_types')->onDelete('restrict');
             $table->foreign('clinic_id')->references('id')->on('clinics')->onDelete('set null');
         });
     }

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -843,7 +843,7 @@ return [
 
                 'create' => [
                     'title'       => 'Create Resource',
-                    'type'        => 'Type',
+                    'resource_type' => 'Resource Type',
                     'name'        => 'Name',
                     'save-btn'    => 'Save',
                 ],

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -2397,8 +2397,8 @@ return [
         'clinics-info' => 'Beheer klinieken',
         'resource_types' => 'Resourcetypen',
         'resource_types-info' => 'Beheer resourcetypen',
-        'resources' => 'Resources',
-        'resources-info' => 'Beheer resources',
+    'resources' => 'Resources',
+    'resources-info' => 'Beheer resources',
     ],
 
     'user' => [

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
@@ -24,6 +24,26 @@
             <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
                 <x-admin::form.control-group>
                     <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.resource_type')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="select"
+                        name="resource_type_id"
+                        rules="required|numeric"
+                        :label="trans('admin::app.settings.resources.index.create.resource_type')"
+                    >
+                        <option value="">@lang('admin::app.select')</option>
+                        @foreach ($resourceTypes as $type)
+                            <option value="{{ $type->id }}">{{ $type->name }}</option>
+                        @endforeach
+                    </x-admin::form.control-group.control>
+
+                    <x-admin::form.control-group.error control-name="resource_type_id" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
                         @lang('admin::app.settings.resources.index.create.type')
                     </x-admin::form.control-group.label>
 

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
@@ -42,21 +42,7 @@
                     <x-admin::form.control-group.error control-name="resource_type_id" />
                 </x-admin::form.control-group>
 
-                <x-admin::form.control-group>
-                    <x-admin::form.control-group.label class="required">
-                        @lang('admin::app.settings.resources.index.create.type')
-                    </x-admin::form.control-group.label>
-
-                    <x-admin::form.control-group.control
-                        type="text"
-                        name="type"
-                        rules="required|min:1|max:100"
-                        :label="trans('admin::app.settings.resources.index.create.type')"
-                        :placeholder="trans('admin::app.settings.resources.index.create.type')"
-                    />
-
-                    <x-admin::form.control-group.error control-name="type" />
-                </x-admin::form.control-group>
+                
 
                 <x-admin::form.control-group>
                     <x-admin::form.control-group.label class="required">

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
@@ -43,22 +43,7 @@
                     <x-admin::form.control-group.error control-name="resource_type_id" />
                 </x-admin::form.control-group>
 
-                <x-admin::form.control-group>
-                    <x-admin::form.control-group.label class="required">
-                        @lang('admin::app.settings.resources.index.create.type')
-                    </x-admin::form.control-group.label>
-
-                    <x-admin::form.control-group.control
-                        type="text"
-                        name="type"
-                        value="{{ old('type', $resource->type) }}"
-                        rules="required|min:1|max:100"
-                        :label="trans('admin::app.settings.resources.index.create.type')"
-                        :placeholder="trans('admin::app.settings.resources.index.create.type')"
-                    />
-
-                    <x-admin::form.control-group.error control-name="type" />
-                </x-admin::form.control-group>
+                
 
                 <x-admin::form.control-group>
                     <x-admin::form.control-group.label class="required">

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/edit.blade.php
@@ -25,6 +25,26 @@
             <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
                 <x-admin::form.control-group>
                     <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.resources.index.create.resource_type')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="select"
+                        name="resource_type_id"
+                        rules="required|numeric"
+                        :label="trans('admin::app.settings.resources.index.create.resource_type')"
+                    >
+                        <option value="">@lang('admin::app.select')</option>
+                        @foreach ($resourceTypes as $type)
+                            <option value="{{ $type->id }}" @selected(old('resource_type_id', $resource->resource_type_id) == $type->id)>{{ $type->name }}</option>
+                        @endforeach
+                    </x-admin::form.control-group.control>
+
+                    <x-admin::form.control-group.error control-name="resource_type_id" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
                         @lang('admin::app.settings.resources.index.create.type')
                     </x-admin::form.control-group.label>
 


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR introduces a `SimpleEntityController` base class to centralize common CRUD logic, significantly reducing code duplication across `ClinicController`, `ResourceController`, and `ResourceTypeController`. It also implements a new mandatory relationship, ensuring every `Resource` is associated with a `ResourceType` through updated models, migrations, validations, and UI forms.

## How To Test This?
1.  **Verify CRUD operations:** Confirm that creating, editing, and deleting Clinics, Resources, and Resource Types still functions as expected.
2.  **Resource-ResourceType relationship:**
    *   Navigate to Resource create/edit forms and ensure `Resource Type` is a required select field.
    *   Attempt to create/update a Resource without selecting a `Resource Type` and verify validation errors.
    *   Attempt to delete a `ResourceType` that is currently assigned to a `Resource` and confirm the deletion is prevented.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master 

## Tailwind Reordering
- [x] Please make sure all the Tailwind classes are reordered.

---
<a href="https://cursor.com/background-agent?bcId=bc-c14a8617-ecb9-4124-a2f1-ef0e47913fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c14a8617-ecb9-4124-a2f1-ef0e47913fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

