### PR TITLE
Create partner products entity and management screen

### DIFF
--- a/app/DataGrids/Settings/PartnerProductDataGrid.php
+++ b/app/DataGrids/Settings/PartnerProductDataGrid.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\DataGrids\Settings;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Webkul\DataGrid\DataGrid;
+
+class PartnerProductDataGrid extends DataGrid
+{
+    public function prepareQueryBuilder(): Builder
+    {
+        $queryBuilder = DB::table('partner_products')
+            ->addSelect(
+                'partner_products.id',
+                'partner_products.partner_name'
+            );
+
+        $this->addFilter('id', 'partner_products.id');
+
+        return $queryBuilder;
+    }
+
+    public function prepareColumns(): void
+    {
+        $this->addColumn([
+            'index'      => 'id',
+            'label'      => trans('admin::app.settings.partner_products.index.datagrid.id'),
+            'type'       => 'string',
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+
+        $this->addColumn([
+            'index'      => 'partner_name',
+            'type'       => 'string',
+            'label'      => trans('admin::app.settings.partner_products.index.datagrid.partner_name'),
+            'searchable' => true,
+            'filterable' => true,
+            'sortable'   => true,
+        ]);
+    }
+
+    public function prepareActions(): void
+    {
+        if (bouncer()->hasPermission('settings.partner_products.edit')) {
+            $this->addAction([
+                'index'  => 'edit',
+                'icon'   => 'icon-edit',
+                'title'  => trans('admin::app.settings.partner_products.index.datagrid.edit'),
+                'method' => 'GET',
+                'url'    => fn ($row) => route('admin.settings.partner_products.edit', $row->id),
+            ]);
+        }
+
+        if (bouncer()->hasPermission('settings.partner_products.delete')) {
+            $this->addAction([
+                'index'  => 'delete',
+                'icon'   => 'icon-delete',
+                'title'  => trans('admin::app.settings.partner_products.index.datagrid.delete'),
+                'method' => 'DELETE',
+                'url'    => fn ($row) => route('admin.settings.partner_products.delete', $row->id),
+            ]);
+        }
+    }
+}
+

--- a/app/Http/Controllers/Admin/Settings/PartnerProductController.php
+++ b/app/Http/Controllers/Admin/Settings/PartnerProductController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Settings;
+
+use App\DataGrids\Settings\PartnerProductDataGrid;
+use App\Repositories\PartnerProductRepository;
+use Illuminate\Http\Request;
+
+class PartnerProductController extends SimpleEntityController
+{
+    public function __construct(protected PartnerProductRepository $partnerProductRepository)
+    {
+        parent::__construct($partnerProductRepository);
+
+        $this->entityName = 'partner_products';
+        $this->datagridClass = PartnerProductDataGrid::class;
+        $this->indexView = 'admin::settings.partner_products.index';
+        $this->createView = 'admin::settings.partner_products.create';
+        $this->editView = 'admin::settings.partner_products.edit';
+        $this->indexRoute = 'admin.settings.partner_products.index';
+        $this->permissionPrefix = 'settings.partner_products';
+    }
+
+    protected function validateStore(Request $request): void
+    {
+        $request->validate([
+            'partner_name' => 'required|unique:partner_products,partner_name|max:100',
+            'description'  => 'nullable|string',
+        ]);
+    }
+
+    protected function validateUpdate(Request $request, int $id): void
+    {
+        $request->validate([
+            'partner_name' => 'required|max:100|unique:partner_products,partner_name,'.$id,
+            'description'  => 'nullable|string',
+        ]);
+    }
+
+    protected function getCreateSuccessMessage(): string
+    {
+        return trans('admin::app.settings.partner_products.index.create-success');
+    }
+
+    protected function getUpdateSuccessMessage(): string
+    {
+        return trans('admin::app.settings.partner_products.index.update-success');
+    }
+
+    protected function getDestroySuccessMessage(): string
+    {
+        return trans('admin::app.settings.partner_products.index.destroy-success');
+    }
+
+    protected function getDeleteFailedMessage(): string
+    {
+        return trans('admin::app.settings.partner_products.index.delete-failed');
+    }
+}
+

--- a/app/Models/PartnerProduct.php
+++ b/app/Models/PartnerProduct.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasAuditTrail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PartnerProduct extends Model
+{
+    use HasAuditTrail, HasFactory;
+
+    protected $table = 'partner_products';
+
+    protected $fillable = [
+        'partner_name',
+        'description',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'created_by' => 'integer',
+        'updated_by' => 'integer',
+    ];
+}
+

--- a/app/Repositories/PartnerProductRepository.php
+++ b/app/Repositories/PartnerProductRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\PartnerProduct;
+use Webkul\Core\Eloquent\Repository;
+
+class PartnerProductRepository extends Repository
+{
+    public function model(): string
+    {
+        return PartnerProduct::class;
+    }
+}
+

--- a/database/factories/PartnerProductFactory.php
+++ b/database/factories/PartnerProductFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PartnerProduct;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PartnerProductFactory extends Factory
+{
+    protected $model = PartnerProduct::class;
+
+    public function definition(): array
+    {
+        return [
+            'partner_name' => $this->faker->unique()->company(),
+            'description'  => $this->faker->sentence(8),
+        ];
+    }
+}
+

--- a/database/migrations/2025_09_26_120500_create_partner_products_table.php
+++ b/database/migrations/2025_09_26_120500_create_partner_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Helpers\AuditTrailMigrationHelper;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('partner_products', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('partner_name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+            AuditTrailMigrationHelper::addAuditTrailColumns($table);
+
+            $table->unique('partner_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partner_products');
+    }
+};
+

--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -320,6 +320,26 @@ return [
         'route' => ['admin.settings.clinics.delete'],
         'sort'  => 3,
     ], [
+        'key'   => 'settings.partner_products',
+        'name'  => 'Partner Products',
+        'route' => 'admin.settings.partner_products.index',
+        'sort'  => 5,
+    ], [
+        'key'   => 'settings.partner_products.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => ['admin.settings.partner_products.create', 'admin.settings.partner_products.store'],
+        'sort'  => 1,
+    ], [
+        'key'   => 'settings.partner_products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => ['admin.settings.partner_products.edit', 'admin.settings.partner_products.update'],
+        'sort'  => 2,
+    ], [
+        'key'   => 'settings.partner_products.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => ['admin.settings.partner_products.delete'],
+        'sort'  => 3,
+    ], [
         'key'   => 'settings.lead',
         'name'  => 'admin::app.acl.lead',
         'route' => ['admin.settings.pipelines.index', 'admin.settings.sources.index', 'admin.settings.types.index'],

--- a/packages/Webkul/Admin/src/Config/menu.php
+++ b/packages/Webkul/Admin/src/Config/menu.php
@@ -190,11 +190,18 @@ return [
         'sort'       => 1,
         'icon-class' => 'icon-settings-pipeline',
     ], [
+        'key'        => 'settings.partner_products',
+        'name'       => 'admin::app.layouts.partner_products',
+        'info'       => 'admin::app.layouts.partner_products-info',
+        'route'      => 'admin.settings.partner_products.index',
+        'sort'       => 2,
+        'icon-class' => 'icon-setting',
+    ], [
         'key'        => 'settings.clinics.reources',
         'name'       => 'admin::app.layouts.resources',
         'info'       => 'admin::app.layouts.resources-info',
         'route'      => 'admin.settings.resources.index',
-        'sort'       => 2
+        'sort'       => 3
         ,
         'icon-class' => 'icon-setting',
     ], [
@@ -202,7 +209,7 @@ return [
         'name'       => 'admin::app.layouts.resource_types',
         'info'       => 'admin::app.layouts.resource_types-info',
         'route'      => 'admin.settings.resource_types.index',
-        'sort'       => 3,
+        'sort'       => 4,
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.lead',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1819,6 +1819,35 @@ return [
                 'update-success'    => 'Import updated successfully.',
             ],
         ],
+
+        'partner_products' => [
+            'index' => [
+                'title'           => 'Partner Products',
+                'create-btn'      => 'Add Partner Product',
+                'create-success'  => 'Partner product created successfully.',
+                'update-success'  => 'Partner product updated successfully.',
+                'destroy-success' => 'Partner product deleted successfully.',
+                'delete-failed'   => 'Failed to delete partner product.',
+
+                'datagrid' => [
+                    'id'            => 'ID',
+                    'partner_name'  => 'Partner Name',
+                    'edit'          => 'Edit',
+                    'delete'        => 'Delete',
+                ],
+
+                'edit' => [
+                    'title' => 'Edit Partner Product',
+                ],
+
+                'create' => [
+                    'title'         => 'Create Partner Product',
+                    'partner_name'  => 'Partner Name',
+                    'description'   => 'Description',
+                    'save-btn'      => 'Save',
+                ],
+            ],
+        ],
     ],
 
     'activities' => [
@@ -2503,6 +2532,8 @@ return [
         'workflow-leads'       => 'Backoffice',
         'clinics'              => 'Clinics',
         'clinics-info'         => 'Manage clinics',
+        'partner_products'     => 'Partner Products',
+        'partner_products-info'=> 'Manage partner products',
         'resource_types'       => 'Resource Types',
         'resource_types-info'  => 'Manage resource types',
         'resources'            => 'Resources',

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -1731,6 +1731,35 @@ return [
         ],
     ],
 
+    'partner_products' => [
+        'index' => [
+            'title'           => 'Partnerproducten',
+            'create-btn'      => 'Partnerproduct toevoegen',
+            'create-success'  => 'Partnerproduct succesvol aangemaakt.',
+            'update-success'  => 'Partnerproduct succesvol bijgewerkt.',
+            'destroy-success' => 'Partnerproduct succesvol verwijderd.',
+            'delete-failed'   => 'Verwijderen van partnerproduct mislukt.',
+
+            'datagrid' => [
+                'id'            => 'ID',
+                'partner_name'  => 'Partnernaam',
+                'edit'          => 'Bewerken',
+                'delete'        => 'Verwijderen',
+            ],
+
+            'edit' => [
+                'title' => 'Partnerproduct bewerken',
+            ],
+
+            'create' => [
+                'title'         => 'Partnerproduct aanmaken',
+                'partner_name'  => 'Partnernaam',
+                'description'   => 'Omschrijving',
+                'save-btn'      => 'Opslaan',
+            ],
+        ],
+    ],
+
     'activities' => [
         'index' => [
             'title' => 'Activiteiten',
@@ -2395,6 +2424,8 @@ return [
         'workflow-leads' => 'Sales',
         'clinics' => 'Klinieken',
         'clinics-info' => 'Beheer klinieken',
+        'partner_products' => 'Partnerproducten',
+        'partner_products-info' => 'Beheer partnerproducten',
         'resource_types' => 'Resourcetypen',
         'resource_types-info' => 'Beheer resourcetypen',
     'resources' => 'Resources',

--- a/packages/Webkul/Admin/src/Resources/views/settings/partner_products/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/partner_products/create.blade.php
@@ -1,0 +1,59 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.partner_products.index.create.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.partner_products.store')" method="POST">
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.partner_products" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.partner_products.index.create.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.partner_products.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.partner_products.index.create.partner_name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="partner_name"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.partner_products.index.create.partner_name')"
+                        :placeholder="trans('admin::app.settings.partner_products.index.create.partner_name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="partner_name" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label>
+                        @lang('admin::app.settings.partner_products.index.create.description')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="textarea"
+                        name="description"
+                        :label="trans('admin::app.settings.partner_products.index.create.description')"
+                        :placeholder="trans('admin::app.settings.partner_products.index.create.description')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="description" />
+                </x-admin::form.control-group>
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/partner_products/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/partner_products/edit.blade.php
@@ -1,0 +1,62 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.partner_products.index.edit.title')
+    </x-slot>
+
+    <x-admin::form :action="route('admin.settings.partner_products.update', $partner_products->id)" method="POST">
+        @method('PUT')
+        <div class="flex flex-col gap-4">
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <div class="flex flex-col gap-2">
+                    <x-admin::breadcrumbs name="settings.partner_products" />
+
+                    <div class="text-xl font-bold dark:text-gray-300">
+                        @lang('admin::app.settings.partner_products.index.edit.title')
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-2.5">
+                    <button type="submit" class="primary-button">
+                        @lang('admin::app.settings.partner_products.index.create.save-btn')
+                    </button>
+                </div>
+            </div>
+
+            <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label class="required">
+                        @lang('admin::app.settings.partner_products.index.create.partner_name')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="text"
+                        name="partner_name"
+                        value="{{ old('partner_name', $partner_products->partner_name) }}"
+                        rules="required|min:1|max:100"
+                        :label="trans('admin::app.settings.partner_products.index.create.partner_name')"
+                        :placeholder="trans('admin::app.settings.partner_products.index.create.partner_name')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="partner_name" />
+                </x-admin::form.control-group>
+
+                <x-admin::form.control-group>
+                    <x-admin::form.control-group.label>
+                        @lang('admin::app.settings.partner_products.index.create.description')
+                    </x-admin::form.control-group.label>
+
+                    <x-admin::form.control-group.control
+                        type="textarea"
+                        name="description"
+                        value="{{ old('description', $partner_products->description) }}"
+                        :label="trans('admin::app.settings.partner_products.index.create.description')"
+                        :placeholder="trans('admin::app.settings.partner_products.index.create.description')"
+                    />
+
+                    <x-admin::form.control-group.error control-name="description" />
+                </x-admin::form.control-group>
+            </div>
+        </div>
+    </x-admin::form>
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/partner_products/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/partner_products/index.blade.php
@@ -1,0 +1,29 @@
+<x-admin::layouts>
+    <x-slot:title>
+        @lang('admin::app.settings.partner_products.index.title')
+    </x-slot>
+
+    <div class="flex flex-col gap-4">
+        <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+            <div class="flex flex-col gap-2">
+                <x-admin::breadcrumbs name="settings.partner_products" />
+
+                <div class="text-xl font-bold dark:text-gray-300">
+                    @lang('admin::app.settings.partner_products.index.title')
+                </div>
+            </div>
+
+            <div class="flex items-center gap-x-2.5">
+                @if (bouncer()->hasPermission('settings.partner_products.create'))
+                    <a href="{{ route('admin.settings.partner_products.create') }}" class="primary-button">
+                        @lang('admin::app.settings.partner_products.index.create-btn')
+                    </a>
+                @endif
+            </div>
+        </div>
+
+        <x-admin::datagrid :src="route('admin.settings.partner_products.index')" ref="datagrid" />
+    </div>
+
+</x-admin::layouts>
+

--- a/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/settings-routes.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\Settings\ClinicController;
+use App\Http\Controllers\Admin\Settings\PartnerProductController;
 use Illuminate\Support\Facades\Route;
 use Webkul\Admin\Http\Controllers\Settings\AttributeController;
 use Webkul\Admin\Http\Controllers\Settings\DataTransfer\ImportController;
@@ -61,6 +62,19 @@ Route::prefix('settings')->group(function () {
         // Some datagrid actions may send DELETE to base path; support both
         Route::delete('', 'destroy')->name('admin.settings.clinics.delete');
         Route::delete('{id}', 'destroy')->name('admin.settings.clinics.delete');
+    });
+
+    /**
+     * Partner Products routes.
+     */
+    Route::controller(PartnerProductController::class)->prefix('partner-products')->group(function () {
+        Route::get('', 'index')->name('admin.settings.partner_products.index');
+        Route::get('create', 'create')->name('admin.settings.partner_products.create');
+        Route::post('create', 'store')->name('admin.settings.partner_products.store');
+        Route::get('edit/{id}', 'edit')->name('admin.settings.partner_products.edit');
+        Route::put('edit/{id}', 'update')->name('admin.settings.partner_products.update');
+        Route::delete('', 'destroy')->name('admin.settings.partner_products.delete');
+        Route::delete('{id}', 'destroy')->name('admin.settings.partner_products.delete');
     });
 
     /**

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -220,6 +220,18 @@ Breadcrumbs::for('settings.clinics.create', function (BreadcrumbTrail $trail) {
     $trail->push(trans('admin::app.settings.clinics.index.create.title'), route('admin.settings.clinics.create'));
 });
 
+// Settings > Partner Products
+Breadcrumbs::for('settings.partner_products', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings');
+    $trail->push(trans('admin::app.layouts.partner_products'), route('admin.settings.partner_products.index'));
+});
+
+// Settings > Partner Products > Create
+Breadcrumbs::for('settings.partner_products.create', function (BreadcrumbTrail $trail) {
+    $trail->parent('settings.partner_products');
+    $trail->push(trans('admin::app.settings.partner_products.index.create.title'), route('admin.settings.partner_products.create'));
+});
+
 // Dashboard > Groups > Create Group
 Breadcrumbs::for('settings.groups.create', function (BreadcrumbTrail $trail) {
     $trail->parent('settings.groups');

--- a/tests/Feature/Settings/PartnerProductCrudTest.php
+++ b/tests/Feature/Settings/PartnerProductCrudTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PartnerProduct;
+use Webkul\Installer\Http\Middleware\CanInstall;
+
+beforeEach(function () {
+    config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
+    test()->withoutMiddleware(CanInstall::class);
+
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+});
+
+test('partner products index returns datagrid json', function () {
+    $p1 = PartnerProduct::factory()->create();
+    $p2 = PartnerProduct::factory()->create();
+
+    $response = $this->getJson(route('admin.settings.partner_products.index'));
+    $response->assertOk();
+
+    $ids = getDatagridIds($response);
+    expect($ids)->toContain($p1->id, $p2->id);
+});
+
+test('can create partner product', function () {
+    $payload = [
+        'partner_name' => 'Acme Partner',
+        'description'  => 'Great partner product',
+    ];
+
+    $response = $this->postJson(route('admin.settings.partner_products.store'), $payload);
+    $response->assertOk();
+
+    $this->assertDatabaseHas('partner_products', [
+        'partner_name' => 'Acme Partner',
+    ]);
+});
+
+test('can update partner product', function () {
+    $pp = PartnerProduct::factory()->create();
+
+    $payload = [
+        'partner_name' => 'Updated Partner Name',
+        'description'  => 'Updated description',
+        '_method'      => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.settings.partner_products.update', ['id' => $pp->id]), $payload);
+    $response->assertOk()->assertJsonPath('data.partner_name', 'Updated Partner Name');
+
+    $this->assertDatabaseHas('partner_products', [
+        'id'           => $pp->id,
+        'partner_name' => 'Updated Partner Name',
+    ]);
+});
+
+test('can delete partner product', function () {
+    $pp = PartnerProduct::factory()->create();
+
+    $response = $this->deleteJson(route('admin.settings.partner_products.delete', ['id' => $pp->id]));
+    $response->assertOk();
+
+    $this->assertDatabaseMissing('partner_products', [
+        'id' => $pp->id,
+    ]);
+});
+


### PR DESCRIPTION
## Issue Reference
<!--- No specific issue ID was provided. -->

## Description
This PR introduces the `PartnerProduct` entity and its full CRUD management interface, mirroring the existing `Clinic` entity's structure and abstractions.

Key changes include:
- **Entity & Migration:** `PartnerProduct` model with `HasAuditTrail` and a corresponding migration using `AuditTrailMigrationHelper`.
- **CRUD Screens:** Complete create, read, update, and delete (CRUD) functionality with dedicated views, controller, repository, and datagrid. Actions redirect back to the overview.
- **Navigation:** Added "Partner Products" to the admin menu under `Settings`, positioned below `Clinics`.
- **Factory & Tests:** A factory for `PartnerProduct` and a simple feature test suite for CRUD operations, following the `ClinicCrudTest` pattern.
- **Localization & ACL:** Added English and Dutch language strings, breadcrumbs, and Access Control List (ACL) entries for the new entity.

## How To Test This?
1.  Navigate to `Admin -> Settings -> Partner Products` in the admin panel.
2.  Verify that the "Partner Products" menu item is present and accessible.
3.  Test the "Add Partner Product" button to create a new partner product.
4.  Verify that existing partner products can be edited and deleted from the datagrid.
5.  Confirm that after create/edit/delete actions, the user is redirected back to the partner products overview.
6.  Run the feature tests: `php artisan test tests/Feature/Settings/PartnerProductCrudTest.php`

## Documentation
- [x] My pull request requires an update on the documentation repository.
This new feature requires documentation for its usage and location within the admin panel.

## Branch Selection
- [x] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
The `./vendor/bin/duster fix` command was requested but could not be executed due to Composer not being available in the environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-ede36f36-63ed-484c-a792-b66e4454752c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ede36f36-63ed-484c-a792-b66e4454752c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

