### PR TITLE
Manage resource schedule with audit trail

### DIFF
--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -37,4 +37,9 @@ class Resource extends Model
     {
         return $this->belongsTo(ResourceType::class);
     }
+
+    public function shifts()
+    {
+        return $this->hasMany(Shift::class);
+    }
 }

--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasAuditTrail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Shift extends BaseModel
+{
+    use HasFactory, HasAuditTrail;
+
+    protected $table = 'shifts';
+
+    protected $fillable = [
+        'resource_id',
+        'starts_at',
+        'ends_at',
+        'notes',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'resource_id' => 'integer',
+        'starts_at'   => 'datetime',
+        'ends_at'     => 'datetime',
+        'created_by'  => 'integer',
+        'updated_by'  => 'integer',
+    ];
+
+    public function resource()
+    {
+        return $this->belongsTo(Resource::class);
+    }
+}
+

--- a/database/factories/ShiftFactory.php
+++ b/database/factories/ShiftFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Resource;
+use App\Models\Shift;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Shift>
+ */
+class ShiftFactory extends Factory
+{
+    protected $model = Shift::class;
+
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('+0 days', '+1 month');
+        $end = (clone $start)->modify('+4 hours');
+
+        return [
+            'resource_id' => Resource::factory(),
+            'starts_at'   => $start,
+            'ends_at'     => $end,
+            'notes'       => $this->faker->optional()->sentence(),
+        ];
+    }
+}
+

--- a/database/migrations/2025_09_26_090000_create_shifts_table.php
+++ b/database/migrations/2025_09_26_090000_create_shifts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('shifts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('resource_id');
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->text('notes')->nullable();
+
+            // Audit trail fields
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('resource_id')
+                ->references('id')->on('resources')
+                ->onDelete('cascade');
+
+            // Optional FKs for audit users (keep nullable, do not cascade)
+            $table->foreign('created_by')->references('id')->on('users');
+            $table->foreign('updated_by')->references('id')->on('users');
+
+            $table->index(['resource_id', 'starts_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shifts');
+    }
+};
+


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Implemented a roster management system for resources, including an audit trail, by introducing a new `Shift` entity.

Key changes:
-   **`Shift` Model & Migration:** Created `app/Models/Shift.php` and `database/migrations/2025_09_26_090000_create_shifts_table.php` to define roster items with `resource_id`, `starts_at`, `ends_at`, `notes`, and audit fields (`created_by`, `updated_by`).
-   **Audit Trail:** The `Shift` model utilizes the existing `HasAuditTrail` trait for automatic `created_by` and `updated_by` population.
-   **Relationships:** Added a `hasMany` relationship for `shifts` in `app/Models/Resource.php` and a `belongsTo` relationship for `resource` in `app/Models/Shift.php`.
-   **Factory:** Added `database/factories/ShiftFactory.php` for seeding and testing.

## How To Test This?
1.  Run migrations:
    ```bash
    php artisan migrate
    ```
2.  Verify basic usage in a tinker session:
    ```php
    $resource = \App\Models\Resource::first(); // Ensure you have at least one resource
    $shift = $resource->shifts()->create([
        'starts_at' => now()->addDay(),
        'ends_at'   => now()->addDay()->addHours(4),
        'notes'     => 'Avonddienst',
    ]);
    // Check $shift->created_by and $shift->updated_by are populated (if a user is logged in)
    // Verify $shift->resource->id matches $resource->id
    ```

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-d132d2df-25ec-4111-824c-66be6adbc3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d132d2df-25ec-4111-824c-66be6adbc3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

