### PR TITLE
Update shift with clinic and resource

### DIFF
--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\HasAuditTrail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Validation\ValidationException;
 
 class Shift extends BaseModel
 {
@@ -12,6 +13,7 @@ class Shift extends BaseModel
     protected $table = 'shifts';
 
     protected $fillable = [
+        'clinic_id',
         'resource_id',
         'starts_at',
         'ends_at',
@@ -21,6 +23,7 @@ class Shift extends BaseModel
     ];
 
     protected $casts = [
+        'clinic_id'  => 'integer',
         'resource_id' => 'integer',
         'starts_at'   => 'datetime',
         'ends_at'     => 'datetime',
@@ -28,8 +31,43 @@ class Shift extends BaseModel
         'updated_by'  => 'integer',
     ];
 
+    protected static function booted()
+    {
+        static::saving(function (Shift $shift) {
+            if (! $shift->resource_id) {
+                throw ValidationException::withMessages([
+                    'resource_id' => 'Resource is verplicht voor een dienst (shift).',
+                ]);
+            }
+
+            if (! $shift->clinic_id && $shift->resource_id) {
+                $shift->clinic_id = optional(Resource::find($shift->resource_id))->clinic_id;
+            }
+
+            if (! $shift->clinic_id) {
+                throw ValidationException::withMessages([
+                    'clinic_id' => 'Clinic is verplicht voor een dienst (shift).',
+                ]);
+            }
+
+            if ($shift->resource_id) {
+                $resource = Resource::find($shift->resource_id);
+                if ($resource && $resource->clinic_id && (int) $resource->clinic_id !== (int) $shift->clinic_id) {
+                    throw ValidationException::withMessages([
+                        'resource_id' => 'Geselecteerde resource hoort niet bij de gekozen kliniek.',
+                    ]);
+                }
+            }
+        });
+    }
+
     public function resource()
     {
         return $this->belongsTo(Resource::class);
+    }
+
+    public function clinic()
+    {
+        return $this->belongsTo(Clinic::class);
     }
 }

--- a/database/factories/ShiftFactory.php
+++ b/database/factories/ShiftFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Resource;
+use App\Models\Clinic;
 use App\Models\Shift;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -19,6 +20,7 @@ class ShiftFactory extends Factory
         $end = (clone $start)->modify('+4 hours');
 
         return [
+            'clinic_id'  => Clinic::factory(),
             'resource_id' => Resource::factory(),
             'starts_at'   => $start,
             'ends_at'     => $end,

--- a/database/migrations/2025_09_26_090000_create_shifts_table.php
+++ b/database/migrations/2025_09_26_090000_create_shifts_table.php
@@ -10,6 +10,7 @@ return new class extends Migration
     {
         Schema::create('shifts', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('clinic_id');
             $table->unsignedBigInteger('resource_id');
             $table->dateTime('starts_at');
             $table->dateTime('ends_at');
@@ -21,15 +22,14 @@ return new class extends Migration
 
             $table->timestamps();
 
-            $table->foreign('resource_id')
-                ->references('id')->on('resources')
-                ->onDelete('cascade');
+            $table->foreign('clinic_id')->references('id')->on('clinics')->onDelete('cascade');
+            $table->foreign('resource_id')->references('id')->on('resources')->onDelete('cascade');
 
             // Optional FKs for audit users (keep nullable, do not cascade)
             $table->foreign('created_by')->references('id')->on('users');
             $table->foreign('updated_by')->references('id')->on('users');
 
-            $table->index(['resource_id', 'starts_at']);
+            $table->index(['clinic_id', 'resource_id', 'starts_at']);
         });
     }
 

--- a/database/migrations/2025_09_30_090500_add_clinic_id_to_shifts_table.php
+++ b/database/migrations/2025_09_30_090500_add_clinic_id_to_shifts_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Resource;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('shifts', 'clinic_id')) {
+            Schema::table('shifts', function (Blueprint $table) {
+                $table->unsignedBigInteger('clinic_id')->nullable()->after('id');
+            });
+
+            // Backfill clinic_id from resource's clinic
+            DB::table('shifts')->orderBy('id')->chunkById(1000, function ($rows) {
+                foreach ($rows as $row) {
+                    if (! $row->resource_id) {
+                        continue;
+                    }
+
+                    $clinicId = DB::table('resources')->where('id', $row->resource_id)->value('clinic_id');
+
+                    if ($clinicId) {
+                        DB::table('shifts')->where('id', $row->id)->update(['clinic_id' => $clinicId]);
+                    }
+                }
+            });
+
+            Schema::table('shifts', function (Blueprint $table) {
+                $table->unsignedBigInteger('clinic_id')->nullable(false)->change();
+                $table->foreign('clinic_id')->references('id')->on('clinics')->onDelete('cascade');
+                $table->index(['clinic_id', 'resource_id', 'starts_at']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('shifts', 'clinic_id')) {
+            Schema::table('shifts', function (Blueprint $table) {
+                $table->dropForeign(['clinic_id']);
+                $table->dropIndex(['clinic_id', 'resource_id', 'starts_at']);
+                $table->dropColumn('clinic_id');
+            });
+        }
+    }
+};
+


### PR DESCRIPTION
## Issue Reference
N/A

## Description
This PR implements the requirement for a `Shift` to have a mandatory `Clinic` and a `Resource`.

Key changes include:
-   **`Shift` Model:** Added `clinic_id` and a `belongsTo` relationship to `Clinic`.
-   **Model Validation:** Implemented `saving` event listener to enforce:
    -   `resource_id` is always present.
    -   `clinic_id` is always present (attempting to backfill from `resource.clinic_id` if missing).
    -   The `Shift`'s `clinic_id` is consistent with its associated `Resource`'s `clinic_id`.
-   **Migrations:**
    -   The base `create_shifts_table` migration was updated to include `clinic_id`.
    -   A new migration (`add_clinic_id_to_shifts_table`) was created to safely add `clinic_id` to existing `shifts` tables, backfill the `clinic_id` from the associated `resource`'s `clinic_id`, and then make the column non-nullable.
-   **`ShiftFactory`:** Updated to include `clinic_id` when creating new shifts.

**Important Notes:**
-   **Migrations Blocked:** I was unable to run `composer install` and `php artisan migrate` due to environment limitations. These commands **must be run manually** to apply the database changes.
-   **UI Blocked:** I could not locate any Shift CRUD screens or routes to add the required clinic and resource selectors. Please provide the paths if these screens exist.

## How To Test This?
1.  Run `composer install` and `php artisan migrate` to apply the database schema changes and backfill existing data.
2.  Attempt to create or update a `Shift` (e.g., via a factory or directly through the model):
    *   Verify that creating a `Shift` without a `resource_id` or `clinic_id` results in a validation error.
    *   Verify that creating a `Shift` where its `clinic_id` does not match the `clinic_id` of its selected `resource` results in a validation error.
3.  Confirm that existing `Shift` records (created before this migration) have their `clinic_id` correctly backfilled based on their associated `resource`'s `clinic_id`.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-8a9dcd18-6974-46b7-af38-41825dc79e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a9dcd18-6974-46b7-af38-41825dc79e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

