### PR TITLE
Summarize and consolidate schedule shifts

### DIFF
--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -31,13 +31,107 @@ class ResourceController extends SimpleEntityController
     public function show(int $id): View
     {
         $resource = $this->resourceRepository->findOrFail($id);
-        $upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
+		$upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
 
-        return view('admin::settings.resources.show', [
+		$scheduleSummary = $this->buildMergedWeeklySummary($upcomingShifts->all());
+
+		return view('admin::settings.resources.show', [
             'resource'       => $resource,
             'upcomingShifts' => $upcomingShifts,
+			'scheduleSummary'=> $scheduleSummary,
         ]);
     }
+
+	/**
+	 * Build a merged weekly summary of availability/unavailability.
+	 *
+	 * @param array<int, \App\Models\Shift> $shifts
+	 * @return array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>
+	 */
+	protected function buildMergedWeeklySummary(array $shifts): array
+	{
+		// Initialize summary for days 1..7 (Mon..Sun)
+		$summary = [];
+		for ($day = 1; $day <= 7; $day++) {
+			$summary[$day] = [
+				'available' => [],
+				'unavailable' => [],
+			];
+		}
+
+		foreach ($shifts as $shift) {
+			$blocksByDay = (array) ($shift->weekday_time_blocks ?? []);
+			$available = (bool) ($shift->available ?? true);
+
+			foreach ($blocksByDay as $day => $blocks) {
+				if (!is_array($blocks)) {
+					continue;
+				}
+
+				foreach ($blocks as $block) {
+					$from = isset($block['from']) ? (string) $block['from'] : null;
+					$to = isset($block['to']) ? (string) $block['to'] : null;
+					if (!$from || !$to) {
+						continue;
+					}
+
+					$entry = ['from' => $from, 'to' => $to];
+					if ($available) {
+						$summary[$day]['available'][] = $entry;
+					} else {
+						$summary[$day]['unavailable'][] = $entry;
+					}
+				}
+			}
+		}
+
+		// Merge overlaps inside each day's available/unavailable lists
+		for ($day = 1; $day <= 7; $day++) {
+			$summary[$day]['available'] = $this->mergeOverlappingTimeRanges($summary[$day]['available']);
+			$summary[$day]['unavailable'] = $this->mergeOverlappingTimeRanges($summary[$day]['unavailable']);
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Merge overlapping time ranges within a single day.
+	 *
+	 * Input/Output format: array of ['from' => 'HH:MM', 'to' => 'HH:MM']
+	 *
+	 * @param array<int, array{from: string, to: string}> $ranges
+	 * @return array<int, array{from: string, to: string}>
+	 */
+	protected function mergeOverlappingTimeRanges(array $ranges): array
+	{
+		if (empty($ranges)) {
+			return [];
+		}
+
+		usort($ranges, function ($a, $b) {
+			return strcmp($a['from'], $b['from']);
+		});
+
+		$merged = [];
+		$current = $ranges[0];
+
+		for ($i = 1; $i < count($ranges); $i++) {
+			$next = $ranges[$i];
+			if ($next['from'] <= $current['to']) {
+				// Overlaps or touches: extend the current range
+				if ($next['to'] > $current['to']) {
+					$current['to'] = $next['to'];
+				}
+			} else {
+				$merged[] = $current;
+				$current = $next;
+			}
+		}
+
+		$merged[] = $current;
+
+		return $merged;
+	}
 
     protected function getCreateViewData(Request $request): array
     {

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
@@ -34,22 +34,51 @@
                 <div class="relative w-full overflow-x-auto">
                     <div class="min-w-[640px]">
                         <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-                            <div>@lang('admin::app.settings.resources.show.upcoming')</div>
+                            <div>Samenvatting van roosters (samengevoegd)</div>
                         </div>
                         <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
-                            @forelse($upcomingShifts as $shift)
-                                <div class="flex items-center justify-between py-2 text-sm">
-                                    <div class="flex items-center gap-2">
-                                        <span class="h-2 w-2 rounded-full bg-green-500"></span>
-                                        <span>{{ \Carbon\Carbon::parse($shift->starts_at)->format('d-m-Y H:i') }}</span>
-                                        <span class="mx-1">→</span>
-                                        <span>{{ \Carbon\Carbon::parse($shift->ends_at)->format('d-m-Y H:i') }}</span>
+                            @php
+                                $dayNames = [
+                                    1 => trans('admin::app.monday'),
+                                    2 => trans('admin::app.tuesday'),
+                                    3 => trans('admin::app.wednesday'),
+                                    4 => trans('admin::app.thursday'),
+                                    5 => trans('admin::app.friday'),
+                                    6 => trans('admin::app.saturday'),
+                                    7 => trans('admin::app.sunday'),
+                                ];
+                            @endphp
+
+                            @for($day = 1; $day <= 7; $day++)
+                                @php
+                                    $daySummary = $scheduleSummary[$day] ?? ['available' => [], 'unavailable' => []];
+                                    $available = $daySummary['available'] ?? [];
+                                    $unavailable = $daySummary['unavailable'] ?? [];
+                                @endphp
+                                <div class="py-3 text-sm">
+                                    <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
+                                    <div class="mb-1 flex flex-wrap items-center gap-2">
+                                        <span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">Beschikbaar</span>
+                                        @if (count($available))
+                                            @foreach($available as $range)
+                                                <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                                            @endforeach
+                                        @else
+                                            <span class="text-xs text-gray-500">—</span>
+                                        @endif
                                     </div>
-                                    <div class="truncate text-gray-600 dark:text-gray-300">{{ $shift->notes }}</div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
+                                        @if (count($unavailable))
+                                            @foreach($unavailable as $range)
+                                                <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                                            @endforeach
+                                        @else
+                                            <span class="text-xs text-gray-500">—</span>
+                                        @endif
+                                    </div>
                                 </div>
-                            @empty
-                                <div class="py-6 text-center text-gray-500">@lang('admin::app.settings.resources.show.no-upcoming')</div>
-                            @endforelse
+                            @endfor
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
The previous roster view on the resource detail page listed individual shifts, making it difficult to quickly grasp the overall availability. This PR introduces a summarized view for the resource's schedule. It merges overlapping or consecutive time blocks for both available and unavailable periods, presenting a clear, per-weekday overview. This allows users to easily verify the resource's schedule at a glance without needing to review each separate shift entry.

## How To Test This?
1.  Navigate to `admin/settings/resources/{resource_id}/bekijken` for a resource with defined upcoming shifts.
2.  Observe the "Samenvatting van roosters" section.
3.  Verify that time blocks for 'Beschikbaar' (Available) and 'Niet beschikbaar' (Unavailable) are merged where they overlap or touch.
4.  Confirm that available blocks are displayed in green badges and unavailable blocks in red badges, grouped by weekday.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-95a5bcab-72f4-438f-a5d6-38574c120014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95a5bcab-72f4-438f-a5d6-38574c120014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

