### PR TITLE
Summarize and merge overlapping shifts for schedule clarity

### DIFF
--- a/.cursor/config.json
+++ b/.cursor/config.json
@@ -1,0 +1,5 @@
+{
+    "defaultPrompts": {
+        "pr": "Controleer en voer de volgende stappen altijd uit bij een PR:\n\n1. **CI artifacts**\n   - Controleer of er een artifact `ci_errors.txt` aanwezig is vanuit de build.\n   - Verwijs in de PR-review naar de gevonden fouten of bevestig dat er geen fouten waren.\n\n2. **Class diagram in AsciiDoc**\n   - Het class diagram (`.adoc`) is leidend.\n   - Als er een verzoek is om een nieuw veld toe te voegen, werk dan ook het class diagram bij zodat dit consistent blijft.\n\n3. **Nieuwe entiteiten**\n   - Voeg altijd de trait `HasAuditTrail` toe.\n   - Maak een migratie met gebruik van `AuditTrailMigrationHelper`.\n   - Voeg een factory toe voor de nieuwe entiteit.\n   - Maak een CRUD-test aan, neem `ClinicCrudTest` als voorbeeld (in dezelfde syntax).\n   - Voor de CRUD-schermen: gebruik de implementatie van `Clinic` als voorbeeld voor een eenvoudige entiteit.\n\n4. **Code formatting**\n   - Voer aan het einde het commando uit: `./vendor/bin/duster fix`."
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         run: npm run build
 
       - name: Run backend tests
-        run: php artisan test --parallel --colors=always
+        run: |
+          set -o pipefail
+          php artisan test --parallel --colors=always --log-junit backend_junit.xml | tee backend_tests.txt
 
       - name: Start Laravel server
         run: php artisan serve --host=0.0.0.0 --port=8000 &
@@ -89,6 +91,27 @@ jobs:
         run: dotnet build ./UiTests/UiTests.csproj --configuration Release --nologo
 
       - name: Run UI tests
-        run: dotnet test ./UiTests/UiTests.csproj --configuration Release --no-build --logger "trx;LogFileName=test_results.trx"
+        run: |
+          set -o pipefail
+          dotnet test ./UiTests/UiTests.csproj --configuration Release --no-build --logger "trx;LogFileName=test_results.trx" | tee ui_tests.txt
         env:
           TestSettings__BaseUrl: http://localhost:8000
+
+      - name: Collect Laravel log (if exists)
+        if: always()
+        run: |
+          if [ -f storage/logs/laravel.log ]; then
+            cp storage/logs/laravel.log laravel.log || true
+          fi
+
+      - name: Upload CI error artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-errors
+          path: |
+            backend_tests.txt
+            backend_junit.xml
+            ui_tests.txt
+            test_results.trx
+            laravel.log

--- a/app/DataGrids/Settings/ShiftDataGrid.php
+++ b/app/DataGrids/Settings/ShiftDataGrid.php
@@ -25,7 +25,7 @@ class ShiftDataGrid extends DataGrid
 
         $queryBuilder = DB::table('shifts')
             ->where('shifts.resource_id', $resourceId)
-            ->addSelect('shifts.id', 'shifts.period_start', 'shifts.period_end', 'shifts.notes', 'shifts.weekday_time_blocks');
+            ->addSelect('shifts.id', 'shifts.period_start', 'shifts.period_end', 'shifts.notes', 'shifts.weekday_time_blocks', 'shifts.available');
 
         $this->addFilter('id', 'shifts.id');
 
@@ -36,6 +36,22 @@ class ShiftDataGrid extends DataGrid
 
     public function prepareColumns(): void
     {
+        $this->addColumn([
+            'index'      => 'available',
+            'label'      => trans('admin::app.settings.shifts.fields.available'),
+            'type'       => 'boolean',
+            'searchable' => false,
+            'filterable' => true,
+            'sortable'   => false,
+            'closure'    => function ($row) {
+                $isAvailable = (bool) ($row->available ?? false);
+                return $isAvailable
+                    ? "<span class='icon-tick text-green-600 text-lg' title='" . e(trans('admin::app.settings.shifts.fields.available')) . "'></span>"
+                    : "<span class='icon-cross-large text-red-600 text-lg' title='" . e(trans('admin::app.settings.shifts.fields.available')) . "'></span>";
+            },
+            'escape'     => false,
+        ]);
+
         $this->addColumn([
             'index'      => 'id',
             'label'      => trans('admin::app.settings.shifts.datagrid.id'),

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -35,17 +35,17 @@ class ResourceController extends SimpleEntityController
         $resource = $this->resourceRepository->findOrFail($id);
 		$upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
 
-		$scheduleSummary = $this->buildMergedWeeklySummary($upcomingShifts->all());
+		$periodSummaries = $this->buildPeriodAwareWeeklySummaries($upcomingShifts->all());
 
 		return view('admin::settings.resources.show', [
             'resource'       => $resource,
             'upcomingShifts' => $upcomingShifts,
-			'scheduleSummary'=> $scheduleSummary,
+			'periodSummaries' => $periodSummaries,
         ]);
     }
 
 	/**
-	 * Build a merged weekly summary of availability/unavailability.
+	 * Build a merged weekly summary of availability/unavailability (legacy, without period awareness).
 	 *
 	 * @param array<int, \App\Models\Shift> $shifts
 	 * @return array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>
@@ -94,6 +94,116 @@ class ResourceController extends SimpleEntityController
 		}
 
 		return $summary;
+	}
+
+	/**
+	 * Build per-period weekly summaries by segmenting overlapping date periods
+	 * into non-overlapping ranges with a constant set of active shifts.
+	 *
+	 * @param array<int, \App\Models\Shift> $shifts
+	 * @return array<int, array{label: string, start: ?string, end: ?string, summary: array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>}>
+	 */
+	protected function buildPeriodAwareWeeklySummaries(array $shifts): array
+	{
+		if (empty($shifts)) {
+			return [];
+		}
+
+		// Collect timeline boundary events: start at period_start, end at day after period_end
+		$events = [];
+		$today = now()->startOfDay();
+		$maxLookahead = $today->copy()->addMonths(18); // cap open-ended at 18 months for display
+
+		foreach ($shifts as $idx => $shift) {
+			$start = optional($shift->period_start)->startOfDay() ?? $today;
+			$end = $shift->period_end ? $shift->period_end->copy()->addDay()->startOfDay() : null; // end exclusive
+
+			// Ignore fully past periods
+			if ($shift->period_end && $shift->period_end->lt($today)) {
+				continue;
+			}
+
+			$events[] = ['date' => $start, 'type' => 'start', 'idx' => $idx];
+			if ($end) {
+				$events[] = ['date' => $end, 'type' => 'end', 'idx' => $idx];
+			}
+		}
+
+		if (empty($events)) {
+			return [];
+		}
+
+		usort($events, function ($a, $b) {
+			if ($a['date']->eq($b['date'])) {
+				return $a['type'] === 'end' ? -1 : 1; // end before start on same day
+			}
+			return $a['date'] <=> $b['date'];
+		});
+
+		$active = [];
+		$segments = [];
+		for ($i = 0; $i < count($events); $i++) {
+			$event = $events[$i];
+			$date = $event['date'];
+			$type = $event['type'];
+			$idx  = $event['idx'];
+
+			if ($type === 'end') {
+				unset($active[$idx]);
+			} else {
+				$active[$idx] = true;
+			}
+
+			$nextDate = $i + 1 < count($events) ? $events[$i + 1]['date'] : $maxLookahead;
+			if (!empty($active) && $date < $nextDate) {
+				$segmentShiftIndexes = array_keys($active);
+				$segments[] = [
+					'from' => $date->copy(),
+					'to'   => $nextDate ? $nextDate->copy() : null,
+					'shifts' => $segmentShiftIndexes,
+				];
+			}
+		}
+
+		// Merge adjacent segments with identical active shift sets
+		$normalized = [];
+		foreach ($segments as $seg) {
+			$signature = implode(',', $seg['shifts']);
+			$last = end($normalized);
+			if ($last !== false && $last['signature'] === $signature && $last['to']->eq($seg['from'])) {
+				$normalized[key($normalized)]['to'] = $seg['to'];
+			} else {
+				$normalized[] = [
+					'from' => $seg['from'],
+					'to' => $seg['to'],
+					'shifts' => $seg['shifts'],
+					'signature' => $signature,
+				];
+			}
+		}
+
+		$result = [];
+		foreach ($normalized as $seg) {
+			$segmentShifts = [];
+			foreach ($seg['shifts'] as $sIdx) {
+				$segmentShifts[] = $shifts[$sIdx];
+			}
+
+			$summary = $this->buildMergedWeeklySummary($segmentShifts);
+
+			$fromStr = $seg['from'] ? $seg['from']->format('Y-m-d') : null;
+			$toStr = $seg['to'] ? $seg['to']->copy()->subDay()->format('Y-m-d') : null; // convert exclusive end back to inclusive
+			$label = $fromStr && $toStr ? ($fromStr . ' — ' . $toStr) : ($fromStr . ' — ∞');
+
+			$result[] = [
+				'label' => $label,
+				'start' => $fromStr,
+				'end' => $toStr,
+				'summary' => $summary,
+			];
+		}
+
+		return $result;
 	}
 
 	/**

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -124,11 +124,6 @@ class ResourceController extends SimpleEntityController
             $start = optional($shift->period_start)->startOfDay() ?? $today;
             $end = $shift->period_end ? $shift->period_end->copy()->addDay()->startOfDay() : null; // end exclusive
 
-            // Ignore fully past periods
-            if ($shift->period_end && $shift->period_end->lt($today)) {
-                continue;
-            }
-
             $events[] = ['date' => $start, 'type' => 'start', 'idx' => $idx];
             if ($end) {
                 $events[] = ['date' => $end, 'type' => 'end', 'idx' => $idx];

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -33,217 +33,218 @@ class ResourceController extends SimpleEntityController
     public function show(int $id): View
     {
         $resource = $this->resourceRepository->findOrFail($id);
-		$upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
+        $upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
 
-		$periodSummaries = $this->buildPeriodAwareWeeklySummaries($upcomingShifts->all());
+        $periodSummaries = $this->buildPeriodAwareWeeklySummaries($upcomingShifts->all());
 
-		return view('admin::settings.resources.show', [
-            'resource'       => $resource,
-            'upcomingShifts' => $upcomingShifts,
-			'periodSummaries' => $periodSummaries,
+        return view('admin::settings.resources.show', [
+            'resource'        => $resource,
+            'upcomingShifts'  => $upcomingShifts,
+            'periodSummaries' => $periodSummaries,
         ]);
     }
 
-	/**
-	 * Build a merged weekly summary of availability/unavailability (legacy, without period awareness).
-	 *
-	 * @param array<int, \App\Models\Shift> $shifts
-	 * @return array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>
-	 */
-	protected function buildMergedWeeklySummary(array $shifts): array
-	{
-		// Initialize summary for days 1..7 (Mon..Sun)
-		$summary = [];
-		for ($day = 1; $day <= 7; $day++) {
-			$summary[$day] = [
-				'available' => [],
-				'unavailable' => [],
-			];
-		}
+    /**
+     * Build a merged weekly summary of availability/unavailability (legacy, without period awareness).
+     *
+     * @param  array<int, \App\Models\Shift>  $shifts
+     * @return array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>
+     */
+    protected function buildMergedWeeklySummary(array $shifts): array
+    {
+        // Initialize summary for days 1..7 (Mon..Sun)
+        $summary = [];
+        for ($day = 1; $day <= 7; $day++) {
+            $summary[$day] = [
+                'available'   => [],
+                'unavailable' => [],
+            ];
+        }
 
-		foreach ($shifts as $shift) {
-			$blocksByDay = (array) ($shift->weekday_time_blocks ?? []);
-			$available = (bool) ($shift->available ?? true);
+        foreach ($shifts as $shift) {
+            $blocksByDay = (array) ($shift->weekday_time_blocks ?? []);
+            $available = (bool) ($shift->available ?? true);
 
-			foreach ($blocksByDay as $day => $blocks) {
-				if (!is_array($blocks)) {
-					continue;
-				}
+            foreach ($blocksByDay as $day => $blocks) {
+                if (! is_array($blocks)) {
+                    continue;
+                }
 
-				foreach ($blocks as $block) {
-					$from = isset($block['from']) ? (string) $block['from'] : null;
-					$to = isset($block['to']) ? (string) $block['to'] : null;
-					if (!$from || !$to) {
-						continue;
-					}
+                foreach ($blocks as $block) {
+                    $from = isset($block['from']) ? (string) $block['from'] : null;
+                    $to = isset($block['to']) ? (string) $block['to'] : null;
+                    if (! $from || ! $to) {
+                        continue;
+                    }
 
-					$entry = ['from' => $from, 'to' => $to];
-					if ($available) {
-						$summary[$day]['available'][] = $entry;
-					} else {
-						$summary[$day]['unavailable'][] = $entry;
-					}
-				}
-			}
-		}
+                    $entry = ['from' => $from, 'to' => $to];
+                    if ($available) {
+                        $summary[$day]['available'][] = $entry;
+                    } else {
+                        $summary[$day]['unavailable'][] = $entry;
+                    }
+                }
+            }
+        }
 
-		// Merge overlaps inside each day's available/unavailable lists
-		for ($day = 1; $day <= 7; $day++) {
-			$summary[$day]['available'] = $this->mergeOverlappingTimeRanges($summary[$day]['available']);
-			$summary[$day]['unavailable'] = $this->mergeOverlappingTimeRanges($summary[$day]['unavailable']);
-		}
+        // Merge overlaps inside each day's available/unavailable lists
+        for ($day = 1; $day <= 7; $day++) {
+            $summary[$day]['available'] = $this->mergeOverlappingTimeRanges($summary[$day]['available']);
+            $summary[$day]['unavailable'] = $this->mergeOverlappingTimeRanges($summary[$day]['unavailable']);
+        }
 
-		return $summary;
-	}
+        return $summary;
+    }
 
-	/**
-	 * Build per-period weekly summaries by segmenting overlapping date periods
-	 * into non-overlapping ranges with a constant set of active shifts.
-	 *
-	 * @param array<int, \App\Models\Shift> $shifts
-	 * @return array<int, array{label: string, start: ?string, end: ?string, summary: array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>}>
-	 */
-	protected function buildPeriodAwareWeeklySummaries(array $shifts): array
-	{
-		if (empty($shifts)) {
-			return [];
-		}
+    /**
+     * Build per-period weekly summaries by segmenting overlapping date periods
+     * into non-overlapping ranges with a constant set of active shifts.
+     *
+     * @param  array<int, \App\Models\Shift>  $shifts
+     * @return array<int, array{label: string, start: ?string, end: ?string, summary: array<int, array{available: array<int, array{from: string, to: string}>, unavailable: array<int, array{from: string, to: string}>}>}>
+     */
+    protected function buildPeriodAwareWeeklySummaries(array $shifts): array
+    {
+        if (empty($shifts)) {
+            return [];
+        }
 
-		// Collect timeline boundary events: start at period_start, end at day after period_end
-		$events = [];
-		$today = now()->startOfDay();
-		$maxLookahead = $today->copy()->addMonths(18); // cap open-ended at 18 months for display
+        // Collect timeline boundary events: start at period_start, end at day after period_end
+        $events = [];
+        $today = now()->startOfDay();
+        $maxLookahead = $today->copy()->addMonths(18); // cap open-ended at 18 months for display
 
-		foreach ($shifts as $idx => $shift) {
-			$start = optional($shift->period_start)->startOfDay() ?? $today;
-			$end = $shift->period_end ? $shift->period_end->copy()->addDay()->startOfDay() : null; // end exclusive
+        foreach ($shifts as $idx => $shift) {
+            $start = optional($shift->period_start)->startOfDay() ?? $today;
+            $end = $shift->period_end ? $shift->period_end->copy()->addDay()->startOfDay() : null; // end exclusive
 
-			// Ignore fully past periods
-			if ($shift->period_end && $shift->period_end->lt($today)) {
-				continue;
-			}
+            // Ignore fully past periods
+            if ($shift->period_end && $shift->period_end->lt($today)) {
+                continue;
+            }
 
-			$events[] = ['date' => $start, 'type' => 'start', 'idx' => $idx];
-			if ($end) {
-				$events[] = ['date' => $end, 'type' => 'end', 'idx' => $idx];
-			}
-		}
+            $events[] = ['date' => $start, 'type' => 'start', 'idx' => $idx];
+            if ($end) {
+                $events[] = ['date' => $end, 'type' => 'end', 'idx' => $idx];
+            }
+        }
 
-		if (empty($events)) {
-			return [];
-		}
+        if (empty($events)) {
+            return [];
+        }
 
-		usort($events, function ($a, $b) {
-			if ($a['date']->eq($b['date'])) {
-				return $a['type'] === 'end' ? -1 : 1; // end before start on same day
-			}
-			return $a['date'] <=> $b['date'];
-		});
+        usort($events, function ($a, $b) {
+            if ($a['date']->eq($b['date'])) {
+                return $a['type'] === 'end' ? -1 : 1; // end before start on same day
+            }
 
-		$active = [];
-		$segments = [];
-		for ($i = 0; $i < count($events); $i++) {
-			$event = $events[$i];
-			$date = $event['date'];
-			$type = $event['type'];
-			$idx  = $event['idx'];
+            return $a['date'] <=> $b['date'];
+        });
 
-			if ($type === 'end') {
-				unset($active[$idx]);
-			} else {
-				$active[$idx] = true;
-			}
+        $active = [];
+        $segments = [];
+        for ($i = 0; $i < count($events); $i++) {
+            $event = $events[$i];
+            $date = $event['date'];
+            $type = $event['type'];
+            $idx = $event['idx'];
 
-			$nextDate = $i + 1 < count($events) ? $events[$i + 1]['date'] : $maxLookahead;
-			if (!empty($active) && $date < $nextDate) {
-				$segmentShiftIndexes = array_keys($active);
-				$segments[] = [
-					'from' => $date->copy(),
-					'to'   => $nextDate ? $nextDate->copy() : null,
-					'shifts' => $segmentShiftIndexes,
-				];
-			}
-		}
+            if ($type === 'end') {
+                unset($active[$idx]);
+            } else {
+                $active[$idx] = true;
+            }
 
-		// Merge adjacent segments with identical active shift sets
-		$normalized = [];
-		foreach ($segments as $seg) {
-			$signature = implode(',', $seg['shifts']);
-			$last = end($normalized);
-			if ($last !== false && $last['signature'] === $signature && $last['to']->eq($seg['from'])) {
-				$normalized[key($normalized)]['to'] = $seg['to'];
-			} else {
-				$normalized[] = [
-					'from' => $seg['from'],
-					'to' => $seg['to'],
-					'shifts' => $seg['shifts'],
-					'signature' => $signature,
-				];
-			}
-		}
+            $nextDate = $i + 1 < count($events) ? $events[$i + 1]['date'] : $maxLookahead;
+            if (! empty($active) && $date < $nextDate) {
+                $segmentShiftIndexes = array_keys($active);
+                $segments[] = [
+                    'from'   => $date->copy(),
+                    'to'     => $nextDate ? $nextDate->copy() : null,
+                    'shifts' => $segmentShiftIndexes,
+                ];
+            }
+        }
 
-		$result = [];
-		foreach ($normalized as $seg) {
-			$segmentShifts = [];
-			foreach ($seg['shifts'] as $sIdx) {
-				$segmentShifts[] = $shifts[$sIdx];
-			}
+        // Merge adjacent segments with identical active shift sets
+        $normalized = [];
+        foreach ($segments as $seg) {
+            $signature = implode(',', $seg['shifts']);
+            $last = end($normalized);
+            if ($last !== false && $last['signature'] === $signature && $last['to']->eq($seg['from'])) {
+                $normalized[key($normalized)]['to'] = $seg['to'];
+            } else {
+                $normalized[] = [
+                    'from'      => $seg['from'],
+                    'to'        => $seg['to'],
+                    'shifts'    => $seg['shifts'],
+                    'signature' => $signature,
+                ];
+            }
+        }
 
-			$summary = $this->buildMergedWeeklySummary($segmentShifts);
+        $result = [];
+        foreach ($normalized as $seg) {
+            $segmentShifts = [];
+            foreach ($seg['shifts'] as $sIdx) {
+                $segmentShifts[] = $shifts[$sIdx];
+            }
 
-			$fromStr = $seg['from'] ? $seg['from']->format('Y-m-d') : null;
-			$toStr = $seg['to'] ? $seg['to']->copy()->subDay()->format('Y-m-d') : null; // convert exclusive end back to inclusive
-			$label = $fromStr && $toStr ? ($fromStr . ' — ' . $toStr) : ($fromStr . ' — ∞');
+            $summary = $this->buildMergedWeeklySummary($segmentShifts);
 
-			$result[] = [
-				'label' => $label,
-				'start' => $fromStr,
-				'end' => $toStr,
-				'summary' => $summary,
-			];
-		}
+            $fromStr = $seg['from'] ? $seg['from']->format('Y-m-d') : null;
+            $toStr = $seg['to'] ? $seg['to']->copy()->subDay()->format('Y-m-d') : null; // convert exclusive end back to inclusive
+            $label = $fromStr && $toStr ? ($fromStr.' — '.$toStr) : ($fromStr.' — ∞');
 
-		return $result;
-	}
+            $result[] = [
+                'label'   => $label,
+                'start'   => $fromStr,
+                'end'     => $toStr,
+                'summary' => $summary,
+            ];
+        }
 
-	/**
-	 * Merge overlapping time ranges within a single day.
-	 *
-	 * Input/Output format: array of ['from' => 'HH:MM', 'to' => 'HH:MM']
-	 *
-	 * @param array<int, array{from: string, to: string}> $ranges
-	 * @return array<int, array{from: string, to: string}>
-	 */
-	protected function mergeOverlappingTimeRanges(array $ranges): array
-	{
-		if (empty($ranges)) {
-			return [];
-		}
+        return $result;
+    }
 
-		usort($ranges, function ($a, $b) {
-			return strcmp($a['from'], $b['from']);
-		});
+    /**
+     * Merge overlapping time ranges within a single day.
+     *
+     * Input/Output format: array of ['from' => 'HH:MM', 'to' => 'HH:MM']
+     *
+     * @param  array<int, array{from: string, to: string}>  $ranges
+     * @return array<int, array{from: string, to: string}>
+     */
+    protected function mergeOverlappingTimeRanges(array $ranges): array
+    {
+        if (empty($ranges)) {
+            return [];
+        }
 
-		$merged = [];
-		$current = $ranges[0];
+        usort($ranges, function ($a, $b) {
+            return strcmp($a['from'], $b['from']);
+        });
 
-		for ($i = 1; $i < count($ranges); $i++) {
-			$next = $ranges[$i];
-			if ($next['from'] <= $current['to']) {
-				// Overlaps or touches: extend the current range
-				if ($next['to'] > $current['to']) {
-					$current['to'] = $next['to'];
-				}
-			} else {
-				$merged[] = $current;
-				$current = $next;
-			}
-		}
+        $merged = [];
+        $current = $ranges[0];
 
-		$merged[] = $current;
+        for ($i = 1; $i < count($ranges); $i++) {
+            $next = $ranges[$i];
+            if ($next['from'] <= $current['to']) {
+                // Overlaps or touches: extend the current range
+                if ($next['to'] > $current['to']) {
+                    $current['to'] = $next['to'];
+                }
+            } else {
+                $merged[] = $current;
+                $current = $next;
+            }
+        }
 
-		return $merged;
-	}
+        $merged[] = $current;
+
+        return $merged;
+    }
 
     protected function getCreateViewData(Request $request): array
     {

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -33,13 +33,16 @@ class ResourceController extends SimpleEntityController
     public function show(int $id): View
     {
         $resource = $this->resourceRepository->findOrFail($id);
-        $upcomingShifts = $this->shiftRepository->upcomingForResource($resource->id, 50);
+        // Load all shifts for accurate period summaries (not only upcoming)
+        $allShifts = $this->shiftRepository->forResource($resource->id)
+            ->orderBy('period_start')
+            ->get();
 
-        $periodSummaries = $this->buildPeriodAwareWeeklySummaries($upcomingShifts->all());
+        $periodSummaries = $this->buildPeriodAwareWeeklySummaries($allShifts->all());
 
         return view('admin::settings.resources.show', [
             'resource'        => $resource,
-            'upcomingShifts'  => $upcomingShifts,
+            'upcomingShifts'  => collect(),
             'periodSummaries' => $periodSummaries,
         ]);
     }
@@ -87,10 +90,13 @@ class ResourceController extends SimpleEntityController
             }
         }
 
-        // Merge overlaps inside each day's available/unavailable lists
+        // Merge overlaps and compute net available by subtracting unavailable
         for ($day = 1; $day <= 7; $day++) {
-            $summary[$day]['available'] = $this->mergeOverlappingTimeRanges($summary[$day]['available']);
-            $summary[$day]['unavailable'] = $this->mergeOverlappingTimeRanges($summary[$day]['unavailable']);
+            $mergedAvailable = $this->mergeOverlappingTimeRanges($summary[$day]['available']);
+            $mergedUnavailable = $this->mergeOverlappingTimeRanges($summary[$day]['unavailable']);
+
+            $summary[$day]['available'] = $this->subtractTimeRanges($mergedAvailable, $mergedUnavailable);
+            $summary[$day]['unavailable'] = $mergedUnavailable;
         }
 
         return $summary;
@@ -244,6 +250,62 @@ class ResourceController extends SimpleEntityController
         $merged[] = $current;
 
         return $merged;
+    }
+
+    /**
+     * Subtract unavailable ranges from available ranges within a day,
+     * returning the net available ranges.
+     *
+     * @param  array<int, array{from: string, to: string}>  $available
+     * @param  array<int, array{from: string, to: string}>  $unavailable
+     * @return array<int, array{from: string, to: string}>
+     */
+    protected function subtractTimeRanges(array $available, array $unavailable): array
+    {
+        if (empty($available)) {
+            return [];
+        }
+        if (empty($unavailable)) {
+            return $available;
+        }
+
+        // Inputs should be merged and sorted
+        $available = $this->mergeOverlappingTimeRanges($available);
+        $unavailable = $this->mergeOverlappingTimeRanges($unavailable);
+
+        $result = [];
+        foreach ($available as $a) {
+            $segments = [[$a['from'], $a['to']]];
+            foreach ($unavailable as $u) {
+                $newSegments = [];
+                foreach ($segments as [$sf, $st]) {
+                    // no overlap
+                    if ($u['to'] <= $sf || $u['from'] >= $st) {
+                        $newSegments[] = [$sf, $st];
+                        continue;
+                    }
+                    // left remainder
+                    if ($u['from'] > $sf) {
+                        $newSegments[] = [$sf, min($st, $u['from'])];
+                    }
+                    // right remainder
+                    if ($u['to'] < $st) {
+                        $newSegments[] = [max($sf, $u['to']), $st];
+                    }
+                }
+                $segments = $newSegments;
+                if (empty($segments)) {
+                    break;
+                }
+            }
+            foreach ($segments as [$sf, $st]) {
+                if ($sf < $st) {
+                    $result[] = ['from' => $sf, 'to' => $st];
+                }
+            }
+        }
+
+        return $this->mergeOverlappingTimeRanges($result);
     }
 
     protected function getCreateViewData(Request $request): array

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
@@ -39,5 +39,3 @@
             @endif
         </div>
     @endfor
-@endphp
-

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
@@ -29,7 +29,7 @@
                     <span class="text-xs text-gray-500">—</span>
                 @endif
             </div>
-            @if (count($unavailable))
+            @if (count($unavailable) && count($available) === 0)
                 <div class="flex flex-wrap items-center gap-2">
                     <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
                     @foreach ($unavailable as $range)

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
@@ -13,9 +13,8 @@
 <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
     @for ($day = 1; $day <= 7; $day++)
         @php
-            $daySummary = $summary[$day] ?? ['available' => [], 'unavailable' => []];
+            $daySummary = $summary[$day] ?? ['available' => []];
             $available = $daySummary['available'] ?? [];
-            $unavailable = $daySummary['unavailable'] ?? [];
         @endphp
         <div class="py-3 text-sm">
             <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
@@ -26,18 +25,9 @@
                         <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
                     @endforeach
                 @else
-                    @if (! count($unavailable))
-                        <span class="text-xs text-gray-500">—</span>
-                    @endif
+                    <span class="text-xs text-gray-500">—</span>
                 @endif
             </div>
-            @if (count($unavailable) && count($available) === 0)
-                <div class="flex flex-wrap items-center gap-2">
-                    <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
-                    @foreach ($unavailable as $range)
-                        <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
-                    @endforeach
-                </div>
-            @endif
+            
         </div>
     @endfor

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
@@ -1,0 +1,43 @@
+@php
+    $dayNames = [
+        1 => trans('admin::app.monday'),
+        2 => trans('admin::app.tuesday'),
+        3 => trans('admin::app.wednesday'),
+        4 => trans('admin::app.thursday'),
+        5 => trans('admin::app.friday'),
+        6 => trans('admin::app.saturday'),
+        7 => trans('admin::app.sunday'),
+    ];
+@endphp
+
+<div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
+    @for ($day = 1; $day <= 7; $day++)
+        @php
+            $daySummary = $summary[$day] ?? ['available' => [], 'unavailable' => []];
+            $available = $daySummary['available'] ?? [];
+            $unavailable = $daySummary['unavailable'] ?? [];
+        @endphp
+        <div class="py-3 text-sm">
+            <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
+            <div class="mb-1 flex flex-wrap items-center gap-2">
+                <span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">Beschikbaar</span>
+                @if (count($available))
+                    @foreach ($available as $range)
+                        <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                    @endforeach
+                @else
+                    <span class="text-xs text-gray-500">—</span>
+                @endif
+            </div>
+            @if (count($unavailable))
+                <div class="flex flex-wrap items-center gap-2">
+                    <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
+                    @foreach ($unavailable as $range)
+                        <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+    @endfor
+@endphp
+

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/partials/weekly-summary.blade.php
@@ -26,7 +26,9 @@
                         <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
                     @endforeach
                 @else
-                    <span class="text-xs text-gray-500">—</span>
+                    @if (! count($unavailable))
+                        <span class="text-xs text-gray-500">—</span>
+                    @endif
                 @endif
             </div>
             @if (count($unavailable) && count($available) === 0)

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
@@ -74,16 +74,14 @@
                                                         <span class="text-xs text-gray-500">—</span>
                                                     @endif
                                                 </div>
-                                                <div class="flex flex-wrap items-center gap-2">
-                                                    <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
-                                                    @if (count($unavailable))
+                                                @if (count($unavailable))
+                                                    <div class="flex flex-wrap items-center gap-2">
+                                                        <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
                                                         @foreach ($unavailable as $range)
                                                             <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
                                                         @endforeach
-                                                    @else
-                                                        <span class="text-xs text-gray-500">—</span>
-                                                    @endif
-                                                </div>
+                                                    </div>
+                                                @endif
                                             </div>
                                         @endfor
                                     </div>

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
@@ -33,18 +33,6 @@
                 <div class="mb-3 text-base font-semibold">@lang('admin::app.settings.resources.show.schedule')</div>
                 <div class="relative w-full overflow-x-auto">
                     <div class="min-w-[640px]">
-                        @php
-                            $dayNames = [
-                                1 => trans('admin::app.monday'),
-                                2 => trans('admin::app.tuesday'),
-                                3 => trans('admin::app.wednesday'),
-                                4 => trans('admin::app.thursday'),
-                                5 => trans('admin::app.friday'),
-                                6 => trans('admin::app.saturday'),
-                                7 => trans('admin::app.sunday'),
-                            ];
-                        @endphp
-
                         @if (empty($periodSummaries))
                             <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
                                 <div>Geen roosterinformatie beschikbaar</div>
@@ -55,36 +43,7 @@
                                     <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
                                         <div>Periode: {{ $period['label'] }}</div>
                                     </div>
-                                    <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
-                                        @for ($day = 1; $day <= 7; $day++)
-                                            @php
-                                                $daySummary = $period['summary'][$day] ?? ['available' => [], 'unavailable' => []];
-                                                $available = $daySummary['available'] ?? [];
-                                                $unavailable = $daySummary['unavailable'] ?? [];
-                                            @endphp
-                                            <div class="py-3 text-sm">
-                                                <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
-                                                <div class="mb-1 flex flex-wrap items-center gap-2">
-                                                    <span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">Beschikbaar</span>
-                                                    @if (count($available))
-                                                        @foreach ($available as $range)
-                                                            <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
-                                                        @endforeach
-                                                    @else
-                                                        <span class="text-xs text-gray-500">—</span>
-                                                    @endif
-                                                </div>
-                                                @if (count($unavailable))
-                                                    <div class="flex flex-wrap items-center gap-2">
-                                                        <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
-                                                        @foreach ($unavailable as $range)
-                                                            <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
-                                                        @endforeach
-                                                    </div>
-                                                @endif
-                                            </div>
-                                        @endfor
-                                    </div>
+                                    @include('admin::settings.resources.partials.weekly-summary', ['summary' => $period['summary']])
                                 </div>
                             @endforeach
                         @endif

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/show.blade.php
@@ -33,53 +33,63 @@
                 <div class="mb-3 text-base font-semibold">@lang('admin::app.settings.resources.show.schedule')</div>
                 <div class="relative w-full overflow-x-auto">
                     <div class="min-w-[640px]">
-                        <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-                            <div>Samenvatting van roosters (samengevoegd)</div>
-                        </div>
-                        <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
-                            @php
-                                $dayNames = [
-                                    1 => trans('admin::app.monday'),
-                                    2 => trans('admin::app.tuesday'),
-                                    3 => trans('admin::app.wednesday'),
-                                    4 => trans('admin::app.thursday'),
-                                    5 => trans('admin::app.friday'),
-                                    6 => trans('admin::app.saturday'),
-                                    7 => trans('admin::app.sunday'),
-                                ];
-                            @endphp
+                        @php
+                            $dayNames = [
+                                1 => trans('admin::app.monday'),
+                                2 => trans('admin::app.tuesday'),
+                                3 => trans('admin::app.wednesday'),
+                                4 => trans('admin::app.thursday'),
+                                5 => trans('admin::app.friday'),
+                                6 => trans('admin::app.saturday'),
+                                7 => trans('admin::app.sunday'),
+                            ];
+                        @endphp
 
-                            @for($day = 1; $day <= 7; $day++)
-                                @php
-                                    $daySummary = $scheduleSummary[$day] ?? ['available' => [], 'unavailable' => []];
-                                    $available = $daySummary['available'] ?? [];
-                                    $unavailable = $daySummary['unavailable'] ?? [];
-                                @endphp
-                                <div class="py-3 text-sm">
-                                    <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
-                                    <div class="mb-1 flex flex-wrap items-center gap-2">
-                                        <span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">Beschikbaar</span>
-                                        @if (count($available))
-                                            @foreach($available as $range)
-                                                <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
-                                            @endforeach
-                                        @else
-                                            <span class="text-xs text-gray-500">—</span>
-                                        @endif
+                        @if (empty($periodSummaries))
+                            <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                                <div>Geen roosterinformatie beschikbaar</div>
+                            </div>
+                        @else
+                            @foreach ($periodSummaries as $period)
+                                <div class="mb-4 rounded-md border border-gray-200 p-3 dark:border-gray-800">
+                                    <div class="mb-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                                        <div>Periode: {{ $period['label'] }}</div>
                                     </div>
-                                    <div class="flex flex-wrap items-center gap-2">
-                                        <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
-                                        @if (count($unavailable))
-                                            @foreach($unavailable as $range)
-                                                <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
-                                            @endforeach
-                                        @else
-                                            <span class="text-xs text-gray-500">—</span>
-                                        @endif
+                                    <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
+                                        @for ($day = 1; $day <= 7; $day++)
+                                            @php
+                                                $daySummary = $period['summary'][$day] ?? ['available' => [], 'unavailable' => []];
+                                                $available = $daySummary['available'] ?? [];
+                                                $unavailable = $daySummary['unavailable'] ?? [];
+                                            @endphp
+                                            <div class="py-3 text-sm">
+                                                <div class="mb-2 font-semibold">{{ $dayNames[$day] }}</div>
+                                                <div class="mb-1 flex flex-wrap items-center gap-2">
+                                                    <span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">Beschikbaar</span>
+                                                    @if (count($available))
+                                                        @foreach ($available as $range)
+                                                            <span class="rounded border border-green-300 px-2 py-0.5 text-xs text-green-800 dark:border-green-700 dark:text-green-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                                                        @endforeach
+                                                    @else
+                                                        <span class="text-xs text-gray-500">—</span>
+                                                    @endif
+                                                </div>
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <span class="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-300">Niet beschikbaar</span>
+                                                    @if (count($unavailable))
+                                                        @foreach ($unavailable as $range)
+                                                            <span class="rounded border border-red-300 px-2 py-0.5 text-xs text-red-800 dark:border-red-700 dark:text-red-300">{{ $range['from'] }}–{{ $range['to'] }}</span>
+                                                        @endforeach
+                                                    @else
+                                                        <span class="text-xs text-gray-500">—</span>
+                                                    @endif
+                                                </div>
+                                            </div>
+                                        @endfor
                                     </div>
                                 </div>
-                            @endfor
-                        </div>
+                            @endforeach
+                        @endif
                     </div>
                 </div>
             </div>

--- a/packages/Webkul/Admin/src/Resources/views/settings/shifts/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/shifts/create.blade.php
@@ -76,13 +76,17 @@
                         @lang('admin::app.settings.shifts.fields.available')
                     </x-admin::form.control-group.label>
 
-                    <x-admin::form.control-group.control
-                        type="checkbox"
-                        name="available"
-                        value="1"
-                        :label="trans('admin::app.settings.shifts.fields.available')"
-                        :checked="true"
-                    />
+                    <input type="hidden" name="available" value="0" />
+                    <label class="inline-flex items-center gap-2 text-sm text-gray-800 dark:text-white">
+                        <input
+                            type="checkbox"
+                            name="available"
+                            value="1"
+                            class="h-4 w-4 rounded border-gray-300 text-brandColor focus:ring-brandColor"
+                            @checked(old('available', true))
+                        />
+                        <span>@lang('admin::app.settings.shifts.fields.available')</span>
+                    </label>
 
                     <x-admin::form.control-group.error control-name="available" />
                 </x-admin::form.control-group>

--- a/packages/Webkul/Admin/src/Resources/views/settings/shifts/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/shifts/edit.blade.php
@@ -78,13 +78,17 @@
                         @lang('admin::app.settings.shifts.fields.available')
                     </x-admin::form.control-group.label>
 
-                    <x-admin::form.control-group.control
-                        type="checkbox"
-                        name="available"
-                        value="1"
-                        :label="trans('admin::app.settings.shifts.fields.available')"
-                        :checked="(bool) old('available', $shift->available)"
-                    />
+                    <input type="hidden" name="available" value="0" />
+                    <label class="inline-flex items-center gap-2 text-sm text-gray-800 dark:text-white">
+                        <input
+                            type="checkbox"
+                            name="available"
+                            value="1"
+                            class="h-4 w-4 rounded border-gray-300 text-brandColor focus:ring-brandColor"
+                            @checked(old('available', (bool) $shift->available))
+                        />
+                        <span>@lang('admin::app.settings.shifts.fields.available')</span>
+                    </label>
 
                     <x-admin::form.control-group.error control-name="available" />
                 </x-admin::form.control-group>

--- a/tests/Feature/Settings/ResourceScheduleViewTest.php
+++ b/tests/Feature/Settings/ResourceScheduleViewTest.php
@@ -1,12 +1,9 @@
 <?php
 
 use App\Models\Resource;
-use App\Models\Shift;
-use App\Models\User;
 use Illuminate\Support\Carbon;
-
 use Webkul\Installer\Http\Middleware\CanInstall;
-use function Pest\Laravel\actingAs;
+
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 
@@ -25,8 +22,8 @@ it('renders per-period weekly summaries with merged time ranges', function () {
     // Build dynamic future dates to avoid being filtered out by upcoming query.
     $startA = now()->copy()->addDays(1)->toDateString();
     $startB = now()->copy()->addDays(15)->toDateString();
-    $endA   = now()->copy()->addDays(31)->toDateString();
-    $endB   = now()->copy()->addDays(60)->toDateString();
+    $endA = now()->copy()->addDays(31)->toDateString();
+    $endB = now()->copy()->addDays(60)->toDateString();
     $startC = Carbon::parse($endB)->addDay()->toDateString();
 
     // Period A: startA .. endA
@@ -86,18 +83,17 @@ it('renders per-period weekly summaries with merged time ranges', function () {
 
     // Expect three period segments rendered (A-only, A+B overlap, C-only)
     $segment1Start = Carbon::parse($startA)->toDateString();
-    $segment1End   = Carbon::parse($startB)->subDay()->toDateString();
-    $resp->assertSee('Periode: ' . $segment1Start . ' — ' . $segment1End, false);
+    $segment1End = Carbon::parse($startB)->subDay()->toDateString();
+    $resp->assertSee('Periode: '.$segment1Start.' — '.$segment1End, false);
     // Monday available merged range from A: 08:00–12:00, no unavailable
     $resp->assertSee('08:00–12:00', false);
 
     // Segment 2: A+B overlap
-    $resp->assertSee('Periode: ' . Carbon::parse($startB)->toDateString() . ' — ' . Carbon::parse($endB)->toDateString(), false);
+    $resp->assertSee('Periode: '.Carbon::parse($startB)->toDateString().' — '.Carbon::parse($endB)->toDateString(), false);
     // For Monday, available still 08:00–12:00 from A; unavailable 10:00–11:00 from B
     $resp->assertSee('10:00–11:00', false);
 
     // Segment 3: C only (open ended)
-    $resp->assertSee('Periode: ' . Carbon::parse($startC)->toDateString() . ' — ∞', false);
+    $resp->assertSee('Periode: '.Carbon::parse($startC)->toDateString().' — ∞', false);
     $resp->assertSee('13:00–16:00', false);
 });
-

--- a/tests/Feature/Settings/ResourceScheduleViewTest.php
+++ b/tests/Feature/Settings/ResourceScheduleViewTest.php
@@ -5,13 +5,20 @@ use App\Models\Shift;
 use App\Models\User;
 use Illuminate\Support\Carbon;
 
+use Webkul\Installer\Http\Middleware\CanInstall;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 
+beforeEach(function () {
+    config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
+    test()->withoutMiddleware(CanInstall::class);
+
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+});
+
 it('renders per-period weekly summaries with merged time ranges', function () {
-    $user = User::factory()->create();
-    actingAs($user, 'user');
 
     $resource = Resource::factory()->create();
 

--- a/tests/Feature/Settings/ResourceScheduleViewTest.php
+++ b/tests/Feature/Settings/ResourceScheduleViewTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\Resource;
+use App\Models\Shift;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+
+it('renders per-period weekly summaries with merged time ranges', function () {
+    $user = User::factory()->create();
+    actingAs($user, 'user');
+
+    $resource = Resource::factory()->create();
+
+    // Build dynamic future dates to avoid being filtered out by upcoming query.
+    $startA = now()->copy()->addDays(1)->toDateString();
+    $startB = now()->copy()->addDays(15)->toDateString();
+    $endA   = now()->copy()->addDays(31)->toDateString();
+    $endB   = now()->copy()->addDays(60)->toDateString();
+    $startC = Carbon::parse($endB)->addDay()->toDateString();
+
+    // Period A: startA .. endA
+    // Available blocks overlap and should merge (08:00-10:00 + 09:30-12:00 => 08:00-12:00)
+    $payloadA = [
+        'resource_id'         => $resource->id,
+        'period_start'        => $startA,
+        'period_end'          => $endA,
+        'weekday_time_blocks' => [
+            1 => [
+                ['from' => '08:00', 'to' => '10:00'],
+                ['from' => '09:30', 'to' => '12:00'],
+            ],
+            2 => [], 3 => [], 4 => [], 5 => [], 6 => [], 7 => [],
+        ],
+        'available' => true,
+        'notes'     => 'Period A available',
+    ];
+
+    // Period B: startB .. endB (overlaps with A), unavailable for part of day
+    $payloadB = [
+        'resource_id'         => $resource->id,
+        'period_start'        => $startB,
+        'period_end'          => $endB,
+        'weekday_time_blocks' => [
+            1 => [
+                ['from' => '10:00', 'to' => '11:00'],
+            ],
+            2 => [], 3 => [], 4 => [], 5 => [], 6 => [], 7 => [],
+        ],
+        'available' => false,
+        'notes'     => 'Period B unavailable overlap',
+    ];
+
+    // Period C: open-ended from the day after endB, available distinct block
+    $payloadC = [
+        'resource_id'         => $resource->id,
+        'period_start'        => $startC,
+        'weekday_time_blocks' => [
+            1 => [
+                ['from' => '13:00', 'to' => '16:00'],
+            ],
+            2 => [], 3 => [], 4 => [], 5 => [], 6 => [], 7 => [],
+        ],
+        'available' => true,
+        'notes'     => 'Period C open ended',
+    ];
+
+    // Create via controller endpoints to ensure validation/casting
+    post(route('admin.settings.resources.shifts.store', $resource->id), $payloadA)->assertRedirect();
+    post(route('admin.settings.resources.shifts.store', $resource->id), $payloadB)->assertRedirect();
+    post(route('admin.settings.resources.shifts.store', $resource->id), $payloadC)->assertRedirect();
+
+    // Visit the bekijken page
+    $resp = get(route('admin.settings.resources.show', $resource->id));
+    $resp->assertOk();
+
+    // Expect three period segments rendered (A-only, A+B overlap, C-only)
+    $segment1Start = Carbon::parse($startA)->toDateString();
+    $segment1End   = Carbon::parse($startB)->subDay()->toDateString();
+    $resp->assertSee('Periode: ' . $segment1Start . ' — ' . $segment1End, false);
+    // Monday available merged range from A: 08:00–12:00, no unavailable
+    $resp->assertSee('08:00–12:00', false);
+
+    // Segment 2: A+B overlap
+    $resp->assertSee('Periode: ' . Carbon::parse($startB)->toDateString() . ' — ' . Carbon::parse($endB)->toDateString(), false);
+    // For Monday, available still 08:00–12:00 from A; unavailable 10:00–11:00 from B
+    $resp->assertSee('10:00–11:00', false);
+
+    // Segment 3: C only (open ended)
+    $resp->assertSee('Periode: ' . Carbon::parse($startC)->toDateString() . ' — ∞', false);
+    $resp->assertSee('13:00–16:00', false);
+});
+

--- a/tests/Unit/BuildMergedWeeklySummaryTest.php
+++ b/tests/Unit/BuildMergedWeeklySummaryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Http\Controllers\Admin\Settings\ResourceController;
+use App\Models\Shift;
+use Illuminate\Support\Facades\App;
+
+it('merges overlapping and adjacent time blocks per day by availability flag', function () {
+    // Build two shifts with overlapping Monday blocks, one available and one unavailable
+    $shiftAvailable = new Shift([
+        'available' => true,
+        'weekday_time_blocks' => [
+            1 => [
+                ['from' => '08:00', 'to' => '10:00'],
+                ['from' => '09:30', 'to' => '12:00'], // overlaps with 08:00-10:00 -> merged 08:00-12:00
+                ['from' => '12:00', 'to' => '13:00'], // adjacent to end -> merged into 08:00-13:00
+            ],
+        ],
+    ]);
+
+    $shiftUnavailable = new Shift([
+        'available' => false,
+        'weekday_time_blocks' => [
+            1 => [
+                ['from' => '10:00', 'to' => '11:00'], // should appear under unavailable
+                ['from' => '11:00', 'to' => '11:30'], // adjacent -> merge to 10:00-11:30
+            ],
+            2 => [
+                ['from' => '14:00', 'to' => '15:00'],
+                ['from' => '14:30', 'to' => '16:00'], // merge to 14:00-16:00 on Tuesday unavailable
+            ],
+        ],
+    ]);
+
+    // Controller instance (dependencies are not used for this method)
+    $controller = App::make(ResourceController::class);
+
+    // Access protected method via reflection
+    $method = (new ReflectionClass($controller))->getMethod('buildMergedWeeklySummary');
+    $method->setAccessible(true);
+    $result = $method->invoke($controller, [$shiftAvailable, $shiftUnavailable]);
+
+    // Monday checks (day 1)
+    expect($result[1]['available'])
+        ->toBe([['from' => '08:00', 'to' => '13:00']]);
+
+    expect($result[1]['unavailable'])
+        ->toBe([['from' => '10:00', 'to' => '11:30']]);
+
+    // Tuesday checks (day 2)
+    expect($result[2]['available'])->toBe([]);
+    expect($result[2]['unavailable'])
+        ->toBe([['from' => '14:00', 'to' => '16:00']]);
+});
+

--- a/tests/Unit/BuildMergedWeeklySummaryTest.php
+++ b/tests/Unit/BuildMergedWeeklySummaryTest.php
@@ -2,7 +2,11 @@
 
 use App\Http\Controllers\Admin\Settings\ResourceController;
 use App\Models\Shift;
-use Illuminate\Support\Facades\App;
+use App\Repositories\ClinicRepository;
+use App\Repositories\ResourceRepository;
+use App\Repositories\ResourceTypeRepository;
+use App\Repositories\ShiftRepository;
+use Mockery;
 
 it('merges overlapping and adjacent time blocks per day by availability flag', function () {
     // Build two shifts with overlapping Monday blocks, one available and one unavailable
@@ -31,8 +35,13 @@ it('merges overlapping and adjacent time blocks per day by availability flag', f
         ],
     ]);
 
-    // Controller instance (dependencies are not used for this method)
-    $controller = App::make(ResourceController::class);
+    // Controller instance with mocked dependencies (not used by the method)
+    $controller = new ResourceController(
+        Mockery::mock(ResourceRepository::class),
+        Mockery::mock(ResourceTypeRepository::class),
+        Mockery::mock(ShiftRepository::class),
+        Mockery::mock(ClinicRepository::class),
+    );
 
     // Access protected method via reflection
     $method = (new ReflectionClass($controller))->getMethod('buildMergedWeeklySummary');

--- a/tests/Unit/BuildMergedWeeklySummaryTest.php
+++ b/tests/Unit/BuildMergedWeeklySummaryTest.php
@@ -7,7 +7,7 @@ use App\Repositories\ResourceRepository;
 use App\Repositories\ResourceTypeRepository;
 use App\Repositories\ShiftRepository;
 
-it('merges overlapping and adjacent time blocks per day by availability flag', function () {
+it('merges blocks and computes net availability minus unavailability', function () {
     // Build two shifts with overlapping Monday blocks, one available and one unavailable
     $shiftAvailable = new Shift([
         'available'           => true,
@@ -47,9 +47,9 @@ it('merges overlapping and adjacent time blocks per day by availability flag', f
     $method->setAccessible(true);
     $result = $method->invoke($controller, [$shiftAvailable, $shiftUnavailable]);
 
-    // Monday checks (day 1)
+    // Monday checks (day 1): available 08:00–13:00 minus unavailable 10:00–11:30 => 08:00–10:00 and 11:30–13:00
     expect($result[1]['available'])
-        ->toBe([['from' => '08:00', 'to' => '13:00']])
+        ->toBe([['from' => '08:00', 'to' => '10:00'], ['from' => '11:30', 'to' => '13:00']])
         ->and($result[1]['unavailable'])
         ->toBe([['from' => '10:00', 'to' => '11:30']])
         ->and($result[2]['available'])->toBe([])

--- a/tests/Unit/BuildMergedWeeklySummaryTest.php
+++ b/tests/Unit/BuildMergedWeeklySummaryTest.php
@@ -6,12 +6,11 @@ use App\Repositories\ClinicRepository;
 use App\Repositories\ResourceRepository;
 use App\Repositories\ResourceTypeRepository;
 use App\Repositories\ShiftRepository;
-use Mockery;
 
 it('merges overlapping and adjacent time blocks per day by availability flag', function () {
     // Build two shifts with overlapping Monday blocks, one available and one unavailable
     $shiftAvailable = new Shift([
-        'available' => true,
+        'available'           => true,
         'weekday_time_blocks' => [
             1 => [
                 ['from' => '08:00', 'to' => '10:00'],
@@ -22,7 +21,7 @@ it('merges overlapping and adjacent time blocks per day by availability flag', f
     ]);
 
     $shiftUnavailable = new Shift([
-        'available' => false,
+        'available'           => false,
         'weekday_time_blocks' => [
             1 => [
                 ['from' => '10:00', 'to' => '11:00'], // should appear under unavailable
@@ -50,14 +49,12 @@ it('merges overlapping and adjacent time blocks per day by availability flag', f
 
     // Monday checks (day 1)
     expect($result[1]['available'])
-        ->toBe([['from' => '08:00', 'to' => '13:00']]);
-
-    expect($result[1]['unavailable'])
-        ->toBe([['from' => '10:00', 'to' => '11:30']]);
+        ->toBe([['from' => '08:00', 'to' => '13:00']])
+        ->and($result[1]['unavailable'])
+        ->toBe([['from' => '10:00', 'to' => '11:30']])
+        ->and($result[2]['available'])->toBe([])
+        ->and($result[2]['unavailable'])
+        ->toBe([['from' => '14:00', 'to' => '16:00']]);
 
     // Tuesday checks (day 2)
-    expect($result[2]['available'])->toBe([]);
-    expect($result[2]['unavailable'])
-        ->toBe([['from' => '14:00', 'to' => '16:00']]);
 });
-

--- a/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
+++ b/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Http\Controllers\Admin\Settings\ResourceController;
-use App\Models\Shift;
 use App\Repositories\ClinicRepository;
 use App\Repositories\ResourceRepository;
 use App\Repositories\ResourceTypeRepository;
@@ -11,23 +10,23 @@ use Mockery;
 
 it('produces two distinct periods in period-aware summaries', function () {
     // Two shifts in non-overlapping date ranges
-    $shiftPeriod1 = new Shift([
+    $shiftPeriod1 = (object) [
         'available' => true,
         'period_start' => Carbon::now()->addDays(1),
         'period_end' => Carbon::now()->addDays(10),
         'weekday_time_blocks' => [
             1 => [ ['from' => '08:00', 'to' => '12:00'] ],
         ],
-    ]);
+    ];
 
-    $shiftPeriod2 = new Shift([
+    $shiftPeriod2 = (object) [
         'available' => false,
         'period_start' => Carbon::now()->addDays(20),
         'period_end' => Carbon::now()->addDays(30),
         'weekday_time_blocks' => [
             1 => [ ['from' => '10:00', 'to' => '11:00'] ],
         ],
-    ]);
+    ];
 
     $controller = new ResourceController(
         Mockery::mock(ResourceRepository::class),

--- a/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
+++ b/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Http\Controllers\Admin\Settings\ResourceController;
+use App\Models\Shift;
+use App\Repositories\ClinicRepository;
+use App\Repositories\ResourceRepository;
+use App\Repositories\ResourceTypeRepository;
+use App\Repositories\ShiftRepository;
+use Illuminate\Support\Carbon;
+use Mockery;
+
+it('produces two distinct periods in period-aware summaries', function () {
+    // Two shifts in non-overlapping date ranges
+    $shiftPeriod1 = new Shift([
+        'available' => true,
+        'period_start' => Carbon::now()->addDays(1),
+        'period_end' => Carbon::now()->addDays(10),
+        'weekday_time_blocks' => [
+            1 => [ ['from' => '08:00', 'to' => '12:00'] ],
+        ],
+    ]);
+
+    $shiftPeriod2 = new Shift([
+        'available' => false,
+        'period_start' => Carbon::now()->addDays(20),
+        'period_end' => Carbon::now()->addDays(30),
+        'weekday_time_blocks' => [
+            1 => [ ['from' => '10:00', 'to' => '11:00'] ],
+        ],
+    ]);
+
+    $controller = new ResourceController(
+        Mockery::mock(ResourceRepository::class),
+        Mockery::mock(ResourceTypeRepository::class),
+        Mockery::mock(ShiftRepository::class),
+        Mockery::mock(ClinicRepository::class),
+    );
+
+    $method = (new ReflectionClass($controller))->getMethod('buildPeriodAwareWeeklySummaries');
+    $method->setAccessible(true);
+    $result = $method->invoke($controller, [$shiftPeriod1, $shiftPeriod2]);
+
+    expect($result)->toBeArray();
+    expect(count($result))->toBe(2);
+
+    // First period summary corresponds to shiftPeriod1 range
+    $first = $result[0];
+    expect($first['summary'][1]['available'])->toBe([['from' => '08:00', 'to' => '12:00']]);
+    expect($first['summary'][1]['unavailable'])->toBe([]);
+
+    // Second period summary corresponds to shiftPeriod2 range
+    $second = $result[1];
+    expect($second['summary'][1]['available'])->toBe([]);
+    expect($second['summary'][1]['unavailable'])->toBe([['from' => '10:00', 'to' => '11:00']]);
+});
+

--- a/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
+++ b/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
@@ -53,3 +53,71 @@ it('produces two distinct periods in period-aware summaries', function () {
     expect($second['summary'][1]['unavailable'])->toBe([['from' => '10:00', 'to' => '11:00']]);
 });
 
+it('computes net availability with an unavailable sub-period within same month', function () {
+    $septStart = Carbon::createFromDate(now()->year, 9, 1)->startOfDay();
+    $septEnd   = Carbon::createFromDate(now()->year, 9, 30)->startOfDay();
+    $firstWeekEnd = $septStart->copy()->addDays(6);
+
+    $availAllMonth = (object) [
+        'available' => true,
+        'period_start' => $septStart->copy(),
+        'period_end' => $septEnd->copy(),
+        'weekday_time_blocks' => [
+            1 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            2 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            3 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            4 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            5 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            6 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            7 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+        ],
+    ];
+
+    $unavailFirstWeek = (object) [
+        'available' => false,
+        'period_start' => $septStart->copy(),
+        'period_end' => $firstWeekEnd->copy(),
+        'weekday_time_blocks' => [
+            1 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            2 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            3 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            4 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            5 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            6 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            7 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+        ],
+    ];
+
+    $controller = new ResourceController(
+        Mockery::mock(ResourceRepository::class),
+        Mockery::mock(ResourceTypeRepository::class),
+        Mockery::mock(ShiftRepository::class),
+        Mockery::mock(ClinicRepository::class),
+    );
+
+    $method = (new ReflectionClass($controller))->getMethod('buildPeriodAwareWeeklySummaries');
+    $method->setAccessible(true);
+    $result = $method->invoke($controller, [$availAllMonth, $unavailFirstWeek]);
+
+    // Expect at least two segments in September: first week and the remainder
+    expect(count($result))->toBeGreaterThanOrEqual(2);
+
+    // First week segment
+    $labelFirstWeek = $septStart->format('Y-m-d') . ' — ' . $firstWeekEnd->format('Y-m-d');
+    $firstWeek = collect($result)->firstWhere('label', $labelFirstWeek);
+    expect($firstWeek)->not()->toBeNull();
+    for ($day = 1; $day <= 7; $day++) {
+        expect($firstWeek['summary'][$day]['available'])->toBe([[ 'from' => '12:00', 'to' => '17:00' ]]);
+    }
+
+    // Remainder segment
+    $remStart = $firstWeekEnd->copy()->addDay();
+    $rem = collect($result)->first(function ($seg) use ($remStart, $septEnd) {
+        return $seg['start'] === $remStart->format('Y-m-d') && $seg['end'] === $septEnd->format('Y-m-d');
+    });
+    expect($rem)->not()->toBeNull();
+    for ($day = 1; $day <= 7; $day++) {
+        expect($rem['summary'][$day]['available'])->toBe([[ 'from' => '08:00', 'to' => '17:00' ]]);
+    }
+});
+

--- a/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
+++ b/tests/Unit/BuildPeriodAwareWeeklySummariesTest.php
@@ -121,3 +121,61 @@ it('computes net availability with an unavailable sub-period within same month',
     }
 });
 
+it('shows net availability 12:00–17:00 for first week sub-period within same month', function () {
+    // A: whole September available 08:00–17:00
+    // B: sub-period 2025-09-05 .. 2025-09-12 unavailable 08:00–12:00
+    $year = 2025;
+    $septStart = Carbon::createFromDate($year, 9, 1)->startOfDay();
+    $septEnd   = Carbon::createFromDate($year, 9, 30)->startOfDay();
+    $subStart  = Carbon::createFromDate($year, 9, 5)->startOfDay();
+    $subEnd    = Carbon::createFromDate($year, 9, 12)->startOfDay();
+
+    $availAllMonth = (object) [
+        'available' => true,
+        'period_start' => $septStart->copy(),
+        'period_end' => $septEnd->copy(),
+        'weekday_time_blocks' => [
+            1 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            2 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            3 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            4 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            5 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            6 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+            7 => [[ 'from' => '08:00', 'to' => '17:00' ]],
+        ],
+    ];
+
+    $unavailSub = (object) [
+        'available' => false,
+        'period_start' => $subStart->copy(),
+        'period_end' => $subEnd->copy(),
+        'weekday_time_blocks' => [
+            1 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            2 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            3 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            4 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            5 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            6 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+            7 => [[ 'from' => '08:00', 'to' => '12:00' ]],
+        ],
+    ];
+
+    $controller = new ResourceController(
+        Mockery::mock(ResourceRepository::class),
+        Mockery::mock(ResourceTypeRepository::class),
+        Mockery::mock(ShiftRepository::class),
+        Mockery::mock(ClinicRepository::class),
+    );
+
+    $method = (new ReflectionClass($controller))->getMethod('buildPeriodAwareWeeklySummaries');
+    $method->setAccessible(true);
+    $result = $method->invoke($controller, [$availAllMonth, $unavailSub]);
+
+    $label = $subStart->format('Y-m-d') . ' — ' . $subEnd->format('Y-m-d');
+    $segment = collect($result)->firstWhere('label', $label);
+    expect($segment)->not()->toBeNull();
+
+    // Monday availability should be 12:00–17:00
+    expect($segment['summary'][1]['available'])->toBe([[ 'from' => '12:00', 'to' => '17:00' ]]);
+});
+


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
N/A

## Description
This pull request enhances the resource schedule view (`admin/settings/resources/{id}/bekijken`) to provide a period-aware summary of shifts.

Previously, the schedule summary did not account for the `period_start` and `period_end` of shifts, making it difficult to verify schedules that change over time.

This change introduces:
-   **Period Segmentation**: The backend now segments all upcoming shifts into distinct, non-overlapping date periods where a consistent set of shifts is active.
-   **Per-Period Weekly Summaries**: For each identified period, a merged weekly schedule is generated, clearly showing available and unavailable time blocks for each day.
-   **Improved UI**: The frontend now displays these summaries grouped by their respective periods, making it easy to understand the resource's schedule across different timeframes. Overlapping shifts within a day are merged into clear "Beschikbaar" (Available) and "Niet beschikbaar" (Unavailable) time ranges.

## How To Test This?
1.  Navigate to `admin/settings/resources/{id}/bekijken` for a resource.
2.  Ensure the resource has multiple shifts, some with defined `period_start` and `period_end` dates, and potentially some overlapping periods.
3.  Verify that the "Roosters" block now displays separate sections, each labeled with a date range (e.g., "Periode: YYYY-MM-DD — YYYY-MM-DD" or "YYYY-MM-DD — ∞").
4.  Within each period's section, check that the daily schedules correctly merge overlapping shifts and clearly distinguish between "Beschikbaar" and "Niet beschikbaar" time ranges.
5.  Test with a resource that has no shifts to ensure the "Geen roosterinformatie beschikbaar" message is displayed correctly.

## Documentation
-   [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
-   [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-9cfa9811-55fe-427b-a1ed-e188de952f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cfa9811-55fe-427b-a1ed-e188de952f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

