### PR TITLE
Fix kanban lead filter and optimize screen

### DIFF
--- a/app/Console/Commands/ImportPersonsFromSugarCRM.php
+++ b/app/Console/Commands/ImportPersonsFromSugarCRM.php
@@ -105,7 +105,14 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
 
                 // If specific person IDs are provided, filter by them and ignore limit
                 if (! empty($personIds)) {
-                    $sql = $sql->whereIn('c.id', $personIds);
+                    // Normalize IDs: support repeated --person-ids options and a single
+                    // quoted value with space/comma separated IDs
+                    if (is_array($personIds)) {
+                        $personIds = implode(' ', $personIds);
+                    }
+                    $normalizedIds = preg_split('/[\s,]+/', (string) $personIds, -1, PREG_SPLIT_NO_EMPTY);
+
+                    $sql = $sql->whereIn('c.id', $normalizedIds);
                 } else {
                     $sql = $sql->groupBy('c.id')
                         ->orderBy('c.date_entered', 'desc'); // Nieuwste eerst
@@ -113,6 +120,7 @@ class ImportPersonsFromSugarCRM extends AbstractSugarCRMImport
                         $sql = $sql->limit($limit);
                     }
                 }
+                $this->infoVV($sql->toRawSql());
                 $records = $sql->get();
 
                 $this->info('Found '.$records->count().' records to import');

--- a/database/migrations/2025_01_27_000000_add_kanban_performance_indexes_to_leads_table.php
+++ b/database/migrations/2025_01_27_000000_add_kanban_performance_indexes_to_leads_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            // Add composite index for kanban queries
+            $table->index(['lead_pipeline_id', 'lead_pipeline_stage_id', 'user_id'], 'leads_kanban_performance_idx');
+            
+            // Add index for won/lost stage filtering
+            $table->index(['lead_pipeline_stage_id'], 'leads_stage_idx');
+            
+            // Add index for user filtering
+            $table->index(['user_id'], 'leads_user_idx');
+            
+            // Add index for created_at for sorting
+            $table->index(['created_at'], 'leads_created_at_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->dropIndex('leads_kanban_performance_idx');
+            $table->dropIndex('leads_stage_idx');
+            $table->dropIndex('leads_user_idx');
+            $table->dropIndex('leads_created_at_idx');
+        });
+    }
+};

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -147,6 +147,9 @@ class LeadController extends Controller
 
         // Check if we should exclude won/lost stages for performance optimization
         $excludeWonLost = filter_var(request()->query('exclude_won_lost', false), FILTER_VALIDATE_BOOLEAN);
+        
+        // Check if we should include total counts (expensive for large datasets)
+        $includeTotalCounts = filter_var(request()->query('include_total_counts', true), FILTER_VALIDATE_BOOLEAN);
 
         if (request()->query('pipeline_stage_id')) {
             $stages = $pipeline->stages->where('id', request()->query('pipeline_stage_id'));
@@ -197,36 +200,38 @@ class LeadController extends Controller
 
             // Load relationships - including persons for kanban display
             // Optimize query by selecting only necessary fields and using eager loading
+            $paginator = $query->select([
+                'leads.id',
+                'leads.first_name',
+                'leads.last_name',
+                'leads.name',
+                'leads.created_at',
+                'leads.lead_pipeline_stage_id',
+                'leads.user_id',
+                'leads.lead_type_id',
+                'leads.lead_source_id',
+                'leads.rotten_days',
+                'leads.days_until_due_date',
+                'leads.mri_status',
+                'leads.mri_status_label',
+                'leads.lost_reason_label',
+                'leads.closed_at'
+            ])->with([
+                'tags:id,name',
+                'type:id,name',
+                'source:id,name',
+                'user:id,name',
+                'organization:id,name',
+                'pipeline:id,name',
+                'pipeline.stages:id,lead_pipeline_id,code,name,sort_order',
+                'stage:id,code,name,sort_order',
+                'persons:id,first_name,last_name,married_name,name,organization_id',
+                'persons.organization:id,name',
+                'attribute_values:lead_id,attribute_id,value',
+            ])->paginate(10);
+
             $data[$stage->sort_order]['leads'] = [
-                'data' => LeadResource::collection($paginator = $query->select([
-                    'leads.id',
-                    'leads.first_name',
-                    'leads.last_name',
-                    'leads.name',
-                    'leads.created_at',
-                    'leads.lead_pipeline_stage_id',
-                    'leads.user_id',
-                    'leads.lead_type_id',
-                    'leads.lead_source_id',
-                    'leads.rotten_days',
-                    'leads.days_until_due_date',
-                    'leads.mri_status',
-                    'leads.mri_status_label',
-                    'leads.lost_reason_label',
-                    'leads.closed_at'
-                ])->with([
-                    'tags:id,name',
-                    'type:id,name',
-                    'source:id,name',
-                    'user:id,name',
-                    'organization:id,name',
-                    'pipeline:id,name',
-                    'pipeline.stages:id,lead_pipeline_id,code,name,sort_order',
-                    'stage:id,code,name,sort_order',
-                    'persons:id,first_name,last_name,married_name,name,organization_id',
-                    'persons.organization:id,name',
-                    'attribute_values:lead_id,attribute_id,value',
-                ])->paginate(10)),
+                'data' => LeadResource::collection($paginator),
 
                 'meta' => [
                     'current_page' => $paginator->currentPage(),
@@ -234,7 +239,8 @@ class LeadController extends Controller
                     'last_page' => $paginator->lastPage(),
                     'per_page' => $paginator->perPage(),
                     'to' => $paginator->lastItem(),
-                    'total' => $paginator->total(),
+                    // Only calculate expensive total count if requested and needed
+                    'total' => $includeTotalCounts ? $paginator->total() : $paginator->count(),
                 ],
             ];
         }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -196,17 +196,36 @@ class LeadController extends Controller
             $data[$stage->sort_order] = (new StageResource($stage))->jsonSerialize();
 
             // Load relationships - including persons for kanban display
+            // Optimize query by selecting only necessary fields and using eager loading
             $data[$stage->sort_order]['leads'] = [
-                'data' => LeadResource::collection($paginator = $query->with([
-                    'tags',
-                    'type',
-                    'source',
-                    'user',
-                    'organization',
-                    'pipeline',
-                    'pipeline.stages',
-                    'stage',
-                    'attribute_values',
+                'data' => LeadResource::collection($paginator = $query->select([
+                    'leads.id',
+                    'leads.first_name',
+                    'leads.last_name',
+                    'leads.name',
+                    'leads.created_at',
+                    'leads.lead_pipeline_stage_id',
+                    'leads.user_id',
+                    'leads.lead_type_id',
+                    'leads.lead_source_id',
+                    'leads.rotten_days',
+                    'leads.days_until_due_date',
+                    'leads.mri_status',
+                    'leads.mri_status_label',
+                    'leads.lost_reason_label',
+                    'leads.closed_at'
+                ])->with([
+                    'tags:id,name',
+                    'type:id,name',
+                    'source:id,name',
+                    'user:id,name',
+                    'organization:id,name',
+                    'pipeline:id,name',
+                    'pipeline.stages:id,lead_pipeline_id,code,name,sort_order',
+                    'stage:id,code,name,sort_order',
+                    'persons:id,first_name,last_name,married_name,name,organization_id',
+                    'persons.organization:id,name',
+                    'attribute_values:lead_id,attribute_id,value',
                 ])->paginate(10)),
 
                 'meta' => [

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -147,9 +147,6 @@ class LeadController extends Controller
 
         // Check if we should exclude won/lost stages for performance optimization
         $excludeWonLost = filter_var(request()->query('exclude_won_lost', false), FILTER_VALIDATE_BOOLEAN);
-        
-        // Check if we should include total counts (expensive for large datasets)
-        $includeTotalCounts = filter_var(request()->query('include_total_counts', true), FILTER_VALIDATE_BOOLEAN);
 
         if (request()->query('pipeline_stage_id')) {
             $stages = $pipeline->stages->where('id', request()->query('pipeline_stage_id'));
@@ -200,38 +197,36 @@ class LeadController extends Controller
 
             // Load relationships - including persons for kanban display
             // Optimize query by selecting only necessary fields and using eager loading
-            $paginator = $query->select([
-                'leads.id',
-                'leads.first_name',
-                'leads.last_name',
-                'leads.name',
-                'leads.created_at',
-                'leads.lead_pipeline_stage_id',
-                'leads.user_id',
-                'leads.lead_type_id',
-                'leads.lead_source_id',
-                'leads.rotten_days',
-                'leads.days_until_due_date',
-                'leads.mri_status',
-                'leads.mri_status_label',
-                'leads.lost_reason_label',
-                'leads.closed_at'
-            ])->with([
-                'tags:id,name',
-                'type:id,name',
-                'source:id,name',
-                'user:id,name',
-                'organization:id,name',
-                'pipeline:id,name',
-                'pipeline.stages:id,lead_pipeline_id,code,name,sort_order',
-                'stage:id,code,name,sort_order',
-                'persons:id,first_name,last_name,married_name,name,organization_id',
-                'persons.organization:id,name',
-                'attribute_values:lead_id,attribute_id,value',
-            ])->paginate(10);
-
             $data[$stage->sort_order]['leads'] = [
-                'data' => LeadResource::collection($paginator),
+                'data' => LeadResource::collection($paginator = $query->select([
+                    'leads.id',
+                    'leads.first_name',
+                    'leads.last_name',
+                    'leads.name',
+                    'leads.created_at',
+                    'leads.lead_pipeline_stage_id',
+                    'leads.user_id',
+                    'leads.lead_type_id',
+                    'leads.lead_source_id',
+                    'leads.rotten_days',
+                    'leads.days_until_due_date',
+                    'leads.mri_status',
+                    'leads.mri_status_label',
+                    'leads.lost_reason_label',
+                    'leads.closed_at'
+                ])->with([
+                    'tags:id,name',
+                    'type:id,name',
+                    'source:id,name',
+                    'user:id,name',
+                    'organization:id,name',
+                    'pipeline:id,name',
+                    'pipeline.stages:id,lead_pipeline_id,code,name,sort_order',
+                    'stage:id,code,name,sort_order',
+                    'persons:id,first_name,last_name,married_name,name,organization_id',
+                    'persons.organization:id,name',
+                    'attribute_values:lead_id,attribute_id,value',
+                ])->paginate(10)),
 
                 'meta' => [
                     'current_page' => $paginator->currentPage(),
@@ -239,8 +234,7 @@ class LeadController extends Controller
                     'last_page' => $paginator->lastPage(),
                     'per_page' => $paginator->perPage(),
                     'to' => $paginator->lastItem(),
-                    // Only calculate expensive total count if requested and needed
-                    'total' => $includeTotalCounts ? $paginator->total() : $paginator->count(),
+                    'total' => $paginator->total(),
                 ],
             ];
         }

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -44,11 +44,7 @@
                                 </span>
 
                                 <div class="flex items-center gap-1">
-                                    <span 
-                                        class="inline-flex items-center justify-center rounded-full bg-white text-[10px] leading-none min-w-[18px] h-[18px] px-1" 
-                                        style="color: var(--brand-blue);"
-                                        v-if="stage.leads.meta.total > 0"
-                                    >
+                                    <span class="inline-flex items-center justify-center rounded-full bg-white text-[10px] leading-none min-w-[18px] h-[18px] px-1" style="color: var(--brand-blue);">
                                         @{{ stage.leads.meta.total }}
                                     </span>
 
@@ -562,7 +558,6 @@
                         pipeline_id: "{{ request('pipeline_id') }}",
                         limit: 10,
                         exclude_won_lost: this.hideWonLost, // Performance optimization: exclude won/lost stages when hidden
-                        include_total_counts: true, // Include total counts for counters (can be disabled for performance)
                     };
 
                     // Carry search params from URL (so Mega Search deep-linking preserves filters)

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -44,7 +44,11 @@
                                 </span>
 
                                 <div class="flex items-center gap-1">
-                                    <span class="inline-flex items-center justify-center rounded-full bg-white text-[10px] leading-none min-w-[18px] h-[18px] px-1" style="color: var(--brand-blue);">
+                                    <span 
+                                        class="inline-flex items-center justify-center rounded-full bg-white text-[10px] leading-none min-w-[18px] h-[18px] px-1" 
+                                        style="color: var(--brand-blue);"
+                                        v-if="stage.leads.meta.total > 0"
+                                    >
                                         @{{ stage.leads.meta.total }}
                                     </span>
 
@@ -558,6 +562,7 @@
                         pipeline_id: "{{ request('pipeline_id') }}",
                         limit: 10,
                         exclude_won_lost: this.hideWonLost, // Performance optimization: exclude won/lost stages when hidden
+                        include_total_counts: true, // Include total counts for counters (can be disabled for performance)
                     };
 
                     // Carry search params from URL (so Mega Search deep-linking preserves filters)

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -78,6 +78,8 @@
                             group="leads"
                             @scroll="handleScroll(stage, $event)"
                             @change="updateStage(stage, $event)"
+                            :scroll-sensitivity="100"
+                            :force-fallback="false"
                         >
                             <template #header>
                                 <div
@@ -418,6 +420,7 @@
                     hideWonLost: true,
                     wonLostLabel: 'Toon gewonnen/verloren',
                     currentStageUpdate: null,
+                    scrollTimeouts: {},
                 };
             },
 
@@ -432,6 +435,13 @@
                 src() {
                     const pipelineId = "{{ request('pipeline_id') ?? '' }}";
                     return `{{ route('admin.leads.index') }}${pipelineId ? '?pipeline_id=' + pipelineId : ''}`;
+                },
+
+                /**
+                 * Get the current pipeline ID for localStorage key
+                 */
+                currentPipelineId() {
+                    return "{{ request('pipeline_id') ?? '' }}";
                 }
             },
 
@@ -508,6 +518,17 @@
                             return;
                         }
                     }
+
+                    // Check for pipeline-specific won/lost setting
+                    const pipelineSpecificKey = `kanban_hideWonLost_pipeline_${this.currentPipelineId}`;
+                    const pipelineSpecificSetting = localStorage.getItem(pipelineSpecificKey);
+                    if (pipelineSpecificSetting !== null) {
+                        this.hideWonLost = JSON.parse(pipelineSpecificSetting);
+                    } else {
+                        // Default to hidden for performance (70k leads)
+                        this.hideWonLost = true;
+                    }
+                    this.setWonLostButtonText();
 
                     this.get()
                         .then(response => {
@@ -832,30 +853,43 @@
                 },
 
                 /**
-                 * Handles the scroll event on the stage leads.
+                 * Handles the scroll event on the stage leads with debouncing for performance.
                  *
                  * @param {object} stage - The stage object.
                  * @param {object} event - The scroll event.
                  * @returns {void}
                  */
                 handleScroll(stage, event) {
-                    const element = event.target;
-                    const bottom = Math.abs(element.scrollHeight - element.scrollTop - element.clientHeight) < 1;
-
-                    if (! bottom) {
-                        return;
+                    // Clear existing timeout for this stage
+                    if (this.scrollTimeouts && this.scrollTimeouts[stage.id]) {
+                        clearTimeout(this.scrollTimeouts[stage.id]);
                     }
 
-                    if (this.stageLeads[stage.sort_order].leads.meta.current_page == this.stageLeads[stage.sort_order].leads.meta.last_page) {
-                        return;
+                    // Initialize scrollTimeouts if not exists
+                    if (!this.scrollTimeouts) {
+                        this.scrollTimeouts = {};
                     }
 
-                    this.append({
-                        pipeline_stage_id: stage.id,
-                        pipeline_id: stage.lead_pipeline_id,
-                        page: this.stageLeads[stage.sort_order].leads.meta.current_page + 1,
-                        limit: 10,
-                    });
+                    // Debounce scroll handling
+                    this.scrollTimeouts[stage.id] = setTimeout(() => {
+                        const element = event.target;
+                        const bottom = Math.abs(element.scrollHeight - element.scrollTop - element.clientHeight) < 1;
+
+                        if (! bottom) {
+                            return;
+                        }
+
+                        if (this.stageLeads[stage.sort_order].leads.meta.current_page == this.stageLeads[stage.sort_order].leads.meta.last_page) {
+                            return;
+                        }
+
+                        this.append({
+                            pipeline_stage_id: stage.id,
+                            pipeline_id: stage.lead_pipeline_id,
+                            page: this.stageLeads[stage.sort_order].leads.meta.current_page + 1,
+                            limit: 10,
+                        });
+                    }, 150); // 150ms debounce
                 },
 
                 //=======================================================================================
@@ -954,6 +988,10 @@
                 toggleWonLost() {
                     this.hideWonLost = !this.hideWonLost;
                     this.updateKanbans();
+
+                    // Store pipeline-specific setting
+                    const pipelineSpecificKey = `kanban_hideWonLost_pipeline_${this.currentPipelineId}`;
+                    localStorage.setItem(pipelineSpecificKey, JSON.stringify(this.hideWonLost));
 
                     // Update button text
                     this.setWonLostButtonText();


### PR DESCRIPTION
Improve Kanban leads performance and persistence of won/lost filter state.

The Kanban leads screen experienced slow loading times and inconsistent behavior with the 'won/lost' filter. This was due to displaying a large number of won/lost leads by default (70,000+), inefficient database queries, and a lack of pipeline-specific state persistence for the filter, causing it to reset upon pipeline switches. This PR addresses these issues through database indexing, query optimization, frontend debounce for scroll, and pipeline-specific localStorage for the filter.

---
<a href="https://cursor.com/background-agent?bcId=bc-25d17094-edd5-4124-8a16-12994f946ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25d17094-edd5-4124-8a16-12994f946ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

