### PR TITLE
Investigate unknown lead_id column error

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -226,7 +226,7 @@ class LeadController extends Controller
                     'stage:id,code,name,sort_order',
                     'persons:id,first_name,last_name,married_name,name,organization_id',
                     'persons.organization:id,name',
-                    'attribute_values:lead_id,attribute_id,value',
+                    'attribute_values:entity_id,attribute_id,value',
                 ])->paginate(10)),
 
                 'meta' => [


### PR DESCRIPTION
Fixes 500 error on lead kanban board by correcting `lead_id` to `entity_id` in `attribute_values` eager load.

The `attribute_values` table uses `entity_id` for its polymorphic relationship, not `lead_id`, which caused a "Column not found: 1054 Unknown column 'lead_id'" error when fetching lead data.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb49c0f1-b96a-4fc8-9710-72f71b458396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb49c0f1-b96a-4fc8-9710-72f71b458396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

