### PR TITLE
Select default clinic when creating resource

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/resource-form-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/resource-form-fields.blade.php
@@ -1,11 +1,18 @@
 @php use App\Models\Clinic;use App\Models\ResourceType; @endphp
 @props([
     'resource' => null,
+    'preSelectedClinicId' => null,
 ])
 
 @php
     $resourceTypes = ResourceType::orderBy('name')->get(['id', 'name']);
     $clinics = Clinic::orderBy('name')->get(['id', 'name']);
+    
+    // Pre-select clinic if provided
+    $selectedClinicId = old('clinic_id', $resource->clinic_id ?? '');
+    if (empty($selectedClinicId) && isset($preSelectedClinicId)) {
+        $selectedClinicId = $preSelectedClinicId;
+    }
 @endphp
 
 <!-- Naam -->
@@ -57,13 +64,13 @@
     <x-admin::form.control-group.control
         type="select"
         name="clinic_id"
-        value="{{ old('clinic_id', $resource->clinic_id ?? '') }}"
+        value="{{ $selectedClinicId }}"
         rules="required|numeric"
         :label="trans('admin::app.settings.resources.index.create.clinic')"
     >
         <option value="">@lang('admin::app.select')</option>
         @foreach ($clinics as $clinic)
-            <option value="{{ $clinic->id }}" @selected(old('clinic_id', $resource->clinic_id ?? '') == $clinic->id)>{{ $clinic->name }}</option>
+            <option value="{{ $clinic->id }}" @selected($selectedClinicId == $clinic->id)>{{ $clinic->name }}</option>
         @endforeach
     </x-admin::form.control-group.control>
 

--- a/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/resources/create.blade.php
@@ -22,7 +22,7 @@
             </div>
 
             <div class="box-shadow rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-                <x-admin::resource-form-fields />
+                <x-admin::resource-form-fields :pre-selected-clinic-id="$preSelectedClinicId" />
             </div>
         </div>
     </x-admin::form>

--- a/tests/Feature/Settings/ResourceCrudTest.php
+++ b/tests/Feature/Settings/ResourceCrudTest.php
@@ -73,3 +73,15 @@ test('can delete resource', function () {
         'id' => $resource->id,
     ]);
 });
+
+test('resource create page pre-selects clinic when clinic_id parameter is provided', function () {
+    $clinic = Clinic::factory()->create();
+    $resourceType = ResourceType::factory()->create();
+
+    $response = $this->get(route('admin.settings.resources.create', ['clinic_id' => $clinic->id]));
+    $response->assertOk();
+
+    // Check that the clinic is pre-selected in the form
+    $response->assertSee('value="' . $clinic->id . '"', false);
+    $response->assertSee($clinic->name, false);
+});


### PR DESCRIPTION
Pre-select the clinic when creating a resource if `clinic_id` is provided in the URL to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8a71e82-8466-48b4-8412-9f3cfd89ce42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8a71e82-8466-48b4-8412-9f3cfd89ce42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

