### PR TITLE
Build crm docker image in ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  docker-crm:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +32,28 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - name: Build and push image using build_image.sh
+      - name: Build and push CRM image using build_image.sh
         run: |
           chmod +x ./build_image.sh
           ./build_image.sh
+
+  docker-sync-flows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sync flows image using build_image_sync_flows.sh
+        run: |
+          chmod +x ./build_image_sync_flows.sh
+          ./build_image_sync_flows.sh


### PR DESCRIPTION
Add `build_image_sync_flows.sh` to GitHub CI to build the sync flows Docker image in parallel with the CRM Docker image.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a663011-9baa-4897-b215-892dac8db794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a663011-9baa-4897-b215-892dac8db794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

