### PR TITLE
Fix crmsyncn8n docker build failure

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,9 @@ jobs:
 
   docker-sync-flows:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,4 +59,6 @@ jobs:
       - name: Build and push sync flows image using build_image_sync_flows.sh
         run: |
           chmod +x ./build_image_sync_flows.sh
+          echo "Building sync flows image..."
           ./build_image_sync_flows.sh
+          echo "Sync flows image build completed successfully"

--- a/build_image_sync_flows.sh
+++ b/build_image_sync_flows.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Stel de variabelen in
 IMAGE_NAME="crmsyncn8n"

--- a/docker/php/Dockerfile.syncflows
+++ b/docker/php/Dockerfile.syncflows
@@ -21,8 +21,6 @@ RUN npm install -g n8n \
 COPY flows /app/flows
 COPY .docker/update-flows-n8n.sh /app/import-flows.sh
 COPY .docker/wait-for-n8n.sh /app/wait-for-n8n.sh
-# INTENTIONAL ERROR TO MAKE PIPELINE FAIL
-RUN invalid-command-that-will-fail
 
 # Maak script uitvoerbaar
 RUN chmod +x /app/import-flows.sh


### PR DESCRIPTION
Fix `permission_denied: write_package` error for `crmsyncn8n` Docker image by adding explicit GitHub Actions permissions and improving build script robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ab9837c-58c5-4c1b-887e-c8a36906b175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ab9837c-58c5-4c1b-887e-c8a36906b175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

