### PR TITLE
MBS-25: Fix breedte checkbox 'Publiceren patiëntportaal' in Bestand toevoegen modal

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/file.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/file.blade.php
@@ -105,7 +105,7 @@
                                         type="checkbox"
                                         v-model="publishToPortal"
                                         @change="onPublishChange"
-                                        class="rounded border-gray-300"
+                                        class="h-4 w-4 shrink-0 rounded border-gray-300"
                                     />
                                     <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
                                         Publiceren in patiëntportaal


### PR DESCRIPTION
## Wat
Voeg `h-4 w-4 shrink-0` toe aan de checkbox \"Publiceren in patiëntportaal\" in de Bestand toevoegen modal bij de kliniek-view.

## Waarom
Zonder expliciete breedte/hoogte stretcht een `<input type=\"checkbox\">` in een flex-container in Safari (en soms Chrome) tot de volle breedte van het formulier.

## Wijziging
- `packages/Webkul/Admin/src/Resources/views/components/activities/actions/file.blade.php`: class `rounded border-gray-300` → `h-4 w-4 shrink-0 rounded border-gray-300`

## Test
- [ ] Checkbox heeft normale afmeting (≈16×16px) in Chrome
- [ ] Checkbox heeft normale afmeting in Safari
- [ ] Geen regressie op andere checkboxen in de kliniek-view