### PR TITLE
fix(MBS-22): lead adresvelden correct leegmaken

### DIFF
--- a/app/Repositories/AddressRepository.php
+++ b/app/Repositories/AddressRepository.php
@@ -48,6 +48,9 @@ class AddressRepository extends Repository
             return null;
         }
 
+        // Strip UI-only meta keys (e.g. _clear) before processing address fields
+        $addressFields = array_diff_key($addressData, array_flip(['_clear']));
+
         // Normalize empty strings to null so cleared fields are stored as null
         $normalized = array_map(function ($value) {
             if (is_string($value) && trim($value) === '') {
@@ -55,7 +58,7 @@ class AddressRepository extends Repository
             }
 
             return $value;
-        }, $addressData);
+        }, $addressFields);
 
         // Filter to filled fields only for update behavior decision
         $filled = array_filter($normalized, function ($value) {

--- a/tests/Feature/Leads/LeadAddressClearTest.php
+++ b/tests/Feature/Leads/LeadAddressClearTest.php
@@ -98,6 +98,31 @@ test('_clear flag 1 deletes the address and clears address_id', function () {
     $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
 });
 
+test('clearing all address fields with _clear=0 (form default) deletes the address', function () {
+    $lead = Lead::factory()->withAddress()->create();
+    $originalAddressId = $lead->address_id;
+
+    $this->assertNotNull($originalAddressId);
+    $this->assertDatabaseHas('addresses', ['id' => $originalAddressId]);
+
+    // Simulate what the HTML form sends: _clear='0' (hidden default) + all fields empty
+    $this->addressRepository->upsertForEntity($lead, [
+        '_clear'              => '0',
+        'street'              => '',
+        'house_number'        => '',
+        'house_number_suffix' => '',
+        'postal_code'         => '',
+        'city'                => '',
+        'state'               => '',
+        'country'             => '',
+    ]);
+
+    $lead->refresh();
+
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});
+
 test('_clear flag 0 keeps the existing address', function () {
     $lead = Lead::factory()->withAddress()->create();
     $originalAddressId = $lead->address_id;

--- a/tests/Feature/Leads/LeadAddressHttpTest.php
+++ b/tests/Feature/Leads/LeadAddressHttpTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Address;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Lead\Models\Lead;
+use Webkul\User\Models\User;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+    $this->user = User::factory()->active()->create();
+});
+
+test('submitting empty address fields via HTTP clears the address', function () {
+    $lead = Lead::factory()->withAddress()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $originalAddressId = $lead->address_id;
+    $this->assertNotNull($originalAddressId);
+
+    $response = $this->actingAs($this->user, 'user')
+        ->put(route('admin.leads.update', $lead->id), [
+            'first_name' => $lead->first_name ?? 'Test',
+            'last_name'  => $lead->last_name ?? 'Lead',
+            'address'    => [
+                '_clear'              => '0',
+                'street'              => '',
+                'house_number'        => '',
+                'house_number_suffix' => '',
+                'postal_code'         => '',
+                'city'                => '',
+                'state'               => '',
+                'country'             => '',
+            ],
+        ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+
+    $lead->refresh();
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});
+
+test('submitting _clear=1 via HTTP deletes the address', function () {
+    $lead = Lead::factory()->withAddress()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $originalAddressId = $lead->address_id;
+    $this->assertNotNull($originalAddressId);
+
+    $response = $this->actingAs($this->user, 'user')
+        ->put(route('admin.leads.update', $lead->id), [
+            'first_name' => $lead->first_name ?? 'Test',
+            'last_name'  => $lead->last_name ?? 'Lead',
+            'address'    => [
+                '_clear' => '1',
+            ],
+        ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+
+    $lead->refresh();
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});


### PR DESCRIPTION
## Samenvatting

Bugfix voor MBS-22: lege adresvelden bij een lead werden niet opgeslagen.

**Root cause:** De hidden form input `address[_clear]=0` (altijd aanwezig in het HTML-formulier) bevuilde de `$filled`-array in `AddressRepository::upsertForEntity`. Omdat `'0'` niet `null` is, was `$filled` nooit leeg, waardoor de branch "verwijder adres als alle velden leeg zijn" nooit werd bereikt. In plaats daarvan probeerde de code het bestaande adres bij te werken met alle velden op `null`, wat de DB-constraints zou schenden.

**Fix:** Strip UI-only meta-keys (zoals `_clear`) vóór normalisatie zodat uitsluitend echte adresvelden de branch-logica bepalen.

## Wijzigingen

- `app/Repositories/AddressRepository.php` — strip `_clear` en andere meta-keys vóór normalisatie
- `tests/Feature/Leads/LeadAddressClearTest.php` — test toegevoegd: `_clear=0` + lege velden → adres verwijderd
- `tests/Feature/Leads/LeadAddressHttpTest.php` — HTTP end-to-end tests voor leegmaken via PUT endpoint

## Test plan

- [ ] `tests/Feature/Leads/LeadAddressClearTest.php` — alle tests groen
- [ ] `tests/Feature/Leads/LeadAddressHttpTest.php` — alle tests groen
- [ ] Handmatig: lead met adres openen, alle velden leegmaken, opslaan → adres weg
- [ ] Handmatig: lead zonder adres openen, opslaan → geen foutmelding

Closes MBS-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)