### PR TITLE
fix(MBS-27): verberg veld 'actief' in lead-bewerkformulier

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -138,7 +138,7 @@
 
                         <div class="w-1/2 max-md:w-full">
                             <!-- Personal Fields Component -->
-                            @include('admin::leads.common.personal-fields', ['entity' => $lead])
+                            @include('admin::leads.common.personal-fields', ['entity' => $lead, 'showPortalFields' => false])
                         </div>
                     </div>
 


### PR DESCRIPTION
## Samenvatting

Bugfix voor MBS-27: het veld 'Actief' (is_active) was zichtbaar in het lead-bewerkformulier, terwijl het Lead-model dit veld niet heeft.

**Root cause:** De gedeelde `personal-fields.blade.php` toont het `is_active` veld wanneer `$showPortalFields=true` (de standaard). Het lead create-formulier gaf al correct `showPortalFields => false` mee. Het lead edit-formulier vergat dit.

**Fix:** Voeg `'showPortalFields' => false` toe aan de include in `leads/edit.blade.php`.

## Acceptance criteria

- [x] Veld 'Actief' is **niet** zichtbaar in het lead-aanmaak/bewerk-formulier
- [x] Veld 'Actief' is **wel** zichtbaar in het person-formulier (ongewijzigd)
- [x] Geen foutmelding bij opslaan van een lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)