### PR TITLE
feat(MBS-29): web-to-lead marketing UTM velden

### DIFF
--- a/app/Http/Requests/Api/HerniaCreateLeadRequest.php
+++ b/app/Http/Requests/Api/HerniaCreateLeadRequest.php
@@ -35,6 +35,25 @@ class HerniaCreateLeadRequest extends FormRequest
 
             'description'          => ['nullable', 'string'],
             'diagnoseform_pdf_url' => ['nullable', 'string'],
+
+            // Marketing / UTM tracking fields
+            'source'         => ['nullable', 'string'],
+            'medium'         => ['nullable', 'string'],
+            'campaign'       => ['nullable', 'string'],
+            'adgroup'        => ['nullable', 'string'],
+            'utm_term'       => ['nullable', 'string'],
+            'utm_content'    => ['nullable', 'string'],
+            'utm_id'         => ['nullable', 'string'],
+            'gclid'          => ['nullable', 'string'],
+            'gbraid'         => ['nullable', 'string'],
+            'wbraid'         => ['nullable', 'string'],
+            'gad_source'     => ['nullable', 'string'],
+            'gad_campaignid' => ['nullable', 'string'],
+            'landing_page'   => ['nullable', 'string'],
+            'referrer'       => ['nullable', 'string'],
+            'first_visit_at' => ['nullable', 'string'],
+            'last_visit_at'  => ['nullable', 'string'],
+            'attribution_url'=> ['nullable', 'string'],
         ];
     }
 

--- a/app/Models/LeadMarketingData.php
+++ b/app/Models/LeadMarketingData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Webkul\Lead\Models\Lead;
+
+class LeadMarketingData extends Model
+{
+    protected $table = 'lead_marketing_data';
+
+    protected $fillable = [
+        'lead_id',
+        'key',
+        'value',
+    ];
+
+    public function lead()
+    {
+        return $this->belongsTo(Lead::class);
+    }
+}

--- a/app/Services/InboundLeads/InboundLeadPayloadMapper.php
+++ b/app/Services/InboundLeads/InboundLeadPayloadMapper.php
@@ -51,6 +51,33 @@ class InboundLeadPayloadMapper
         ], static fn ($v) => $v !== null);
     }
 
+    /**
+     * Extract marketing tracking fields from the Hernia payload.
+     * Returns only fields that have a non-empty value.
+     */
+    public function extractHerniaMarketingData(array $payload): array
+    {
+        $keys = [
+            'source', 'medium', 'campaign', 'adgroup',
+            'utm_term', 'utm_content', 'utm_id',
+            'gclid', 'gbraid', 'wbraid',
+            'gad_source', 'gad_campaignid',
+            'landing_page', 'referrer',
+            'first_visit_at', 'last_visit_at',
+            'attribution_url',
+        ];
+
+        $result = [];
+        foreach ($keys as $key) {
+            $value = $this->nullIfEmpty($payload[$key] ?? null);
+            if ($value !== null) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
     private function mapHerniaAddress(array $payload): array
     {
         $houseNumber = $this->nullIfEmpty($payload['primary_huisnr_c'] ?? null);

--- a/database/migrations/2026_03_28_000000_create_lead_marketing_data_table.php
+++ b/database/migrations/2026_03_28_000000_create_lead_marketing_data_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lead_marketing_data', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('lead_id');
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->timestamps();
+
+            $table->foreign('lead_id')->references('id')->on('leads')->onDelete('cascade');
+            $table->index(['lead_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lead_marketing_data');
+    }
+};

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/marketing.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/marketing.blade.php
@@ -152,4 +152,46 @@ $hasActiveCampaign = $lead->channel !== null;
     </div>
 </div>
 
+@php
+$marketingDataMap = $lead->marketingData->pluck('value', 'key');
+$marketingLabels = [
+    'source'          => 'Source',
+    'medium'          => 'Medium',
+    'campaign'        => 'Campaign',
+    'adgroup'         => 'Ad Group',
+    'utm_term'        => 'UTM Term',
+    'utm_content'     => 'UTM Content',
+    'utm_id'          => 'UTM ID',
+    'gclid'           => 'GCLID',
+    'gbraid'          => 'GBraid',
+    'wbraid'          => 'WBraid',
+    'gad_source'      => 'GAD Source',
+    'gad_campaignid'  => 'GAD Campaign ID',
+    'landing_page'    => 'Landing Page',
+    'referrer'        => 'Referrer',
+    'first_visit_at'  => 'Eerste bezoek',
+    'last_visit_at'   => 'Laatste bezoek',
+    'attribution_url' => 'Attribution URL',
+];
+@endphp
+
+@if($marketingDataMap->isNotEmpty())
+<div class="rounded-lg border bg-white dark:border-gray-800 dark:bg-gray-900">
+    <div class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+        <span class="icon-chart text-xl text-gray-600 dark:text-gray-400"></span>
+        <h3 class="text-base font-semibold text-gray-900 dark:text-white">Google Ads / UTM Tracking</h3>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+        @foreach($marketingLabels as $key => $label)
+            @if($marketingDataMap->has($key))
+            <div class="flex flex-col gap-1">
+                <span class="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">{{ $label }}</span>
+                <span class="text-sm text-gray-900 dark:text-white break-all">{{ $marketingDataMap[$key] }}</span>
+            </div>
+            @endif
+        @endforeach
+    </div>
+</div>
+@endif
+
 {!! view_render_event('admin.leads.view.marketing.after', ['lead' => $lead]) !!}

--- a/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
+++ b/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
@@ -27,6 +27,7 @@ use Webkul\Admin\Http\Controllers\Lead\LeadController as AdminLeadController;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Repositories\AttributeValueRepository;
 use Illuminate\Support\Facades\DB;
+use App\Models\LeadMarketingData;
 use App\Services\LeadValidationService;
 use Webkul\Core\Contracts\Validations\PhoneValidator;
 
@@ -67,13 +68,30 @@ class LeadController extends Controller
      */
     public function storeHernia(HerniaCreateLeadRequest $inbound): JsonResponse
     {
-        $mapped = $this->inboundLeadPayloadMapper->mapHernia($inbound->validated());
+        $validated = $inbound->validated();
+        $mapped = $this->inboundLeadPayloadMapper->mapHernia($validated);
+        $marketingData = $this->inboundLeadPayloadMapper->extractHerniaMarketingData($validated);
 
         $leadForm = LeadForm::createFrom($inbound);
         $leadForm->setContainer(app());
         $leadForm->replace($mapped);
 
-        return $this->storeFromLeadForm($leadForm, forceDepartmentId: Department::findHerniaId(), allowInvalidPhone: true);
+        $response = $this->storeFromLeadForm($leadForm, forceDepartmentId: Department::findHerniaId(), allowInvalidPhone: true);
+
+        if ($response->getStatusCode() === 201 && ! empty($marketingData)) {
+            $leadId = json_decode($response->getContent(), true)['lead_id'] ?? null;
+            if ($leadId) {
+                foreach ($marketingData as $key => $value) {
+                    LeadMarketingData::create([
+                        'lead_id' => $leadId,
+                        'key'     => $key,
+                        'value'   => $value,
+                    ]);
+                }
+            }
+        }
+
+        return $response;
     }
 
     /**

--- a/packages/Webkul/Lead/src/Models/Lead.php
+++ b/packages/Webkul/Lead/src/Models/Lead.php
@@ -9,6 +9,7 @@ use App\Enums\PersonGender;
 use App\Enums\PersonSalutation;
 use App\Models\Anamnesis;
 use App\Models\Department;
+use App\Models\LeadMarketingData;
 use App\Traits\HasDefaultContactInfo;
 use BackedEnum;
 use Carbon\Carbon;
@@ -446,6 +447,22 @@ class Lead extends Model implements LeadContract
 
     public function hasOrganization(): bool {
         return !is_null($this->organization_id);
+    }
+
+    /**
+     * Get the marketing data for this lead.
+     */
+    public function marketingData()
+    {
+        return $this->hasMany(LeadMarketingData::class);
+    }
+
+    /**
+     * Get marketing data as key => value array.
+     */
+    public function getMarketingDataMapAttribute(): array
+    {
+        return $this->marketingData->pluck('value', 'key')->all();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Nieuwe tabel `lead_marketing_data` (key-value) voor marketing trackingdata gekoppeld aan een lead
- `HerniaCreateLeadRequest` accepteert nu de extra UTM/Google Ads velden: `source`, `medium`, `campaign`, `adgroup`, `utm_term`, `utm_content`, `utm_id`, `gclid`, `gbraid`, `wbraid`, `gad_source`, `gad_campaignid`, `landing_page`, `referrer`, `first_visit_at`, `last_visit_at`, `attribution_url`
- `InboundLeadPayloadMapper::extractHerniaMarketingData()` extraheert de marketing velden uit de payload
- `LeadController::storeHernia()` slaat marketing data op na succesvolle lead-aanmaak
- `Lead` model heeft `marketingData()` relatie
- Marketing tab in lead-view toont de UTM/Google Ads trackingdata wanneer aanwezig

## Test plan

- [ ] POST naar `api/leads/hernia` met UTM-velden → velden opgeslagen in `lead_marketing_data`
- [ ] POST zonder UTM-velden → lead aangemaakt, geen marketingdata records
- [ ] Lead-view → marketing tab → Google Ads / UTM sectie zichtbaar wanneer data aanwezig
- [ ] Migratie draaien: `php artisan migrate`

Closes [MBS-29](/MBS/issues/MBS-29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)