### PR TITLE
fix(MBS-41): filter email activities by is_done in sales popup

### DIFF
--- a/app/Http/Controllers/Admin/SalesLeadController.php
+++ b/app/Http/Controllers/Admin/SalesLeadController.php
@@ -415,6 +415,10 @@ class SalesLeadController extends Controller
         $all = $salesActivities->merge($orderActivities)->unique('id')->values();
         $merged = $this->concatEmailActivitiesFor('sales', (int) $id, $all, $this->attachmentRepository);
 
+        if (! is_null($isDoneFilter)) {
+            $merged = $merged->filter(fn ($a) => (int) $a->is_done === $isDoneFilter)->values();
+        }
+
         return ActivityResource::collection($merged);
     }
 


### PR DESCRIPTION
## Samenvatting

Fixes [MBS-41] onjuiste activiteitslijst in Sales-popup.

**Root cause:** In `SalesLeadController::activities()` werden na het filteren op `is_done` de e-mailactiviteiten (altijd `is_done: 1`) onvoorwaardelijk toegevoegd via `concatEmailActivitiesFor()`. Hierdoor verschenen afgesloten mailactiviteiten in de popup voor openstaande activiteiten bij het op 'gewonnen' zetten van een lead.

**Fix:** Na het samenvoegen van e-mailactiviteiten wordt de `is_done` filter alsnog toegepast op de volledige collectie.

## Gewijzigde bestanden

- `app/Http/Controllers/Admin/SalesLeadController.php` — filter de samengevoegde collectie (inclusief e-mails) op `is_done` als de parameter is meegegeven

## Test plan

- [ ] Maak een Sales-lead aan met een afgesloten Mail-activiteit
- [ ] Zet de lead op 'Gewonnen'
- [ ] Controleer dat de popup alleen openstaande activiteiten toont (geen afgesloten mails)
- [ ] Controleer dat de activiteitenlijst zonder filter (`is_done` niet opgegeven) nog steeds e-mails toont

🤖 Generated with [Claude Code](https://claude.com/claude-code)