### PR TITLE
feat(MBS-57): show start time per product in clinic guide, remove email

### DIFF
--- a/app/Http/Controllers/Admin/ClinicGuideController.php
+++ b/app/Http/Controllers/Admin/ClinicGuideController.php
@@ -45,7 +45,7 @@ class ClinicGuideController extends Controller
                         $q->whereHas('partnerProducts', function ($q) {
                             $q->whereHas('clinics');
                         });
-                    })->with(['product', 'person']);
+                    })->with(['product', 'person', 'resourceOrderItems']);
                 },
                 'stage',
                 'user',
@@ -123,6 +123,7 @@ class ClinicGuideController extends Controller
                             'product_name' => $item->product?->name,
                             'person_name'  => $item->person?->name,
                             'quantity'     => $item->quantity,
+                            'start_time'   => $item->resourceOrderItems->sortBy('from')->first()?->from?->format('H:i'),
                         ]),
                         'order_url'      => $orderUrl,
                     ];

--- a/resources/views/adminc/clinic_guide/index.blade.php
+++ b/resources/views/adminc/clinic_guide/index.blade.php
@@ -147,14 +147,7 @@
                                     </a>
                                 </div>
 
-                                <div v-if="item.patient.emails && item.patient.emails.length" class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
-                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-                                    </svg>
-                                    <a :href="'mailto:' + item.patient.emails[0].value" class="hover:text-indigo-600">
-                                        @{{ item.patient.emails[0].value }}
-                                    </a>
-                                </div>
+
                             </div>
 
                             <div v-if="!item.patient" class="text-sm text-gray-400 dark:text-gray-500 italic">
@@ -173,6 +166,7 @@
                                         <span class="w-1 h-1 bg-gray-400 rounded-full flex-shrink-0"></span>
                                         <span>@{{ oi.product_name || 'Onbekend product' }}</span>
                                         <span v-if="oi.quantity > 1" class="text-gray-400">x@{{ oi.quantity }}</span>
+                                        <span v-if="oi.start_time" class="text-gray-400 ml-1">(@{{ oi.start_time }})</span>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
## Summary

- In de Producten sectie van de clinic guide wordt nu de starttijd van het onderzoek getoond (alleen tijd, niet de volledige datum), afkomstig uit de geplande resource (`ResourceOrderItem.from`)
- E-mailadres van de patiënt is verwijderd uit de kaart

## Changes

- `ClinicGuideController`: laad `resourceOrderItems` relatie mee voor order items; voeg `start_time` (format `H:i`) toe aan elk order item in de API response
- `clinic_guide/index.blade.php`: toon `start_time` achter productnaam in de Producten lijst; verwijder email blok

## Test plan

- [ ] Open `/admin/clinic-guide` en navigeer naar een dag met afspraken
- [ ] Controleer dat in de Producten sectie de starttijd tussen haakjes wordt getoond (bijv. `MRI Scan (09:30)`)
- [ ] Controleer dat voor producten zonder geplande resource geen tijd wordt getoond
- [ ] Controleer dat het e-mailadres niet meer zichtbaar is op de kaart

🤖 Generated with [Claude Code](https://claude.com/claude-code)