### PR TITLE
fix: prevent exception leakage and PII logging (MBS-77)

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -262,7 +262,11 @@ class EmailController extends Controller
 
             return Storage::download($attachment->path, $downloadName);
         } catch (Exception $e) {
-            session()->flash('error', $e->getMessage());
+            Log::error('EmailController@download: Error downloading attachment', [
+                'attachment_id' => $id,
+                'error' => $e->getMessage(),
+            ]);
+            session()->flash('error', trans('admin::app.mail.download-failed'));
 
             return redirect()->back();
         }
@@ -522,13 +526,10 @@ class EmailController extends Controller
             Log::error('Error in email templates.get endpoint', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
-                'request_params' => request()->all(),
             ]);
 
             return response()->json([
                 'error' => __('messages.email.server_error'),
-                'message' => $e->getMessage(),
-                'trace' => config('app.debug') ? $e->getTraceAsString() : null,
             ], 500);
         }
     }
@@ -654,9 +655,7 @@ class EmailController extends Controller
 
             return response()->json([
                 'error' => __('messages.email.template_render_error'),
-                'message' => $e->getMessage(),
-                'trace' => config('app.debug') ? $e->getTraceAsString() : null,
-            ], 404);
+            ], 500);
         }
     }
 
@@ -709,8 +708,6 @@ class EmailController extends Controller
 
             return response()->json([
                 'error' => __('messages.email.template_render_error'),
-                'message' => $e->getMessage(),
-                'trace' => config('app.debug') ? $e->getTraceAsString() : null,
             ], 500);
         }
     }
@@ -764,8 +761,6 @@ class EmailController extends Controller
 
             return response()->json([
                 'error' => __('messages.email.template_render_error'),
-                'message' => $e->getMessage(),
-                'trace' => config('app.debug') ? $e->getTraceAsString() : null,
             ], 500);
         }
     }

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -2026,6 +2026,7 @@ return [
         'delete-failed'       => 'Email can not be deleted.',
         'move-success'        => 'Email moved successfully.',
         'move-failed'         => 'Email could not be moved.',
+        'download-failed'     => 'Attachment could not be downloaded.',
 
         'view' => [
             'title'                      => 'Mails',

--- a/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
+++ b/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
@@ -247,10 +247,8 @@ class LeadController extends Controller
                 'errors' => [$e->getMessage()],
             ], 400);
         } catch (Exception $e) {
-            Log::error('Could not store lead ', [
+            Log::error('Could not store lead', [
                 'error' => $e->getMessage(),
-                'data' => $request->all(),
-                'trace' => $e->getTrace(),
             ]);
 
             return response()->json([


### PR DESCRIPTION
## Summary

Implements security fixes from controller reviews [MBS-73] and [MBS-74]:

- **EmailController** (`packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php`)
  - Removed `$e->getMessage()` and stack traces from all JSON error responses (`get`, `getTemplateContent`, `getTemplateContentBody`, `getTemplateContentSubject`)
  - Fixed `download()` to use a generic flash message instead of `$e->getMessage()`
  - Technical details remain in server-side `Log::error()` only
  - Added `download-failed` translation key

- **LeadController API** (`packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php`)
  - Removed `$request->all()` (PII: name, email, phone) from `Log::error()` on lead store failure
  - Removed `$e->getTrace()` (full stack trace) from application logs

## Test plan

- [ ] POST/GET to email template endpoints returns generic error on failure, no exception message in response body
- [ ] Downloading a non-existent attachment shows generic flash error, not the storage exception message
- [ ] Creating a lead with invalid data logs only the error message, not the full request body or stack trace
- [ ] Verify `Log::error()` still logs the exception message server-side for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)