### PR TITLE
fix: exclude LOST order items from afletteren tab

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/orders/view/tab-afletteren.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/view/tab-afletteren.blade.php
@@ -1,6 +1,7 @@
 @props(['order'])
 
 @php
+    use App\Enums\OrderItemStatus;
     use App\Enums\OrderPurchaseStatus;
 
     $priceFields = [
@@ -34,6 +35,10 @@
     ];
 
     foreach (($order->orderItems ?? collect()) as $item) {
+        if ($item->status === OrderItemStatus::LOST) {
+            continue;
+        }
+
         $purchaseTotal = $asAmount($item->resolvedPurchasePrice()->purchase_price);
         $invoiceTotal  = $asAmount($item->invoicePurchasePrice?->purchase_price);
         $status = OrderPurchaseStatus::forItem($purchaseTotal, $invoiceTotal);

--- a/tests/Feature/Orders/AfletterenTabTest.php
+++ b/tests/Feature/Orders/AfletterenTabTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Orders;
+
+use App\Enums\OrderItemStatus;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\PartnerProduct;
+use Webkul\Installer\Http\Middleware\CanInstall;
+use Webkul\Product\Models\Product;
+
+beforeEach(function () {
+    test()->withoutMiddleware(CanInstall::class);
+    $this->actingAs(makeUser(), 'user');
+});
+
+test('afletteren tab does not show order items with status LOST', function () {
+    $order = Order::factory()->create();
+    $product = Product::factory()->create(['name' => 'TestProductVerloren_'.uniqid()]);
+
+    $pp = PartnerProduct::factory()->create(['product_id' => $product->id]);
+    $pp->purchasePrice->update(['purchase_price_clinic' => 99.00, 'purchase_price' => 99.00]);
+
+    OrderItem::factory()->create([
+        'order_id'   => $order->id,
+        'product_id' => $product->id,
+        'status'     => OrderItemStatus::LOST,
+    ]);
+
+    $response = $this->get(route('admin.orders.view', $order->id));
+    $response->assertOk();
+    $response->assertDontSee($product->name, false);
+});
+
+test('afletteren tab shows order items that are not LOST when they have purchase prices', function () {
+    $order = Order::factory()->create();
+    $product = Product::factory()->create(['name' => 'TestProductWon_'.uniqid()]);
+
+    $pp = PartnerProduct::factory()->create(['product_id' => $product->id]);
+    $pp->purchasePrice->update(['purchase_price_clinic' => 99.00, 'purchase_price' => 99.00]);
+
+    OrderItem::factory()->create([
+        'order_id'   => $order->id,
+        'product_id' => $product->id,
+        'status'     => OrderItemStatus::WON,
+    ]);
+
+    $response = $this->get(route('admin.orders.view', $order->id));
+    $response->assertOk();
+    $response->assertSee($product->name, false);
+});


### PR DESCRIPTION
## Summary

- Order items with status **Verloren** (LOST) zijn nu uitgesloten van de afletteren-tab
- Fix zit in `tab-afletteren.blade.php`: vóór de inkoop/invoice-berekening wordt gecheckt of `$item->status === OrderItemStatus::LOST`, zo ja wordt het item overgeslagen
- Test toegevoegd in `AfletterenTabTest.php` die verifieert dat LOST items niet getoond worden en WON items (met inkoopprijs) wel

Closes [MBS-84](/MBS/issues/MBS-84)

## Test plan
- [ ] Open een order met order regels waarvan minimaal één de status Verloren heeft
- [ ] Ga naar het tabblad **Afletteren**
- [ ] Verifieer dat de verloren orderregel niet zichtbaar is in de tabel
- [ ] Verifieer dat overige order regels (Gewonnen, Ingepland) wel zichtbaar zijn

🤖 Generated with [Claude Code](https://claude.com/claude-code)