### PR TITLE
fix: performance N+1 queries in Win/Lost pipeline kanban view

### DIFF
--- a/app/Http/Controllers/Admin/SalesLeadController.php
+++ b/app/Http/Controllers/Admin/SalesLeadController.php
@@ -96,12 +96,16 @@ class SalesLeadController extends Controller
                 continue;
             }
 
-            $query = SalesLead::with(['stage', 'lead', 'user', 'orders'])
+            $query = SalesLead::with(['stage', 'lead', 'user', 'orders', 'persons.organization'])
+                ->withCount([
+                    'activities as open_activities_count' => fn ($q) => $q->where('is_done', 0),
+                    'emails as unread_emails_count'       => fn ($q) => $q->where('is_read', 0),
+                ])
                 ->where('pipeline_stage_id', $stage->id);
             $salesLeads = $query->get();
 
             $salesLeads = $salesLeads->map(function ($salesLead) {
-                $person = $salesLead->persons()->first();
+                $person = $salesLead->persons->first();
 
                 $stagePayload = $salesLead->stage ? [
                     'id'      => $salesLead->stage->id,

--- a/app/Models/SalesLead.php
+++ b/app/Models/SalesLead.php
@@ -155,6 +155,10 @@ class SalesLead extends Model
      */
     public function getOpenActivitiesCountAttribute(): int
     {
+        if (isset($this->attributes['open_activities_count'])) {
+            return (int) $this->attributes['open_activities_count'];
+        }
+
         return (int) $this->activities()->where('is_done', 0)->count();
     }
 
@@ -163,6 +167,10 @@ class SalesLead extends Model
      */
     public function getUnreadEmailsCountAttribute(): int
     {
+        if (isset($this->attributes['unread_emails_count'])) {
+            return (int) $this->attributes['unread_emails_count'];
+        }
+
         return (int) $this->emails()->where('is_read', 0)->count();
     }
 
@@ -317,6 +325,14 @@ class SalesLead extends Model
      */
     public function getPersonsCountAttribute(): int
     {
+        if ($this->relationLoaded('persons')) {
+            return $this->persons->count();
+        }
+
+        if (isset($this->attributes['persons_count'])) {
+            return (int) $this->attributes['persons_count'];
+        }
+
         return (int) $this->persons()->count();
     }
 
@@ -325,6 +341,10 @@ class SalesLead extends Model
      */
     public function hasMultiplePersons(): bool
     {
+        if ($this->relationLoaded('persons')) {
+            return $this->persons->count() > 1;
+        }
+
         return $this->persons()->count() > 1;
     }
 


### PR DESCRIPTION
## Summary

Fixes [MBS-85](/MBS/issues/MBS-85) — pipeline kanban view took ~3 minutes to load when showing Win/Lost stages.

**Root cause:** Multiple N+1 queries per sales lead in `SalesLeadController::get()`:
- `persons()->first()` — executed per lead (not eager loaded)
- `person->organization` — executed per lead (not eager loaded)
- `hasMultiplePersons()` → `persons()->count()` — executed per lead
- `persons_count` → `persons()->count()` — executed per lead
- `open_activities_count` → `activities()->count()` — executed per lead
- `unread_emails_count` → `emails()->count()` — executed per lead

With thousands of won/lost leads this multiplied to thousands of extra queries.

**Fix:**
- Add `persons.organization` to `with()` in the kanban query
- Add `withCount()` for open activities and unread emails
- Update `SalesLead` accessors to use already-loaded relations/attributes instead of re-querying
- Use `$salesLead->persons->first()` (loaded collection) instead of `$salesLead->persons()->first()` (new query)

## Test plan
- [ ] Open pipeline kanban view
- [ ] Toggle Win/Lost on — should load significantly faster (seconds instead of ~3 minutes)
- [ ] Verify lead cards still show correct person, organization, activity counts
- [ ] Check open_activities_count and unread_emails_count show correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)