### PR TITLE
fix: anamnesis edit screen toont verkeerde naam bij import

### DIFF
--- a/app/Models/Anamnesis.php
+++ b/app/Models/Anamnesis.php
@@ -200,6 +200,6 @@ class Anamnesis extends Model
 
     public function getLabelAttribute(): string
     {
-        return $this->lead?->title ?? $this->sales?->name ?? 'Onbekend';
+        return $this->person?->name ?? $this->lead?->title ?? $this->sales?->name ?? 'Onbekend';
     }
 }

--- a/packages/Webkul/Lead/src/Models/Lead.php
+++ b/packages/Webkul/Lead/src/Models/Lead.php
@@ -609,7 +609,7 @@ class Lead extends Model implements LeadContract
                     ],
                     [
                         'id' => Str::uuid(),
-                        'name' => 'Anamnesis voor ' . $this->name,
+                        'name' => 'Anamnesis voor ' . Person::findOrFail($personId)->name,
                         'created_by' => auth()->id() ?? $this->user_id ?? 1,
                         'updated_by' => auth()->id() ?? $this->user_id ?? 1,
                     ]

--- a/tests/Feature/Anamnesis/AnamnesisLeadRelationTest.php
+++ b/tests/Feature/Anamnesis/AnamnesisLeadRelationTest.php
@@ -115,3 +115,39 @@ test('it allows multiple anamnesis for different lead-person combinations', func
 
     // Each combination should have exactly one anamnesis
 });
+
+test('label attribute returns person name when person is linked', function () {
+    $this->seed(TestSeeder::class);
+    $this->artisan('db:seed', ['--class' => LeadChannelSeeder::class]);
+
+    $person = Person::factory()->create(['first_name' => 'Maria', 'last_name' => 'Smit']);
+    $lead = Lead::factory()->create();
+
+    $lead->attachPersons([$person->id]);
+    $anamnesis = Anamnesis::where('lead_id', $lead->id)->where('person_id', $person->id)->first();
+
+    expect($anamnesis->label)->toBe('Maria Smit');
+});
+
+test('label attribute falls back to Onbekend when no person or lead info', function () {
+    $lead = Lead::factory()->create();
+    $anamnesis = Anamnesis::factory()->create(['lead_id' => $lead->id, 'person_id' => null]);
+
+    // Without a linked person, label should not be 'Maria Smit' or similar
+    expect($anamnesis->label)->not->toBe('');
+});
+
+test('createMissingAnamnesis uses person name not lead name', function () {
+    $this->seed(TestSeeder::class);
+    $this->artisan('db:seed', ['--class' => LeadChannelSeeder::class]);
+
+    $person = Person::factory()->create(['first_name' => 'Piet', 'last_name' => 'Jansen']);
+    $lead = Lead::factory()->create(['first_name' => 'Lead', 'last_name' => 'Persoon']);
+
+    $lead->attachPersons([$person->id]);
+
+    $anamnesis = Anamnesis::where('lead_id', $lead->id)->where('person_id', $person->id)->firstOrFail();
+
+    expect($anamnesis->name)->toBe('Anamnesis voor Piet Jansen')
+        ->and($anamnesis->name)->not->toContain('Lead Persoon');
+});


### PR DESCRIPTION
## Summary

Fixes [MBS-86]: Anamnesis bewerk scherm toont verkeerde naam bij import

- **Bug 1**: Edit screen title showed "Anamnesis bewerken - Onbekend" because `getLabelAttribute()` only checked `lead->title` and `sales->name`, never the linked person's name. Fixed by checking `person->name` first.
- **Bug 2**: The `name` field stored on creation (via `Lead::createMissingAnamnesis`) used the lead's own name (`$this->name`) instead of the person's name. Fixed to use `Person::findOrFail($personId)->name`, consistent with how `SalesLead::createMissingAnamnesis` already worked.

## Changes

- `app/Models/Anamnesis.php` — `getLabelAttribute()` now resolves `person->name` first
- `packages/Webkul/Lead/src/Models/Lead.php` — `createMissingAnamnesis()` now names the record after the person
- `tests/Feature/Anamnesis/AnamnesisLeadRelationTest.php` — regression tests for both fixes

## Test plan

- [ ] Edit an existing anamnesis that has a linked person — title should show person's full name
- [ ] Attach a new person to a lead — anamnesis `name` field should contain the person's name, not the lead's name
- [ ] Run `php artisan test --filter=AnamnesisLeadRelation` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)