### PR TITLE
fix: move inbox email to Verwerkt when linked to a lead or entity

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -170,6 +170,8 @@ class EmailController extends Controller
 
         $email = $this->emailRepository->update($data, request('id') ?? $id);
 
+        $this->moveToProcessedIfLinked($email, $data);
+
         Event::dispatch('email.update.after', $email);
 
         if (! is_null(request('is_draft')) && ! request('is_draft')) {
@@ -350,6 +352,19 @@ class EmailController extends Controller
             session()->flash('error', trans('admin::app.mail.delete-failed'));
 
             return redirect()->back();
+        }
+    }
+
+    /**
+     * Move email to "Verwerkt" folder when it is linked to an entity and currently in an inbox-type folder.
+     */
+    private function moveToProcessedIfLinked($email, array $data): void
+    {
+        $entityFields = ['lead_id', 'sales_lead_id', 'person_id', 'clinic_id', 'order_id'];
+        $hasEntityLink = collect($entityFields)->contains(fn ($field) => ! empty($data[$field]));
+
+        if ($hasEntityLink) {
+            $this->emailRepository->moveToProcessedIfInbox($email->id);
         }
     }
 

--- a/packages/Webkul/Admin/src/Listeners/Lead.php
+++ b/packages/Webkul/Admin/src/Listeners/Lead.php
@@ -23,8 +23,12 @@ class Lead
             return;
         }
 
+        $emailId = (int) request('email_id');
+
         $this->emailRepository->update([
             'lead_id' => $lead->id,
-        ], request('email_id'));
+        ], $emailId);
+
+        $this->emailRepository->moveToProcessedIfInbox($emailId);
     }
 }

--- a/packages/Webkul/Email/src/Repositories/EmailRepository.php
+++ b/packages/Webkul/Email/src/Repositories/EmailRepository.php
@@ -123,6 +123,38 @@ class EmailRepository extends Repository
     }
 
     /**
+     * Move email to "Verwerkt" folder if it is currently in an inbox-type folder.
+     */
+    public function moveToProcessedIfInbox(int $emailId): void
+    {
+        $email = $this->find($emailId);
+
+        if (! $email) {
+            return;
+        }
+
+        $inboxFolderNames = [
+            EmailFolderEnum::INBOX->getFolderName(),
+            EmailFolderEnum::PRIVATESCAN_WEBFORM->getFolderName(),
+            EmailFolderEnum::HERNIA_WEBFORM->getFolderName(),
+            EmailFolderEnum::CLINICS->getFolderName(),
+            EmailFolderEnum::NEWSLETTER->getFolderName(),
+        ];
+
+        $currentFolder = Folder::find($email->folder_id);
+
+        if (! $currentFolder || ! in_array($currentFolder->name, $inboxFolderNames, true)) {
+            return;
+        }
+
+        $processedFolder = Folder::where('name', EmailFolderEnum::PROCESSED->getFolderName())->first();
+
+        if ($processedFolder) {
+            parent::update(['folder_id' => $processedFolder->id], $emailId);
+        }
+    }
+
+    /**
      * Sanitize emails.
      *
      * @return array


### PR DESCRIPTION
## Summary

Fixes [MBS-87]: After linking an incoming email from the inbox to a Lead, the email now automatically moves to the "Verwerkt" folder.

**Root cause:** No folder transition was triggered after linking an email to an entity.

**Changes:**
- Added `moveToProcessedIfInbox()` to `EmailRepository` — moves email to "Verwerkt" if currently in an inbox-type folder (Inbox, Privatescan webforms, Hernia Poli webforms, Klinieken, Nieuwsbrief reacties)
- `EmailController::update()` calls this after any entity link (`lead_id`, `sales_lead_id`, `person_id`, `clinic_id`, `order_id`) is set
- `Lead@linkToEmail` listener also calls this when a new Lead is created from an inbox email

## Test plan
- [ ] Open an email in the Inbox
- [ ] Link it to an existing Lead via the action panel
- [ ] Verify the email disappears from Inbox and appears in "Verwerkt"
- [ ] Create a new Lead from an inbox email (using `email_id` parameter)
- [ ] Verify the email is moved to "Verwerkt"
- [ ] Verify that emails already in "Verwerkt", "Sent", "Draft" etc. are NOT moved again when updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)