### PR TITLE
fix: menu-items klinieken/resources zichtbaar voor gebruikers met juiste rechten (MBS-89)

### DIFF
--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -277,27 +277,27 @@ return [
     ], [
         'key'   => 'settings.clinics',
         'name'  => 'Klinieken',
-        'route' => 'admin.settings.clinics.index',
+        'route' => 'admin.clinics.index',
         'sort'  => 1,
     ], [
         'key'   => 'settings.clinics.view',
         'name'  => 'admin::app.acl.view',
-        'route' => ['admin.settings.clinics.view', 'admin.settings.clinics.view'],
+        'route' => ['admin.clinics.view', 'admin.clinics.view'],
         'sort'  => 1,
     ], [
         'key'   => 'settings.clinics.create',
         'name'  => 'admin::app.acl.create',
-        'route' => ['admin.settings.clinics.create', 'admin.settings.clinics.store'],
+        'route' => ['admin.clinics.create', 'admin.clinics.store'],
         'sort'  => 2,
     ], [
         'key'   => 'settings.clinics.edit',
         'name'  => 'admin::app.acl.edit',
-        'route' => ['admin.settings.clinics.edit', 'admin.settings.clinics.update'],
+        'route' => ['admin.clinics.edit', 'admin.clinics.update'],
         'sort'  => 3,
     ], [
         'key'   => 'settings.clinics.delete',
         'name'  => 'admin::app.acl.delete',
-        'route' => ['admin.settings.clinics.delete'],
+        'route' => ['admin.clinics.delete'],
         'sort'  => 4,
     ], [
         'key'   => 'settings.resources',

--- a/packages/Webkul/Admin/src/Config/menu.php
+++ b/packages/Webkul/Admin/src/Config/menu.php
@@ -172,6 +172,7 @@ return [
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.clinics.admin',
+        'acl'        => 'settings.clinics',
         'name'       => 'admin::app.layouts.clinics',
         'info'       => 'admin::app.layouts.clinics-info',
         'route'      => 'admin.clinics.index',
@@ -179,6 +180,7 @@ return [
         'icon-class' => 'icon-settings-pipeline',
     ], [
         'key'        => 'settings.clinics.partner_products',
+        'acl'        => 'partner_products',
         'name'       => 'admin::app.layouts.partner_products',
         'info'       => 'admin::app.layouts.partner_products-info',
         'route'      => 'admin.partner_products.index',
@@ -186,14 +188,15 @@ return [
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.clinics.resources',
+        'acl'        => 'settings.resources',
         'name'       => 'admin::app.layouts.resources',
         'info'       => 'admin::app.layouts.resources-info',
         'route'      => 'admin.settings.resources.index',
-        'sort'       => 3
-        ,
+        'sort'       => 3,
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.clinics.resource_types',
+        'acl'        => 'settings.resources',
         'name'       => 'admin::app.layouts.resource_types',
         'info'       => 'admin::app.layouts.resource_types-info',
         'route'      => 'admin.settings.resource_types.index',
@@ -201,6 +204,7 @@ return [
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.clinics.product_types',
+        'acl'        => 'settings.product_types',
         'name'       => 'admin::app.layouts.product_types',
         'info'       => 'admin::app.layouts.product_types-info',
         'route'      => 'admin.settings.product_types.index',
@@ -208,6 +212,7 @@ return [
         'icon-class' => 'icon-setting',
     ], [
         'key'        => 'settings.clinics.departments',
+        'acl'        => 'settings.clinics',
         'name'       => 'Afdelingen',
         'info'       => 'Afdelingen per kliniek',
         'route'      => 'admin.clinic_departments.index',


### PR DESCRIPTION
## Summary

- Menu-items onder de Klinieken-sectie misten een `acl`-attribuut, waardoor de bouncer altijd de menu-key als ACL-key gebruikte
- Menu-keys zoals `settings.clinics.resources` bestaan niet in de ACL-config → items altijd verborgen voor custom roles
- Nu hebben alle sub-items een expliciet `acl`-attribuut dat verwijst naar de juiste ACL-sectie
- ACL-config verwees naar niet-bestaande route-namen (`admin.settings.clinics.*`); de echte routes zijn `admin.clinics.*`

## Changes

- `menu.php` — `acl`-attribuut toegevoegd aan alle clinics-sub-items:
  - `settings.clinics.admin` → `settings.clinics`
  - `settings.clinics.partner_products` → `partner_products`
  - `settings.clinics.resources` → `settings.resources`
  - `settings.clinics.resource_types` → `settings.resources`
  - `settings.clinics.product_types` → `settings.product_types`
  - `settings.clinics.departments` → `settings.clinics`
- `acl.php` — route-namen gecorrigeerd van `admin.settings.clinics.*` naar `admin.clinics.*`

## Test plan

- [ ] Maak een "medewerker" rol aan met `settings.clinics` (view) en `settings.resources` (view)
- [ ] Login als medewerker — klinieken-sectie moet zichtbaar zijn in het menu
- [ ] Resources menu-item moet zichtbaar zijn onder klinieken
- [ ] Admin-gebruiker heeft nog steeds volledige toegang

Closes [MBS-89](/MBS/issues/MBS-89)

🤖 Generated with [Claude Code](https://claude.com/claude-code)