### PR TITLE
test(afb): fix name assertion for Dutch full_last_name format

### DIFF
--- a/tests/Feature/Afb/AfbDispatchFlowTest.php
+++ b/tests/Feature/Afb/AfbDispatchFlowTest.php
@@ -160,7 +160,7 @@ test('afb generator maps crm fields into afb layout', function () {
         ->toContain('Evidia - Augusta Klinik')
         ->toContain('ORD-TEST-1001')
         ->toContain('Lara')
-        ->toContain('Muller / de Boer')
+        ->toContain('Boer de - Muller')
         ->toContain('MRT HWS zonder KM')
         ->toContain('Ja')
         ->toContain('Nein')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `AfbDispatchFlowTest` to expect the new `full_last_name` output from `HasPersonName` (married name + prefix after surname, dash, birth name), matching the MBS-88 naming change.

**Note:** Tests were not executed in this agent environment (PHP/Docker unavailable); please run `php artisan test tests/Feature/Afb/AfbDispatchFlowTest.php` locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e74bb731-8154-4cc5-97d3-59c2d0e0b8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e74bb731-8154-4cc5-97d3-59c2d0e0b8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

