### PR TITLE
Fix Hernia API lead 500 on DB errors and sanitize JSON exception responses

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
@@ -66,6 +67,17 @@ class Handler extends ExceptionHandler
     {
         $response = parent::render($request, $exception);
 
+        // When APP_DEBUG is false, never expose exception class, SQL, paths, or stack traces in JSON.
+        if ($this->shouldSanitizeJsonErrorResponse($request, $response)) {
+            $status = $response->getStatusCode();
+
+            return response()->json([
+                'message' => $status === 503
+                    ? 'Service temporarily unavailable.'
+                    : 'Server Error',
+            ], $status);
+        }
+
         // Log all 500 errors with full stack trace
         if ($response->getStatusCode() === 500) {
             try {
@@ -89,5 +101,33 @@ class Handler extends ExceptionHandler
         }
 
         return $response;
+    }
+
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     */
+    private function shouldSanitizeJsonErrorResponse($request, $response): bool
+    {
+        // When debug is enabled, keep Laravel's detailed JSON errors for local development.
+        if (config('app.debug')) {
+            return false;
+        }
+
+        if (! $request->expectsJson() && ! $request->is('api/*')) {
+            return false;
+        }
+
+        if ($response->getStatusCode() < 500) {
+            return false;
+        }
+
+        if (! $response instanceof JsonResponse) {
+            return false;
+        }
+
+        $data = $response->getData(true);
+
+        return is_array($data) && array_key_exists('exception', $data);
     }
 }

--- a/app/Http/Requests/Api/HerniaCreateLeadRequest.php
+++ b/app/Http/Requests/Api/HerniaCreateLeadRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Rules\MarketingCampaignExternalIdExists;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\ValidationException;
 
@@ -16,7 +17,7 @@ class HerniaCreateLeadRequest extends FormRequest
     {
         return [
             // NOTE: despite the name, this is the external_id of a Marketing Campaign (marketing_campaigns.external_id)
-            'campaign_id'      => ['required', 'string', 'exists:marketing_campaigns,external_id'],
+            'campaign_id'      => ['required', 'string', new MarketingCampaignExternalIdExists()],
             'lead_source'      => ['required', 'string'],
             'kanaal_c'         => ['required', 'string'],
             'soort_aanvraag_c' => ['required', 'string'],

--- a/app/Http/Requests/Api/PrivatescanCreateLeadRequest.php
+++ b/app/Http/Requests/Api/PrivatescanCreateLeadRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Rules\MarketingCampaignExternalIdExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PrivatescanCreateLeadRequest extends FormRequest
@@ -54,7 +55,7 @@ class PrivatescanCreateLeadRequest extends FormRequest
             'select_interesse' => ['nullable', 'string'],
             'personen'         => ['nullable'],
             // NOTE: despite the name, this is the external_id of a Marketing Campaign (marketing_campaigns.external_id)
-            'campaign_id'      => ['nullable', 'string', 'exists:marketing_campaigns,external_id'],
+            'campaign_id'      => ['nullable', 'string', new MarketingCampaignExternalIdExists(allowEmpty: true)],
         ];
     }
 

--- a/app/Rules/MarketingCampaignExternalIdExists.php
+++ b/app/Rules/MarketingCampaignExternalIdExists.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Log;
+use Webkul\Marketing\Models\Campaign;
+
+/**
+ * Validates marketing campaign by external_id without using the database presence verifier
+ * (which turns connection errors into uncaught QueryExceptions during FormRequest resolution).
+ */
+class MarketingCampaignExternalIdExists implements ValidationRule
+{
+    public function __construct(
+        private readonly bool $allowEmpty = false
+    ) {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value === null || $value === '') {
+            if ($this->allowEmpty) {
+                return;
+            }
+
+            $fail(__('validation.exists', ['attribute' => $attribute]));
+
+            return;
+        }
+
+        if (! is_string($value)) {
+            $fail(__('validation.exists', ['attribute' => $attribute]));
+
+            return;
+        }
+
+        try {
+            $exists = Campaign::query()->where('external_id', $value)->exists();
+        } catch (QueryException $e) {
+            Log::error('Marketing campaign lookup failed during validation', [
+                'attribute' => $attribute,
+                'message'   => $e->getMessage(),
+            ]);
+
+            throw new HttpResponseException(response()->json([
+                'message' => 'Service temporarily unavailable.',
+            ], 503));
+        }
+
+        if (! $exists) {
+            $fail(__('validation.exists', ['attribute' => $attribute]));
+        }
+    }
+}

--- a/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
+++ b/packages/Webkul/Lead/src/Http/Controllers/Api/LeadController.php
@@ -183,11 +183,12 @@ class LeadController extends Controller
         $hasRemovedInvalidPhones = false;
         $invalidPhones = [];
 
-        if (! isset($normalized['first_name']) || trim((string) $normalized['first_name']) === '') {
-            $normalized['first_name'] = '-';
-        }
         if ($allowInvalidPhone) {
             $normalized = $request->all();
+
+            if (! isset($normalized['first_name']) || trim((string) $normalized['first_name']) === '') {
+                $normalized['first_name'] = '-';
+            }
 
             [$normalized, $invalidPhones] = $this->stripInvalidPhones($normalized);
             $hasRemovedInvalidPhones = ! empty($invalidPhones);

--- a/tests/Feature/Api/CreateHerniaLeadApiTest.php
+++ b/tests/Feature/Api/CreateHerniaLeadApiTest.php
@@ -52,6 +52,22 @@ test('POST api/leads/hernia creates a lead', function () {
         ->and($lead->lead_type_id)->toBe(3); // Operatie
 });
 
+test('POST api/leads/hernia rejects unknown marketing campaign external_id', function () {
+    $payload = [
+        'campaign_id'      => '00000000-0000-0000-0000-000000000000',
+        'lead_source'      => 'Herniapoli.nl',
+        'kanaal_c'         => 'website',
+        'soort_aanvraag_c' => 'operatie',
+        'first_name'       => 'Jan',
+        'last_name'        => 'Jansen',
+        'email1'           => 'jan.jansen@example.com',
+    ];
+
+    $this->postJson('/api/leads/hernia', $payload)
+        ->assertStatus(422)
+        ->assertJsonStructure(['errors']);
+});
+
 test('POST api/leads/hernia rejects unknown properties (additionalProperties=false)', function () {
     $payload = [
         'campaign_id'      => '69b238c0-e630-b733-2bb3-4fd85ff554da',

--- a/tests/Feature/Api/JsonApiServerErrorSanitizationTest.php
+++ b/tests/Feature/Api/JsonApiServerErrorSanitizationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Exception;
+use Illuminate\Support\Facades\Route;
+
+test('JSON API 500 responses omit exception details when debug is disabled', function () {
+    config(['app.debug' => false]);
+
+    Route::get('/__test_json_api_server_error', function () {
+        throw new Exception('internal detail that must not leak');
+    });
+
+    $this->getJson('/__test_json_api_server_error')
+        ->assertStatus(500)
+        ->assertJsonMissing(['exception', 'trace', 'file', 'line'])
+        ->assertJson(['message' => 'Server Error']);
+});
+
+test('non-JSON requests under api/* get sanitized JSON 500 when debug is disabled', function () {
+    config(['app.debug' => false]);
+
+    Route::get('/__test_json_api_server_error_accept', function () {
+        throw new Exception('internal detail');
+    });
+
+    $this->get('/__test_json_api_server_error_accept', [
+        'Accept' => 'application/json',
+    ])
+        ->assertStatus(500)
+        ->assertJsonMissing(['exception']);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
API add lead (Hernia) returned 500 with full exception/SQL in the JSON body when the database was unreachable during `exists:marketing_campaigns` validation. Also addresses leaking internal error details when `APP_DEBUG` is false.

## Description
- Added `App\Rules\MarketingCampaignExternalIdExists` and wired it in `HerniaCreateLeadRequest` and `PrivatescanCreateLeadRequest` so campaign lookups use a try/catch around the query. On `QueryException` the API returns **503** with a generic message instead of an uncaught **500** with SQL details.
- Updated `App\Exceptions\Handler` so that when `APP_DEBUG` is false, JSON responses for server errors (status ≥ 500) that include Laravel’s `exception` key are replaced with a minimal payload (`Server Error`, or `Service temporarily unavailable.` for 503) without `exception`, `trace`, `file`, or `line`.
- Fixed `LeadController::storeFromLeadForm`: `$normalized` was used before assignment when `allowInvalidPhone` was false (undefined variable on the generic API path).

## How To Test This?
- With `APP_DEBUG=false`, trigger any 500 on an `Accept: application/json` or `api/*` request and confirm the body has only `message` (no `exception` / `trace`).
- `php artisan test --filter=CreateHerniaLeadApiTest`
- `php artisan test --filter=JsonApiServerErrorSanitizationTest`

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: development

## Tailwind Reordering
N/A (no Tailwind changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1173b71-5d8c-41e7-bc9f-42b14375ea9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1173b71-5d8c-41e7-bc9f-42b14375ea9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

