### PR TITLE
refactor: remove transformToActivity code smell from email controllers

### DIFF
--- a/app/Http/Controllers/Admin/SalesLeadEmailController.php
+++ b/app/Http/Controllers/Admin/SalesLeadEmailController.php
@@ -10,23 +10,6 @@ class SalesLeadEmailController extends BaseEmailController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
-     */
-    public function store()
-    {
-        $response = json_decode(parent::store()->getContent(), true);
-
-        return response()->json([
-            'data'    => $this->transformToActivity($response['data']),
-            'message' => $response['message'],
-        ]);
-
-        return $response;
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Controllers/Admin/Settings/Clinic/EmailController.php
+++ b/app/Http/Controllers/Admin/Settings/Clinic/EmailController.php
@@ -14,20 +14,13 @@ class EmailController extends BaseEmailController
      */
     public function store()
     {
-        // Get clinic_id from route parameter
         $clinicId = request()->route('id');
 
-        // Ensure clinic_id is set from route parameter
         if ($clinicId) {
             request()->merge(['clinic_id' => $clinicId]);
         }
 
-        $response = json_decode(parent::store()->getContent(), true);
-
-        return response()->json([
-            'data'    => $this->transformToActivity($response['data']),
-            'message' => $response['message'],
-        ]);
+        return parent::store();
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/EmailController.php
@@ -4,27 +4,9 @@ namespace Webkul\Admin\Http\Controllers\Lead;
 
 use Illuminate\Support\Facades\Event;
 use Webkul\Admin\Http\Controllers\Mail\EmailController as BaseEmailController;
-use Webkul\Admin\Http\Resources\ActivityResource;
 
 class EmailController extends BaseEmailController
 {
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function store()
-    {
-        $response = json_decode(parent::store()->getContent(), true);
-
-        return response()->json([
-            'data'    => $this->transformToActivity($response['data']),
-            'message' => $response['message'],
-        ]);
-
-        return $response;
-    }
-
     /**
      * Store a newly created resource in storage.
      *

--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -18,7 +18,6 @@ use Webkul\Admin\DataGrids\Mail\EmailDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
 use Webkul\Admin\Http\Requests\MassUpdateRequest;
-use Webkul\Admin\Http\Resources\ActivityResource;
 use Webkul\Admin\Http\Resources\EmailResource;
 use Webkul\Email\Enums\EmailFolderEnum;
 use Webkul\Email\InboundEmailProcessor\Contracts\InboundEmailProcessor;
@@ -727,44 +726,6 @@ class EmailController extends Controller
 
             ], 500);
         }
-    }
-
-    /**
-     * Transform the email data to activity resource.
-     *
-     * @param  array  $data
-     * @return ActivityResource
-     */
-    public function transformToActivity($data)
-    {
-        return new ActivityResource((object) [
-            'id'            => $data['id'],
-            'parent_id'     => $data['parent_id'],
-            'title'         => $data['subject'],
-            'type'          => 'email',
-            'is_done'       => 1,
-            'is_read'       => $data['is_read'] ?? 0,
-            'comment'       => $data['reply'],
-            'schedule_from' => null,
-            'schedule_to'   => null,
-            'user'          => auth()->guard('user')->user(),
-            'user_id'       => auth()->guard('user')->id(),
-            'group'         => null,
-            'participants'  => [],
-            'location'      => null,
-            'additional'    => json_encode([
-                'folders' => $data['folders'],
-                'from'    => $data['from'],
-                'to'      => $data['reply_to'],
-                'cc'      => $data['cc'],
-                'bcc'     => $data['bcc'],
-            ]),
-            'files'         => array_map(function ($attachment) {
-                return (object) $attachment;
-            }, $data['attachments']),
-            'created_at'    => $data['created_at'],
-            'updated_at'    => $data['updated_at'],
-        ]);
     }
 
     /**

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -399,7 +399,7 @@
                     });
                 }
 
-                this.$emitter.on('on-activity-added', (activity) => this.activities.unshift(activity));
+                this.$emitter.on('on-activity-added', () => this.get());
             },
 
             methods: {


### PR DESCRIPTION
## Summary

- Removed `transformToActivity()` method from `Mail/EmailController` — emails have their own entity and should not be disguised as activities
- Removed `store()` overrides in `Lead/EmailController`, `SalesLeadEmailController`, and `Settings/Clinic/EmailController` that only existed to call `transformToActivity()` on the response (including dead code `return $response;` after early returns)
- Updated `on-activity-added` event handler in `activities/index.blade.php` to reload the list via `this.get()` instead of unshifting a transformed activity object — ensures emails appear with accurate server-side data from `ConcatsEmailActivities`

Closes [MBS-94](/MBS/issues/MBS-94)

## Test plan

- [ ] Send an email from a Lead detail page — activity list reloads and shows the email correctly
- [ ] Send an email from a SalesLead detail page — same
- [ ] Send an email from a Clinic detail page — same
- [ ] Add a note/task/call — activity list still reloads and shows the new activity