### PR TITLE
feat: Preventie order aanmaken vanuit Herniapoli sales (MBS-110)

### DIFF
--- a/app/Http/Controllers/Admin/SalesLeadController.php
+++ b/app/Http/Controllers/Admin/SalesLeadController.php
@@ -4,21 +4,28 @@ namespace App\Http\Controllers\Admin;
 
 use App\DataGrids\SalesLeadDataGrid;
 use App\Enums\ActivityStatus;
+use App\Enums\Departments;
 use App\Enums\LostReason;
+use App\Enums\PipelineDefaultKeys;
+use App\Enums\PipelineStage;
 use App\Enums\PipelineType;
 use App\Helpers\RequestHelper;
 use App\Http\Controllers\Controller;
+use App\Models\Department;
 use App\Models\Order;
 use App\Models\SalesLead;
+use App\Models\SalesLeadRelation;
 use App\Repositories\SalesLeadRepository;
 use App\Services\PipelineCookieService;
 use App\Services\StageTransitionAttributes;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rules\Enum;
 use Prettus\Repository\Criteria\RequestCriteria;
+use Throwable;
 use Webkul\Activity\Models\Activity;
 use Webkul\Activity\Repositories\ActivityRepository;
 use Webkul\Admin\Http\Controllers\Concerns\ConcatsEmailActivities;
@@ -603,6 +610,83 @@ class SalesLeadController extends Controller
         }
 
         return $data;
+    }
+
+    /**
+     * Create a new Preventie (Privatescan) sales from a Herniapoli sales lead.
+     * Creates a new Privatescan Lead (won), SalesLead, Order, and links them via SalesLeadRelation.
+     */
+    public function createPreventieSales(int $id): JsonResponse|\Illuminate\Http\RedirectResponse
+    {
+        $herniaSales = SalesLead::with(['lead.department', 'lead.persons', 'persons'])->find($id);
+
+        if (! $herniaSales) {
+            return redirect()->back()->with('error', 'Sales niet gevonden.');
+        }
+
+        if (! $herniaSales->lead?->department?->isHernia()) {
+            return redirect()->back()->with('error', 'Deze actie is alleen beschikbaar voor Herniapoli sales.');
+        }
+
+        try {
+            DB::beginTransaction();
+
+            $sourceLead = $herniaSales->lead;
+            $privatescanDeptId = Department::findPrivateScanId();
+
+            // Create a new Privatescan Lead in the WON stage, copying data from the Hernia lead
+            $preventieLead = new Lead([
+                'lead_pipeline_id'       => PipelineDefaultKeys::PIPELINE_PRIVATESCAN_ID->value,
+                'lead_pipeline_stage_id' => PipelineStage::WON->id(),
+                'status'                 => 1,
+                'first_name'             => $sourceLead->first_name,
+                'last_name'              => $sourceLead->last_name,
+                'emails'                 => $sourceLead->emails,
+                'phones'                 => $sourceLead->phones,
+                'description'            => $sourceLead->description,
+                'user_id'                => $sourceLead->user_id,
+                'lead_source_id'         => $sourceLead->lead_source_id,
+                'lead_type_id'           => $sourceLead->lead_type_id,
+                'department_id'          => $privatescanDeptId,
+                'contact_person_id'      => $herniaSales->contact_person_id ?? $sourceLead->contact_person_id,
+            ]);
+            $preventieLead->save();
+
+            // Copy persons from the Herniapoli sales to the new Preventie lead
+            $personIds = $herniaSales->persons->pluck('id')->toArray();
+            if (! empty($personIds)) {
+                $preventieLead->attachPersons($personIds);
+            }
+
+            // Retrieve the SalesLead created by the LeadObserver (on WON transition)
+            $preventieSales = SalesLead::where('lead_id', $preventieLead->id)->latest()->first();
+
+            if (! $preventieSales) {
+                throw new \RuntimeException('Preventie SalesLead was not created automatically.');
+            }
+
+            // Link the Herniapoli SalesLead to the Preventie SalesLead
+            SalesLeadRelation::firstOrCreate([
+                'source_saleslead_id' => $herniaSales->id,
+                'target_saleslead_id' => $preventieSales->id,
+                'relation_type'       => 'preventie_referral',
+            ]);
+
+            DB::commit();
+
+            session()->flash('success', 'Preventie sales aangemaakt en gekoppeld aan Herniapoli.');
+
+            return redirect()->route('admin.sales-leads.view', $preventieSales->id);
+
+        } catch (Throwable $e) {
+            DB::rollBack();
+            Log::error('Failed to create Preventie sales from Herniapoli', [
+                'hernia_sales_id' => $id,
+                'error'           => $e->getMessage(),
+            ]);
+
+            return redirect()->back()->with('error', 'Er is een fout opgetreden bij het aanmaken van de Preventie sales.');
+        }
     }
 
     private function getValidationRules(bool $isCreate = false): array

--- a/app/Models/SalesLead.php
+++ b/app/Models/SalesLead.php
@@ -350,6 +350,37 @@ class SalesLead extends Model
     }
 
     /**
+     * SalesLeads that this sales lead refers to (e.g. Preventie referrals from Herniapoli).
+     */
+    public function outgoingRelations()
+    {
+        return $this->hasMany(SalesLeadRelation::class, 'source_saleslead_id');
+    }
+
+    /**
+     * SalesLeads that refer to this sales lead (reverse side of the relation).
+     */
+    public function incomingRelations()
+    {
+        return $this->hasMany(SalesLeadRelation::class, 'target_saleslead_id');
+    }
+
+    /**
+     * Preventie SalesLeads created from this Herniapoli sales lead.
+     */
+    public function linkedPreventieSales()
+    {
+        return $this->hasManyThrough(
+            SalesLead::class,
+            SalesLeadRelation::class,
+            'source_saleslead_id',
+            'id',
+            'id',
+            'target_saleslead_id'
+        );
+    }
+
+    /**
      * Copy persons and contact person from a lead to this sales lead.
      */
     public function copyFromLead(Lead $lead): void

--- a/app/Models/SalesLeadRelation.php
+++ b/app/Models/SalesLeadRelation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @mixin IdeHelperSalesLeadRelation
+ */
+class SalesLeadRelation extends Model
+{
+    protected $table = 'saleslead_relations';
+
+    protected $fillable = [
+        'source_saleslead_id',
+        'target_saleslead_id',
+        'relation_type',
+    ];
+
+    public function sourceSalesLead(): BelongsTo
+    {
+        return $this->belongsTo(SalesLead::class, 'source_saleslead_id');
+    }
+
+    public function targetSalesLead(): BelongsTo
+    {
+        return $this->belongsTo(SalesLead::class, 'target_saleslead_id');
+    }
+}

--- a/database/migrations/2026_04_23_100000_create_saleslead_relations_table.php
+++ b/database/migrations/2026_04_23_100000_create_saleslead_relations_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('saleslead_relations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('source_saleslead_id');
+            $table->unsignedBigInteger('target_saleslead_id');
+            $table->string('relation_type')->default('preventie_referral');
+            $table->timestamps();
+
+            $table->foreign('source_saleslead_id')->references('id')->on('salesleads')->onDelete('cascade');
+            $table->foreign('target_saleslead_id')->references('id')->on('salesleads')->onDelete('cascade');
+
+            $table->unique(['source_saleslead_id', 'target_saleslead_id', 'relation_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saleslead_relations');
+    }
+};

--- a/packages/Webkul/Admin/src/Resources/views/sales/view/tab-general.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/view/tab-general.blade.php
@@ -45,6 +45,32 @@
     </div>
     <x-adminc::leads.compact-overview :lead="$sales->lead" showViewLink="true" />
 
+    @php
+        $linkedPreventieSales = $sales->linkedPreventieSales()->with('stage')->get();
+    @endphp
+
+    @if ($linkedPreventieSales->isNotEmpty())
+        <div class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700 dark:bg-blue-900/20">
+            <h4 class="mb-3 text-sm font-semibold text-blue-800 dark:text-blue-200">
+                Gekoppelde Preventie Sales
+            </h4>
+            <div class="flex flex-col gap-2">
+                @foreach ($linkedPreventieSales as $preventieSales)
+                    <div class="flex items-center justify-between rounded border border-blue-100 bg-white px-3 py-2 dark:border-blue-800 dark:bg-gray-800">
+                        <a href="{{ route('admin.sales-leads.view', $preventieSales->id) }}"
+                           class="text-sm font-medium text-blue-700 hover:underline dark:text-blue-300">
+                            {{ $preventieSales->name ?: 'Sales #' . $preventieSales->id }}
+                        </a>
+                        <span class="rounded-full px-2 py-0.5 text-xs font-medium
+                            {{ $preventieSales->stage?->is_won ? 'bg-green-100 text-green-700' : ($preventieSales->stage?->is_lost ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-600') }}">
+                            {{ $preventieSales->stage?->name ?? 'Onbekend' }}
+                        </span>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
     <!-- Person Blocks Grid -->
     <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
         @if ($sales->hasContactPerson())

--- a/packages/Webkul/Admin/src/Routes/Admin/sales-leads-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/sales-leads-routes.php
@@ -29,6 +29,9 @@ Route::group(['middleware' => ['user']], function () {
         Route::delete('', 'detach')->name('admin.sales-leads.emails.detach');
     });
 
+    // Create Preventie sales from a Herniapoli sales lead
+    Route::post('sales-leads/{id}/create-preventie-sales', [SalesLeadController::class, 'createPreventieSales'])->name('admin.sales-leads.create-preventie-sales');
+
     // Temporary debug route
     Route::get('sales-leads/debug/{id}', [SalesLeadController::class, 'debug'])->name('admin.sales-leads.debug');
 });

--- a/resources/views/adminc/sales_leads/view.blade.php
+++ b/resources/views/adminc/sales_leads/view.blade.php
@@ -94,6 +94,19 @@
                             />
                         @endif
 
+                        @if ($salesLead->lead?->department?->isHernia())
+                            <form method="POST" action="{{ route('admin.sales-leads.create-preventie-sales', $salesLead->id) }}" class="inline">
+                                @csrf
+                                <button type="submit"
+                                    class="secondary-button flex items-center gap-1 border border-blue-200 bg-blue-50 text-blue-700 hover:border-blue-400 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-300"
+                                    onclick="return confirm('Nieuwe Preventie Sales aanmaken vanuit deze Herniapoli sales?')"
+                                >
+                                    <span class="icon-plus text-base"></span>
+                                    <span>Nieuwe Preventie Sales aanmaken</span>
+                                </button>
+                            </form>
+                        @endif
+
                         {!! view_render_event('admin.sales.view.actions.after', ['sales' => $salesLead]) !!}
                     </div>
                 </div>

--- a/tests/Feature/Sales/PreventieSalesFromHerniaTest.php
+++ b/tests/Feature/Sales/PreventieSalesFromHerniaTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Sales;
+
+use App\Enums\PipelineDefaultKeys;
+use App\Enums\PipelineStage;
+use App\Models\Department;
+use App\Models\Order;
+use App\Models\SalesLead;
+use App\Models\SalesLeadRelation;
+use Database\Seeders\TestSeeder;
+use Webkul\Contact\Models\Person;
+use Webkul\Lead\Models\Lead;
+use Webkul\Lead\Models\Source;
+use Webkul\Lead\Models\Type;
+use Webkul\User\Models\User;
+
+beforeEach(function (): void {
+    $this->seed(TestSeeder::class);
+    $user = makeUser();
+    $this->actingAs($user, 'user');
+});
+
+test('createPreventieSales creates preventie lead, sales and order and links them', function (): void {
+    $user = User::factory()->create();
+    $source = Source::firstOrCreate(['name' => 'Website']);
+    $type = Type::firstOrCreate(['name' => 'New Lead']);
+
+    $herniaDept = Department::firstOrCreate(['name' => 'Herniapoli']);
+    $privatescanDept = Department::firstOrCreate(['name' => 'Privatescan']);
+
+    $person = Person::factory()->create([
+        'first_name' => 'Jan',
+        'last_name'  => 'Smit',
+        'emails'     => [['value' => 'jan@example.com', 'label' => 'work', 'is_default' => true]],
+        'phones'     => [['value' => '+31612345678', 'label' => 'mobile', 'is_default' => true]],
+    ]);
+
+    // Create Herniapoli lead in WON stage to trigger SalesLead creation
+    $herniaLead = new Lead([
+        'lead_pipeline_id'       => PipelineDefaultKeys::PIPELINE_HERNIA_ID->value,
+        'lead_pipeline_stage_id' => PipelineStage::WON_HERNIA->id(),
+        'status'                 => 1,
+        'first_name'             => 'Jan',
+        'last_name'              => 'Smit',
+        'emails'                 => [['value' => 'jan@example.com', 'label' => 'work', 'is_default' => true]],
+        'phones'                 => [['value' => '+31612345678', 'label' => 'mobile', 'is_default' => true]],
+        'user_id'                => $user->id,
+        'lead_source_id'         => $source->id,
+        'lead_type_id'           => $type->id,
+        'department_id'          => $herniaDept->id,
+    ]);
+    $herniaLead->save();
+    $herniaLead->attachPersons([$person->id]);
+
+    // Create Herniapoli SalesLead directly (simulating the won flow)
+    $herniaSales = SalesLead::create([
+        'name'              => 'Herniapoli Sales Jan Smit',
+        'lead_id'           => $herniaLead->id,
+        'pipeline_stage_id' => PipelineStage::SALES_ORDER_PREVENTIE_HERNIA->id(),
+        'user_id'           => $user->id,
+    ]);
+    $herniaSales->attachPersons([$person->id]);
+
+    // Act: call the createPreventieSales action
+    $response = $this->post(route('admin.sales-leads.create-preventie-sales', $herniaSales->id));
+
+    // Assert: a new Privatescan Lead was created
+    $this->assertDatabaseHas('leads', [
+        'department_id'          => $privatescanDept->id,
+        'lead_pipeline_id'       => PipelineDefaultKeys::PIPELINE_PRIVATESCAN_ID->value,
+        'lead_pipeline_stage_id' => PipelineStage::WON->id(),
+    ]);
+
+    // Assert: a SalesLead was created for the Preventie lead
+    $preventieLead = Lead::where('department_id', $privatescanDept->id)
+        ->where('lead_pipeline_stage_id', PipelineStage::WON->id())
+        ->latest()
+        ->first();
+    $this->assertNotNull($preventieLead);
+
+    $preventieSales = SalesLead::where('lead_id', $preventieLead->id)->first();
+    $this->assertNotNull($preventieSales, 'Preventie SalesLead was not created');
+
+    // Assert: an Order was created for the Preventie sales
+    $this->assertDatabaseHas('orders', ['sales_lead_id' => $preventieSales->id]);
+
+    // Assert: a SalesLeadRelation links the two sales
+    $this->assertDatabaseHas('saleslead_relations', [
+        'source_saleslead_id' => $herniaSales->id,
+        'target_saleslead_id' => $preventieSales->id,
+        'relation_type'       => 'preventie_referral',
+    ]);
+
+    // Assert: redirect to the Preventie sales view
+    $response->assertRedirect(route('admin.sales-leads.view', $preventieSales->id));
+});
+
+test('createPreventieSales returns error for non-hernia sales', function (): void {
+    $user = User::factory()->create();
+    $source = Source::firstOrCreate(['name' => 'Website']);
+    $type = Type::firstOrCreate(['name' => 'New Lead']);
+    $privatescanDept = Department::firstOrCreate(['name' => 'Privatescan']);
+
+    $privatescanLead = new Lead([
+        'lead_pipeline_id'       => PipelineDefaultKeys::PIPELINE_PRIVATESCAN_ID->value,
+        'lead_pipeline_stage_id' => PipelineStage::WON->id(),
+        'status'                 => 1,
+        'first_name'             => 'Anna',
+        'last_name'              => 'Bakker',
+        'emails'                 => [['value' => 'anna@example.com', 'label' => 'work', 'is_default' => true]],
+        'phones'                 => [],
+        'user_id'                => $user->id,
+        'lead_source_id'         => $source->id,
+        'lead_type_id'           => $type->id,
+        'department_id'          => $privatescanDept->id,
+    ]);
+    $privatescanLead->save();
+
+    $privatescanSales = SalesLead::create([
+        'name'              => 'Privatescan Sales Anna Bakker',
+        'lead_id'           => $privatescanLead->id,
+        'pipeline_stage_id' => PipelineStage::SALES_IN_BEHANDELING->id(),
+        'user_id'           => $user->id,
+    ]);
+
+    $response = $this->post(route('admin.sales-leads.create-preventie-sales', $privatescanSales->id));
+
+    $response->assertRedirect();
+    $this->assertDatabaseMissing('saleslead_relations', [
+        'source_saleslead_id' => $privatescanSales->id,
+    ]);
+});


### PR DESCRIPTION
## Summary

- Adds a **"Nieuwe Preventie Sales aanmaken"** button on Herniapoli SalesLead detail view
- Clicking the button creates a new Privatescan Lead (WON stage), SalesLead, Order, and links them via a `SalesLeadRelation`
- Linked Preventie sales are shown in the general tab of the Herniapoli sales card
- Implements **Sales heeft relatie met Sales** via `saleslead_relations` table

## Changes

- **Migration**: `saleslead_relations` table (`source_saleslead_id`, `target_saleslead_id`, `relation_type`)
- **Model**: `SalesLeadRelation` + `linkedPreventieSales()` relation on `SalesLead`
- **Controller**: `SalesLeadController::createPreventieSales()` — validates Herniapoli origin, creates Preventie Lead/SalesLead/Order via existing observer flow, links via `SalesLeadRelation`
- **Route**: `POST sales-leads/{id}/create-preventie-sales`
- **View**: Button in left panel (only visible for Herniapoli sales), linked sales displayed in `tab-general.blade.php`
- **Tests**: `tests/Feature/Sales/PreventieSalesFromHerniaTest.php`

## Test plan

- [ ] Open a Herniapoli SalesLead detail view → button "Nieuwe Preventie Sales aanmaken" is visible
- [ ] Open a Privatescan SalesLead detail view → button is NOT visible
- [ ] Click the button on a Herniapoli SalesLead → redirected to new Preventie SalesLead
- [ ] Verify new Privatescan Lead exists in WON stage with persons copied
- [ ] Verify new SalesLead and Order exist in Privatescan pipelines
- [ ] Back on Herniapoli sales general tab → linked Preventie sales shown with stage badge
- [ ] Run `sail artisan test --filter=PreventieSalesFromHernia`

🤖 Generated with [Claude Code](https://claude.com/claude-code)