### PR TITLE
feat: use actual form name in task title (MBS-111)

### DIFF
--- a/app/Enums/FormType.php
+++ b/app/Enums/FormType.php
@@ -9,6 +9,15 @@ enum FormType: string
     case HerniaDiagnosisForm = 'herniapoli';
     case HerniaNarcoseForm = 'hernianarcose';
 
+    public function label(): string
+    {
+        return match ($this) {
+            self::PrivateScan        => 'GVL',
+            self::HerniaDiagnosisForm => 'Herniapoli',
+            self::HerniaNarcoseForm  => 'Narcose',
+        };
+    }
+
     public static function values(): array
     {
         return array_column(self::cases(), 'value');

--- a/app/Listeners/CreateFormReviewTask.php
+++ b/app/Listeners/CreateFormReviewTask.php
@@ -21,8 +21,8 @@ class CreateFormReviewTask
             Log::info('Create activity to validate form, form has been filled in by user');
             $this->activityRepository->create([
                 'type'          => ActivityType::TASK,
-                'title'         => 'Formulier controleren',
-                'comment'       => "Patiënt heeft formulier ingevuld (ID: {$event->formId}).",
+                'title'         => "{$event->formType->label()} controleren",
+                'comment'       => "Patiënt heeft {$event->formType->label()} formulier ingevuld (ID: {$event->formId}).",
                 'person_id'     => $event->person->id,
                 'schedule_from' => now(),
                 'schedule_to'   => now()->addDays(5),

--- a/tests/Feature/EventWebhookFormCompletedTest.php
+++ b/tests/Feature/EventWebhookFormCompletedTest.php
@@ -101,7 +101,7 @@ test('CreateFormReviewTask listener creates task activity with 5-day deadline', 
         ->first();
 
     expect($activity)->not->toBeNull()
-        ->and($activity->title)->toBe('Formulier controleren')
+        ->and($activity->title)->toBe('GVL controleren')
         ->and($activity->is_done)->toBeFalse()
         ->and($activity->status)->toBe(ActivityStatus::ACTIVE)
         ->and($activity->additional)->toMatchArray(['form_id' => $formId])


### PR DESCRIPTION
## Summary

- Added `label()` method to `FormType` enum with human-readable form names (GVL, Herniapoli, Narcose)
- Updated `CreateFormReviewTask` listener to use the form label in the task title and comment
- Task title changes from "Formulier controleren" → "GVL controleren" (or the appropriate form name)
- Updated test to assert the new title format

## Test plan

- [ ] Trigger a `PatientFormCompletedEvent` with `FormType::PrivateScan` → task title should be "GVL controleren"
- [ ] Unit test `CreateFormReviewTask listener creates task activity with 5-day deadline` passes
- [ ] Verify task comment also shows form name: "Patiënt heeft GVL formulier ingevuld"

Closes MBS-111

🤖 Generated with [Claude Code](https://claude.com/claude-code)