### PR TITLE
feat: exclude sales-linked tasks from task queues (MBS-112)

### DIFF
--- a/app/Services/ActivityQueueRegistry.php
+++ b/app/Services/ActivityQueueRegistry.php
@@ -133,7 +133,7 @@ class ActivityQueueRegistry
                 },
             ],
 
-            // Onze openstaande taken – all internal tasks still open.
+            // Onze openstaande taken – all internal tasks still open (excl. sales tasks).
             'our-tasks' => [
                 'key'   => 'our-tasks',
                 'label' => 'Onze openstaande taken',
@@ -144,11 +144,12 @@ class ActivityQueueRegistry
                 'apply' => static function (Builder $query): void {
                     $query
                         ->where('activities.type', ActivityType::TASK->value)
-                        ->where('activities.is_done', false);
+                        ->where('activities.is_done', false)
+                        ->whereNull('activities.sales_lead_id');
                 },
             ],
 
-            // Mijn openstaande taken – same as above, but only for current user.
+            // Mijn openstaande taken – same as above, but only for current user (excl. sales tasks).
             'my-tasks' => [
                 'key'   => 'my-tasks',
                 'label' => 'Mijn openstaande taken',
@@ -159,7 +160,8 @@ class ActivityQueueRegistry
                 'apply' => static function (Builder $query, ?int $currentUserId): void {
                     $query
                         ->where('activities.type', ActivityType::TASK->value)
-                        ->where('activities.is_done', false);
+                        ->where('activities.is_done', false)
+                        ->whereNull('activities.sales_lead_id');
 
                     if ($currentUserId) {
                         $query->where('activities.user_id', $currentUserId);

--- a/tests/Feature/Activities/ActivityDataGridTest.php
+++ b/tests/Feature/Activities/ActivityDataGridTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Activities;
 
 use App\Enums\ActivityType;
 use App\Enums\PipelineStage;
+use App\Models\SalesLead;
 use App\Services\ActivityQueueRegistry;
 use App\Services\ActivityQueueRepository;
 use Database\Seeders\TestSeeder;
@@ -209,4 +210,56 @@ it('computes open_and_overdue_counts_per_queue_consistently_with_filters', funct
     $counts = $repo->counts('our-tasks');
     expect($counts['open'])->toBe(2)
         ->and($counts['overdue'])->toBe(1);
+});
+
+it('excludes sales-linked tasks from the our-tasks and my-tasks queues', function () {
+    $adminRole = Role::factory()->create([
+        'permission_type' => 'all',
+        'permissions'     => null,
+    ]);
+
+    $admin = User::factory()->create([
+        'role_id'         => $adminRole->id,
+        'view_permission' => 'global',
+        'status'          => 1,
+    ]);
+
+    /** @var Group $group */
+    $group = Group::query()->firstOrFail();
+
+    $salesLead = SalesLead::factory()->create();
+
+    // Task linked to a sales lead – should be excluded.
+    Activity::create([
+        'type'          => ActivityType::TASK->value,
+        'user_id'       => $admin->id,
+        'title'         => 'Sales task',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'is_done'       => 0,
+        'group_id'      => $group->id,
+        'sales_lead_id' => $salesLead->id,
+    ]);
+
+    // Regular task (no sales_lead_id) – should be included.
+    Activity::create([
+        'type'          => ActivityType::TASK->value,
+        'user_id'       => $admin->id,
+        'title'         => 'Regular task',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addDay(),
+        'is_done'       => 0,
+        'group_id'      => $group->id,
+    ]);
+
+    $this->actingAs($admin, 'user');
+
+    /** @var ActivityQueueRepository $repo */
+    $repo = app(ActivityQueueRepository::class);
+
+    $ourTasksCounts = $repo->counts('our-tasks');
+    expect($ourTasksCounts['open'])->toBe(1);
+
+    $myTasksCounts = $repo->counts('my-tasks');
+    expect($myTasksCounts['open'])->toBe(1);
 });


### PR DESCRIPTION
## Summary

- Added `whereNull('activities.sales_lead_id')` filter to the `our-tasks` and `my-tasks` queue definitions in `ActivityQueueRegistry`
- Tasks linked to a sales lead (`sales_lead_id IS NOT NULL`) no longer appear in the operational dashboard task queues
- Only tasks linked to leads, orders, or persons remain visible
- Added test to verify the exclusion behavior for both queues

## Test plan

- [ ] Open operational dashboard `?queue=our-tasks` — tasks with `sales_lead_id` set should not appear
- [ ] Open `?queue=my-tasks` — same exclusion applies
- [ ] New Pest test `excludes sales-linked tasks from the our-tasks and my-tasks queues` passes

Closes MBS-112

🤖 Generated with [Claude Code](https://claude.com/claude-code)