### PR TITLE
fix: hide 'Te laat' badge and red styling for completed activities

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -22,9 +22,9 @@
     <!-- Activity Details -->
     <div class="flex w-full items-start gap-4 rounded-xl border p-4 transition-all"
         :class="{
-            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !isToday(activity.schedule_from) &&
+            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done && !isToday(activity.schedule_from) &&
                 isPast(activity.schedule_from),
-            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': isToday(activity.schedule_from) || !
+            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': activity.is_done || isToday(activity.schedule_from) || !
                 isPast(activity.schedule_from)
         }">
 
@@ -54,8 +54,8 @@
                 <template v-if="activity.type !== 'system'">
                     <a class="flex cursor-pointer flex-wrap grow items-center gap-1 font-medium hover:underline dark:text-white"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !isToday(activity.schedule_from) && isPast(
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
                                 activity.schedule_from)
                         }"
                         :href="activity.type == 'email' ?
@@ -67,7 +67,7 @@
 
                         <!-- Status chip hidden per requirement -->
                     </a>
-                    <span v-if="!isToday(activity.schedule_from) && isPast(activity.schedule_from)"
+                    <span v-if="!activity.is_done && !isToday(activity.schedule_from) && isPast(activity.schedule_from)"
                         class="rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-error dark:bg-red-900/30 dark:text-red-400">
                         Te laat
                     </span>
@@ -77,10 +77,10 @@
                     </span>
                     <div v-if="activity.schedule_from" class="text-xs"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !isToday(activity.schedule_from) && isPast(
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
                                 activity.schedule_from),
-                            'text-gray-600 dark:text-gray-300': !(isToday(activity.schedule_from) || isPast(activity
+                            'text-gray-600 dark:text-gray-300': activity.is_done || !(isToday(activity.schedule_from) || isPast(activity
                                 .schedule_from))
                         }">
                         Vanaf: @{{ $admin.formatDate(activity.schedule_from, 'd MMM yyyy, hh:mm', timezone) }}


### PR DESCRIPTION
## Summary

- Completed activities (is_done = true) no longer show the "Te laat" badge
- Completed activities no longer receive red/orange background, title color, or date text color even when their scheduled date is in the past
- Applies to all activity views where `activity-item` component is used, including the lead activities tab and operational dashboard queues

## Changes

- `activity-item.blade.php`: Added `!activity.is_done` guard to all four overdue-styling conditions:
  1. Card background (red tint)
  2. Title link text color (red)
  3. "Te laat" badge visibility
  4. Schedule date text color (red)

## Test plan

- [ ] Create an activity with a past schedule date and mark it as done — verify no red styling or "Te laat" badge
- [ ] Create an activity with a past schedule date and leave it open — verify red styling and "Te laat" badge still appear
- [ ] Check operational dashboard queues — verify overdue count excludes done tasks (already working server-side)

Closes MBS-113

🤖 Generated with [Claude Code](https://claude.com/claude-code)