### PR TITLE
fix: show Einddatum in activity item and use day-level expiry for Te laat

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -22,10 +22,10 @@
     <!-- Activity Details -->
     <div class="flex w-full items-start gap-4 rounded-xl border p-4 transition-all"
         :class="{
-            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done && !isToday(activity.schedule_from) &&
-                isPast(activity.schedule_from),
-            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': activity.is_done || isToday(activity.schedule_from) || !
-                isPast(activity.schedule_from)
+            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done &&
+                isPastDay(activity.schedule_to || activity.schedule_from),
+            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': activity.is_done ||
+                !isPastDay(activity.schedule_to || activity.schedule_from)
         }">
 
         <!-- Activity Icon -->
@@ -54,9 +54,8 @@
                 <template v-if="activity.type !== 'system'">
                     <a class="flex cursor-pointer flex-wrap grow items-center gap-1 font-medium hover:underline dark:text-white"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
-                                activity.schedule_from)
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from)
                         }"
                         :href="activity.type == 'email' ?
                             ('{{ route('admin.mail.view', ['route' => 'inbox', 'id' => 'replaceId']) }}'.replace(
@@ -67,7 +66,7 @@
 
                         <!-- Status chip hidden per requirement -->
                     </a>
-                    <span v-if="!activity.is_done && !isToday(activity.schedule_from) && isPast(activity.schedule_from)"
+                    <span v-if="!activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from)"
                         class="rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-error dark:bg-red-900/30 dark:text-red-400">
                         Te laat
                     </span>
@@ -77,13 +76,14 @@
                     </span>
                     <div v-if="activity.schedule_from" class="text-xs"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
-                                activity.schedule_from),
-                            'text-gray-600 dark:text-gray-300': activity.is_done || !(isToday(activity.schedule_from) || isPast(activity
-                                .schedule_from))
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-gray-600 dark:text-gray-300': activity.is_done || !(isToday(activity.schedule_from) || isPastDay(activity.schedule_to || activity.schedule_from))
                         }">
                         Vanaf: @{{ $admin.formatDate(activity.schedule_from, 'd MMM yyyy, hh:mm', timezone) }}
+                        <template v-if="activity.schedule_to">
+                            &nbsp;| Einddatum: @{{ $admin.formatDate(activity.schedule_to, 'd MMM yyyy', timezone) }}
+                        </template>
                     </div>
                     <!-- Entity source label (shows where the activity originates from in the hierarchy) -->
                     <span v-if="activity.entity_source"

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -322,7 +322,7 @@
                 countActionNeeded() {
                     return this.activities.filter(activity =>
                         ! activity.is_done &&
-                        this.isPast(activity.schedule_from) &&
+                        this.isPastDay(activity.schedule_to || activity.schedule_from) &&
                         ['call', 'meeting', 'task'].includes(activity.type)
                     ).length;
                 },
@@ -342,7 +342,7 @@
                     // console.log(JSON.parse(JSON.stringify(this.activities)));
                     if (this.selectedType === 'action_needed') {
                          return this.activities
-                             .filter(activity => ! activity.is_done && this.isPast(activity.schedule_from))
+                             .filter(activity => ! activity.is_done && this.isPastDay(activity.schedule_to || activity.schedule_from))
                             .sort((a, b) => {
                                 const aTime = a && a.schedule_from ? new Date(a.schedule_from).getTime() : Infinity;
                                 const bTime = b && b.schedule_from ? new Date(b.schedule_from).getTime() : Infinity;
@@ -564,6 +564,13 @@
                 isPast(dateStr) {
                     if (!dateStr) return false;
                     return new Date(dateStr).getTime() < Date.now();
+                },
+
+                isPastDay(dateStr) {
+                    if (!dateStr) return false;
+                    const d = new Date(dateStr);
+                    const endOfDay = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+                    return endOfDay.getTime() < Date.now();
                 },
             },
         });


### PR DESCRIPTION
## Summary

- Toont `schedule_to` (Einddatum) naast de "Vanaf" datum in het activiteiten-item
- "Te laat" badge en rode styling worden nu bepaald op basis van `schedule_to` (einddatum) op dagniveau, i.p.v. `schedule_from`
- `isPastDay()` functie toegevoegd: een activiteit is pas te laat als de einddag volledig verstreken is (23:59:59)
- `countActionNeeded` en `filteredActivities` (werkbak "actie vereist") gebruiken nu ook de einddatum

## Test plan

- [ ] Open een activiteit met een einddatum in de toekomst — geen "Te laat" badge
- [ ] Open een activiteit waarvan `schedule_to` vandaag is — geen "Te laat" badge (dag niet verstreken)
- [ ] Open een activiteit waarvan `schedule_to` gisteren of eerder is — "Te laat" badge zichtbaar, rode achtergrond
- [ ] Controleer dat "Einddatum: [datum]" zichtbaar is naast "Vanaf:" wanneer `schedule_to` aanwezig is
- [ ] Controleer werkbak "Actie vereist" telt correct op basis van einddatum

Closes [MBS-115](/MBS/issues/MBS-115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)