### PR TITLE
fix: include tussenvoegsel in GVL/Narcose form API call

### DIFF
--- a/app/Http/Controllers/Admin/AnamnesisController.php
+++ b/app/Http/Controllers/Admin/AnamnesisController.php
@@ -542,6 +542,9 @@ class AnamnesisController extends Controller
             $lastName = $nameParts[1] ?? $firstName;
         }
 
+        $lastNameWithPrefix = trim(($person->lastname_prefix ? $person->lastname_prefix.' ' : '').$lastName);
+        $maidenNameWithPrefix = trim(($person->married_name_prefix ? $person->married_name_prefix.' ' : '').($person->married_name ?? ''));
+
         // Determine form type from lead department
         $department = $lead->department;
         $formType = $this->mapFormTypeFromDepartment($department);
@@ -549,8 +552,8 @@ class AnamnesisController extends Controller
         $formData = [
             'user_crm_id'     => $person->id,
             'user_firstname'  => $firstName ?: '-',
-            'user_lastname'   => $lastName ?: '-',
-            'user_maidenname' => ! empty($person->married_name) ? $person->married_name : '--',
+            'user_lastname'   => $lastNameWithPrefix ?: '-',
+            'user_maidenname' => $maidenNameWithPrefix ?: '--',
             'user_email'      => $email,
             'user_birthday'   => $birthday,
             'mri_research'    => 'Nee', // Default, can be updated later

--- a/tests/Feature/SalesLeadCrudTest.php
+++ b/tests/Feature/SalesLeadCrudTest.php
@@ -330,6 +330,46 @@ test('can detach gvl form from anamnesis when forms api returns 200', function (
     });
 });
 
+test('attaching gvl form sends lastname_prefix and married_name_prefix combined in api request', function () {
+    config([
+        'services.portal.patient.api_url'   => 'http://forms',
+        'services.portal.patient.api_token' => 'test-token',
+    ]);
+
+    $person = Person::factory()->create([
+        'first_name'          => 'Jan',
+        'last_name'           => 'Berg',
+        'lastname_prefix'     => 'van den',
+        'married_name'        => 'Smit',
+        'married_name_prefix' => 'de',
+    ]);
+
+    $lead = Lead::factory()->create();
+    $lead->attachPersons([$person->id]);
+
+    $anamnesis = Anamnesis::where('lead_id', $lead->id)->where('person_id', $person->id)->firstOrFail();
+
+    Http::fake([
+        'http://forms/api/forms' => Http::response([
+            'data'     => ['id' => 99],
+            'form_url' => 'https://forms.example.com/forms/99/step/1',
+        ], 201),
+    ]);
+
+    $response = $this->postJson(route('admin.anamnesis.gvl-form.attach', ['id' => $anamnesis->id]));
+
+    $response->assertOk();
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $request->method() === 'POST'
+            && str_contains($request->url(), 'http://forms/api/forms')
+            && ($body['user_lastname'] ?? null) === 'van den Berg'
+            && ($body['user_maidenname'] ?? null) === 'de Smit';
+    });
+});
+
 test('gvl form stays linked to anamnesis when forms api responds with error', function () {
     config([
         'services.portal.patient.api_url'   => 'http://forms',


### PR DESCRIPTION
## Summary

- `lastname_prefix` (tussenvoegsel) is now prepended to `user_lastname` in the forms API call
- `married_name_prefix` is now prepended to `user_maidenname` in the forms API call
- Both fields are combined with a space and trimmed, so missing prefixes don't affect existing behavior

Fixes [MBS-116](/MBS/issues/MBS-116).

## Test plan

- [ ] New test `attaching gvl form sends lastname_prefix and married_name_prefix combined in api request` verifies the combined values are sent to the forms API
- [ ] Existing GVL attach/detach tests still pass
- [ ] Manually verify that creating a GVL or Narcose form for a person with tussenvoegsel includes the prefix in the last name

🤖 Generated with [Claude Code](https://claude.com/claude-code)