### PR TITLE
feat: MBS-127 vervang Aangemaakt op met Begindatum (schedule_from)

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
@@ -152,7 +152,7 @@ class ActivityDataGrid extends DataGrid
         $this->addFilter('is_done', 'activities.is_done');
         $this->addFilter('created_by', DB::raw(DatabaseHelper::concatUserName('users.')));
         $this->addFilter('assigned_user_id', 'users.id');
-        $this->addFilter('created_at', 'activities.created_at');
+        $this->addFilter('schedule_from', 'activities.schedule_from');
         $this->addFilter('days_until_deadline', 'days_until_deadline');
         $this->addFilter('lead_pipeline_stage_id', 'leads.lead_pipeline_stage_id');
         $this->addFilter('lead_pipeline_id', 'leads.lead_pipeline_id');
@@ -333,20 +333,20 @@ class ActivityDataGrid extends DataGrid
 
         // Removed 'Oppakken vanaf' column as requested
 
-        // Created date column
+        // Begin date column (replaces created_at / "Aangemaakt op")
         $this->addColumn([
-            'index'      => 'created_at',
-            'label'      => 'Aangemaakt op',
+            'index'      => 'schedule_from',
+            'label'      => 'Begindatum',
             'type'       => 'datetime',
             'sortable'   => true,
             'searchable' => true,
             'filterable' => false,
             'closure'    => function ($row) {
-                if (empty($row->created_at)) {
+                if (empty($row->schedule_from)) {
                     return 'N/A';
                 }
 
-                $timestamp = strtotime($row->created_at);
+                $timestamp = strtotime($row->schedule_from);
                 if ($timestamp === false) {
                     return 'N/A';
                 }

--- a/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
@@ -180,12 +180,12 @@
                 </div>
             @endif
 
-            <!-- Footer with creation and modification dates -->
+            <!-- Footer with begin date and modification date -->
             <div
                 class="flex w-full flex-col gap-2 p-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-800">
                 <div class="flex justify-between">
-                    <span>Aangemaakt op:</span>
-                    <span>{{ $activity->created_at->format('d-m-Y') }}</span>
+                    <span>Begindatum:</span>
+                    <span>{{ $activity->schedule_from ? \Carbon\Carbon::parse($activity->schedule_from)->format('d-m-Y') : '-' }}</span>
                 </div>
                 <div class="flex justify-between">
                     <span>Bijgewerkt op:</span>

--- a/packages/Webkul/Admin/src/Resources/views/dashboard/operational/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/dashboard/operational/index.blade.php
@@ -189,9 +189,9 @@
                                                 <template v-else-if="column.index === 'assigned_user_id'">
                                                     <div v-html="record.assigned_user_id"></div>
                                                 </template>
-                                                <template v-else-if="column.index === 'created_at'">
+                                                <template v-else-if="column.index === 'schedule_from'">
                                                     <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                        @{{ record.created_at }}
+                                                        @{{ record.schedule_from }}
                                                     </p>
                                                 </template>
                                                 <template v-else>


### PR DESCRIPTION
## Summary

- Vervang de kolom "Aangemaakt op" (`created_at`) door "Begindatum" (`schedule_from`) in de activity datagrid
- Datagrid gebruikt nu het `schedule_from` veld als waarde, niet alleen de kolomnaam
- Zelfde vervanging doorgevoerd in de activity detail view (footer sectie)
- Operational dashboard blade template bijgewerkt voor de nieuwe kolomindex

## Wijzigingen

- `ActivityDataGrid.php`: kolom `created_at` → `schedule_from`, label "Aangemaakt op" → "Begindatum", filter bijgewerkt
- `dashboard/operational/index.blade.php`: template check aangepast van `created_at` naar `schedule_from`
- `activities/view.blade.php`: footer toont nu "Begindatum" met `schedule_from` i.p.v. "Aangemaakt op" met `created_at`

## Test plan

- [ ] Open operational dashboard en controleer dat kolom "Begindatum" de `schedule_from` waarde toont
- [ ] Open activiteit detail view en controleer footer toont "Begindatum" met correcte datum
- [ ] Controleer activities index datagrid toont kolom "Begindatum"

Closes MBS-127

🤖 Generated with [Claude Code](https://claude.com/claude-code)