### PR TITLE
fix: move description field after BSN in lead create and edit

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/common/personal-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/common/personal-fields.blade.php
@@ -173,6 +173,17 @@
         :disabled="!$mayEditPersonFields"
         :readonly="!$mayEditPersonFields"
     />
+
+    <!-- Description -->
+    <x-adminc::components.field
+        type="textarea"
+        name="description"
+        label="Beschrijving"
+        placeholder="Beschrijving"
+        value="{{ old('description', $entity?->description ?? '') }}"
+        class="min-h-[80px]"
+    />
+
     @if($showActiveField)
         <!-- Portal activation toggle -->
         <x-adminc::components.field

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -427,18 +427,6 @@ $salutationToGenderMapping = [
                                         'useVueModel' => true,
                                     ])
 
-                                    <!-- Description -->
-                                    <div class="mb-4">
-                                        <x-adminc::components.field
-                                            type="textarea"
-                                            name="description"
-                                            v-model="formData.description"
-                                            label="Beschrijving"
-                                            placeholder="Beschrijving"
-                                            class="min-h-[80px]"
-                                        />
-                                    </div>
-
                                     <!-- Organization Section -->
                                     <div class="flex flex-col gap-4 mb-4">
                                         @include('admin::leads.common.organization', ['organization' => null])

--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -228,18 +228,6 @@
                         'useVueModel' => false,
                     ])
 
-                    <!-- Lead Details Description -->
-                    <div class="mb-0.5">
-                        <x-adminc::components.field
-                            type="textarea"
-                            name="description"
-                            :label="trans('admin::app.leads.edit.description')"
-                            :placeholder="trans('admin::app.leads.edit.description')"
-                            value="{{ old('description', $lead->description) }}"
-                            class="min-h-[80px]"
-                        />
-                    </div>
-
                     {!! view_render_event('admin.leads.edit.organization.before', ['lead' => $lead]) !!}
 
                     <!-- Organization Section -->


### PR DESCRIPTION
## Summary

- Verplaatst het veld "Beschrijving" naar direct na het BSN-veld (Burgerservicenummer) in zowel het aanmaken als bewerken van een lead
- Beschrijving is verplaatst naar `personal-fields.blade.php` (gedeelde partial), direct na het BSN-veld
- Verwijderd uit `create.blade.php` (stond na channel-to-owner sectie) en `edit.blade.php` (stond na channel-to-owner sectie)

## Test plan

- [ ] Open lead aanmaken: controleer dat "Beschrijving" direct na het BSN-veld verschijnt
- [ ] Open lead bewerken: controleer dat "Beschrijving" direct na het BSN-veld verschijnt en de bestaande waarde toont
- [ ] Maak een lead aan met een beschrijving en verifieer dat de waarde wordt opgeslagen
- [ ] Bewerk een lead met een beschrijving en verifieer dat de waarde wordt opgeslagen

Closes MBS-133

🤖 Generated with [Claude Code](https://claude.com/claude-code)