### PR TITLE
fix: verberg veld 'actief' in lead-bewerkformulier (MBS-27)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -138,7 +138,7 @@
 
                         <div class="w-1/2 max-md:w-full">
                             <!-- Personal Fields Component -->
-                            @include('admin::leads.common.personal-fields', ['entity' => $lead])
+                            @include('admin::leads.common.personal-fields', ['entity' => $lead, 'showPortalFields' => false])
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary

- Het veld 'actief' is verborgen in het lead-bewerkformulier zodat gebruikers dit niet meer kunnen aanpassen

## Test plan
- [ ] Open een lead om te bewerken
- [ ] Verifieer dat het veld 'actief' niet meer zichtbaar is

🤖 Generated with [Claude Code](https://claude.com/claude-code)