### PR TITLE
fix: verwijder publiceren optie voor bestanden vanuit clinic (MBS-28)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/file.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/file.blade.php
@@ -1,6 +1,7 @@
 @props([
-    'entity'            => null,
-    'entityControlName' => null,
+    'entity'               => null,
+    'entityControlName'    => null,
+    'showPublishToPortal'  => true,
 ])
 
 <!-- File Button -->
@@ -25,6 +26,7 @@
         ref="fileActionComponent"
         :entity="{{ json_encode($entity) }}"
         entity-control-name="{{ $entityControlName }}"
+        :show-publish-to-portal="{{ $showPublishToPortal ? 'true' : 'false' }}"
     ></v-file-activity>
 
     {!! view_render_event('admin.components.activities.actions.file.after') !!}
@@ -99,7 +101,7 @@
                             />
 
                             <!-- Publiceren in patiëntportaal -->
-                            <div class="mt-4">
+                            <div v-if="showPublishToPortal" class="mt-4">
                                 <label class="flex cursor-pointer items-center gap-2">
                                     <input
                                         type="checkbox"
@@ -174,7 +176,12 @@
                     type: String,
                     required: true,
                     default: ''
-                }
+                },
+
+                showPublishToPortal: {
+                    type: Boolean,
+                    default: true,
+                },
             },
 
             data: function () {

--- a/resources/views/adminc/clinics/view.blade.php
+++ b/resources/views/adminc/clinics/view.blade.php
@@ -34,7 +34,7 @@
 
                         @if (bouncer()->hasPermission('activities.create'))
                             <!-- File Activity Action -->
-                            <x-admin::activities.actions.file :entity="$clinic" entity-control-name="clinic_id"/>
+                            <x-admin::activities.actions.file :entity="$clinic" entity-control-name="clinic_id" :show-publish-to-portal="false"/>
 
                             <!-- Note Activity Action -->
                             <x-admin::activities.actions.note :entity="$clinic" entity-control-name="clinic_id"/>


### PR DESCRIPTION
## Summary

- De 'publiceren' optie voor bestanden is verwijderd vanuit de clinic-context

> **Note:** This PR is stacked on top of [#298](https://github.com/privatescanbv/krayin-laravel-crm/pull/298) (MBS-27). Merge that PR first.

## Test plan
- [ ] Open een bestanden-overzicht vanuit de clinic
- [ ] Verifieer dat de 'publiceren' optie niet meer beschikbaar is

🤖 Generated with [Claude Code](https://claude.com/claude-code)