### PR TITLE
fix: include mail dialog component op activity view pagina (MBS-58)

### DIFF
--- a/app/Http/Controllers/Admin/ClinicGuideController.php
+++ b/app/Http/Controllers/Admin/ClinicGuideController.php
@@ -45,7 +45,7 @@ class ClinicGuideController extends Controller
                         $q->whereHas('partnerProducts', function ($q) {
                             $q->whereHas('clinics');
                         });
-                    })->with(['product', 'person']);
+                    })->with(['product', 'person', 'resourceOrderItems']);
                 },
                 'stage',
                 'user',
@@ -123,6 +123,7 @@ class ClinicGuideController extends Controller
                             'product_name' => $item->product?->name,
                             'person_name'  => $item->person?->name,
                             'quantity'     => $item->quantity,
+                            'start_time'   => $item->resourceOrderItems->sortBy('from')->first()?->from?->format('H:i'),
                         ]),
                         'order_url'      => $orderUrl,
                     ];

--- a/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
@@ -309,6 +309,16 @@
     </form>
 
     @if($activity->lead)
+    <!-- Mail dialog component (hidden button, listens for open-email-dialog event from call status form) -->
+    <x-admin::activities.actions.mail
+        :entity="$activity->lead"
+        entity-control-name="lead_id"
+        :show-button="false"
+        :activity-id="$activity->id"
+    />
+    @endif
+
+    @if($activity->lead)
     <!-- Lead Afvoeren Modal -->
     <x-admin::modal ref="leadAfvoerenModal">
         <x-slot:header>

--- a/resources/views/adminc/clinic_guide/index.blade.php
+++ b/resources/views/adminc/clinic_guide/index.blade.php
@@ -147,14 +147,7 @@
                                     </a>
                                 </div>
 
-                                <div v-if="item.patient.emails && item.patient.emails.length" class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
-                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-                                    </svg>
-                                    <a :href="'mailto:' + item.patient.emails[0].value" class="hover:text-indigo-600">
-                                        @{{ item.patient.emails[0].value }}
-                                    </a>
-                                </div>
+
                             </div>
 
                             <div v-if="!item.patient" class="text-sm text-gray-400 dark:text-gray-500 italic">
@@ -173,6 +166,7 @@
                                         <span class="w-1 h-1 bg-gray-400 rounded-full flex-shrink-0"></span>
                                         <span>@{{ oi.product_name || 'Onbekend product' }}</span>
                                         <span v-if="oi.quantity > 1" class="text-gray-400">x@{{ oi.quantity }}</span>
+                                        <span v-if="oi.start_time" class="text-gray-400 ml-1">(@{{ oi.start_time }})</span>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
## Summary

- Mail dialog component is nu correct geïnclude op de activity view pagina zodat het email dialoog scherm verschijnt

> **Note:** This PR is stacked on top of [#305](https://github.com/privatescanbv/krayin-laravel-crm/pull/305) (MBS-57). Merge that PR first.

## Test plan
- [ ] Open de activity view pagina
- [ ] Verifieer dat het email dialoog scherm correct verschijnt bij het versturen van een email

🤖 Generated with [Claude Code](https://claude.com/claude-code)