### PR TITLE
fix: voeg operational-dashboard permission toe aan custom rollen (MBS-59)

### DIFF
--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -42,6 +42,7 @@ class RoleSeeder extends Seeder
             'description'     => 'Medewerker met beperkte rechten voor afdelingswerkzaamheden',
             'permission_type' => 'custom',
             'permissions'     => json_encode([
+                'operational-dashboard',
                 'dashboard',
                 'leads',
                 'leads.create',
@@ -100,6 +101,7 @@ class RoleSeeder extends Seeder
             'description'     => 'Kliniek begeleider met toegang tot dagplanning en basisrechten',
             'permission_type' => 'custom',
             'permissions'     => json_encode([
+                'operational-dashboard',
                 'dashboard',
                 'leads',
                 'leads.view',

--- a/packages/Webkul/User/src/Database/Migrations/2026_04_07_000000_add_operational_dashboard_permission_to_custom_roles.php
+++ b/packages/Webkul/User/src/Database/Migrations/2026_04_07_000000_add_operational_dashboard_permission_to_custom_roles.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $roles = DB::table('roles')
+            ->where('permission_type', 'custom')
+            ->whereNotNull('permissions')
+            ->get();
+
+        foreach ($roles as $role) {
+            $permissions = json_decode($role->permissions, true);
+
+            if (is_array($permissions) && ! in_array('operational-dashboard', $permissions)) {
+                array_unshift($permissions, 'operational-dashboard');
+
+                DB::table('roles')
+                    ->where('id', $role->id)
+                    ->update(['permissions' => json_encode(array_values($permissions))]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $roles = DB::table('roles')
+            ->where('permission_type', 'custom')
+            ->whereNotNull('permissions')
+            ->get();
+
+        foreach ($roles as $role) {
+            $permissions = json_decode($role->permissions, true);
+
+            if (is_array($permissions)) {
+                $permissions = array_filter($permissions, fn ($p) => $p !== 'operational-dashboard');
+
+                DB::table('roles')
+                    ->where('id', $role->id)
+                    ->update(['permissions' => json_encode(array_values($permissions))]);
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Summary

- `operational-dashboard` permission toegevoegd aan custom rollen zodat het Werkbakken menu-item zichtbaar is voor de juiste gebruikers

> **Note:** This PR is stacked on top of [#306](https://github.com/privatescanbv/krayin-laravel-crm/pull/306) (MBS-58). Merge PRs #305 and #306 first.

## Test plan
- [ ] Log in als gebruiker met een custom rol
- [ ] Verifieer dat het Werkbakken menu-item zichtbaar is
- [ ] Log in als gebruiker zonder de permission en verifieer dat het menu-item verborgen is

🤖 Generated with [Claude Code](https://claude.com/claude-code)