### PR TITLE
fix: toon Einddatum in activiteit-item en gebruik dag-niveau voor Te laat (MBS-115)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -22,10 +22,10 @@
     <!-- Activity Details -->
     <div class="flex w-full items-start gap-4 rounded-xl border p-4 transition-all"
         :class="{
-            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done && !isToday(activity.schedule_from) &&
-                isPast(activity.schedule_from),
-            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': activity.is_done || isToday(activity.schedule_from) || !
-                isPast(activity.schedule_from)
+            'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done &&
+                isPastDay(activity.schedule_to || activity.schedule_from),
+            'bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': activity.is_done ||
+                !isPastDay(activity.schedule_to || activity.schedule_from)
         }">
 
         <!-- Activity Icon -->
@@ -54,9 +54,8 @@
                 <template v-if="activity.type !== 'system'">
                     <a class="flex cursor-pointer flex-wrap grow items-center gap-1 font-medium hover:underline dark:text-white"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
-                                activity.schedule_from)
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from)
                         }"
                         :href="activity.type == 'email' ?
                             ('{{ route('admin.mail.view', ['route' => 'inbox', 'id' => 'replaceId']) }}'.replace(
@@ -67,7 +66,7 @@
 
                         <!-- Status chip hidden per requirement -->
                     </a>
-                    <span v-if="!activity.is_done && !isToday(activity.schedule_from) && isPast(activity.schedule_from)"
+                    <span v-if="!activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from)"
                         class="rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-error dark:bg-red-900/30 dark:text-red-400">
                         Te laat
                     </span>
@@ -77,13 +76,14 @@
                     </span>
                     <div v-if="activity.schedule_from" class="text-xs"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !activity.is_done && !isToday(activity.schedule_from) && isPast(
-                                activity.schedule_from),
-                            'text-gray-600 dark:text-gray-300': activity.is_done || !(isToday(activity.schedule_from) || isPast(activity
-                                .schedule_from))
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from),
+                            'text-gray-600 dark:text-gray-300': activity.is_done || !(isToday(activity.schedule_from) || isPastDay(activity.schedule_to || activity.schedule_from))
                         }">
                         Vanaf: @{{ $admin.formatDate(activity.schedule_from, 'd MMM yyyy, hh:mm', timezone) }}
+                        <template v-if="activity.schedule_to">
+                            &nbsp;| Einddatum: @{{ $admin.formatDate(activity.schedule_to, 'd MMM yyyy', timezone) }}
+                        </template>
                     </div>
                     <!-- Entity source label (shows where the activity originates from in the hierarchy) -->
                     <span v-if="activity.entity_source"

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -322,7 +322,7 @@
                 countActionNeeded() {
                     return this.activities.filter(activity =>
                         ! activity.is_done &&
-                        this.isPast(activity.schedule_from) &&
+                        this.isPastDay(activity.schedule_to || activity.schedule_from) &&
                         ['call', 'meeting', 'task'].includes(activity.type)
                     ).length;
                 },
@@ -342,7 +342,7 @@
                     // console.log(JSON.parse(JSON.stringify(this.activities)));
                     if (this.selectedType === 'action_needed') {
                          return this.activities
-                             .filter(activity => ! activity.is_done && this.isPast(activity.schedule_from))
+                             .filter(activity => ! activity.is_done && this.isPastDay(activity.schedule_to || activity.schedule_from))
                             .sort((a, b) => {
                                 const aTime = a && a.schedule_from ? new Date(a.schedule_from).getTime() : Infinity;
                                 const bTime = b && b.schedule_from ? new Date(b.schedule_from).getTime() : Infinity;
@@ -564,6 +564,13 @@
                 isPast(dateStr) {
                     if (!dateStr) return false;
                     return new Date(dateStr).getTime() < Date.now();
+                },
+
+                isPastDay(dateStr) {
+                    if (!dateStr) return false;
+                    const d = new Date(dateStr);
+                    const endOfDay = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+                    return endOfDay.getTime() < Date.now();
                 },
             },
         });


### PR DESCRIPTION
## Summary

- Einddatum (`schedule_to`) wordt nu getoond naast "Vanaf:" in het activiteiten-item op dag-niveau
- "Te laat" status wordt berekend op basis van dag-niveau (niet uur-niveau)
- Fixes het probleem dat einddatum niet zichtbaar was na vervaldatum

## Test plan

- [ ] Open een order met activiteiten en controleer dat de Einddatum zichtbaar is achter "Vanaf:"
- [ ] Controleer dat een activiteit als "Te laat" wordt gemarkeerd wanneer de einddatum (dag-niveau) verlopen is

Closes MBS-115

🤖 Generated with [Claude Code](https://claude.com/claude-code)