### PR TITLE
feat: Rapportage upload knop op order view pagina

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -738,6 +738,91 @@ class OrderController extends SimpleEntityController
         ]);
     }
 
+    /**
+     * Return clinics (from order item resource bookings) and unchecked order checks for the report upload modal.
+     */
+    public function reportUploadData(int $orderId): JsonResponse
+    {
+        $order = $this->orderRepository->with([
+            'orderItems.resourceOrderItem.resource.clinic',
+            'orderItems.resourceOrderItem.resource.clinicDepartment.clinic',
+            'orderChecks',
+        ])->findOrFail($orderId);
+
+        $clinics = $order->orderItems
+            ->map(function ($item) {
+                $resource = $item->resourceOrderItem?->resource;
+                if (! $resource) {
+                    return null;
+                }
+
+                return $resource->clinicDepartment?->clinic ?? $resource->clinic;
+            })
+            ->filter()
+            ->unique('id')
+            ->values()
+            ->map(fn ($clinic) => [
+                'id'   => $clinic->id,
+                'name' => $clinic->name,
+            ]);
+
+        $uncheckedChecks = $order->orderChecks
+            ->where('done', false)
+            ->values()
+            ->map(fn ($check) => [
+                'id'   => $check->id,
+                'name' => $check->name,
+            ]);
+
+        return response()->json([
+            'clinics' => $clinics,
+            'checks'  => $uncheckedChecks,
+        ]);
+    }
+
+    /**
+     * Upload a report file: create a file Activity linked to order + clinic, and mark selected checks as done.
+     */
+    public function storeReport(Request $request, int $orderId): JsonResponse
+    {
+        $request->validate([
+            'file'      => 'required|file|max:20480',
+            'clinic_id' => 'required|integer|exists:clinics,id',
+            'check_ids' => 'required|array|min:1',
+            'check_ids.*' => 'integer|exists:order_checks,id',
+            'title'     => 'nullable|string|max:255',
+            'comment'   => 'nullable|string',
+        ]);
+
+        $order = $this->orderRepository->findOrFail($orderId);
+
+        $activityRepository = app(ActivityRepository::class);
+
+        $file = $request->file('file');
+        $title = $request->input('title') ?: $file->getClientOriginalName();
+
+        $activity = $activityRepository->create([
+            'type'      => ActivityType::FILE,
+            'title'     => $title,
+            'comment'   => $request->input('comment'),
+            'is_done'   => true,
+            'user_id'   => auth()->id(),
+            'order_id'  => $order->id,
+            'clinic_id' => $request->input('clinic_id'),
+            'file'      => $file,
+        ]);
+
+        $checkIds = $request->input('check_ids', []);
+        OrderCheck::where('order_id', $orderId)
+            ->whereIn('id', $checkIds)
+            ->update(['done' => true]);
+
+        return response()->json([
+            'data'    => new ActivityResource($activity),
+            'message' => 'Rapportage succesvol geüpload en checks afgevinkt.',
+        ]);
+    }
+
     public function mailPreview(int $orderId): JsonResponse
     {
         $order = $this->orderRepository->findOrFail($orderId);

--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -805,7 +805,7 @@ class OrderController extends SimpleEntityController
             'type'      => ActivityType::FILE,
             'title'     => $title,
             'comment'   => $request->input('comment'),
-            'is_done'   => true,
+            'is_done'   => false,
             'user_id'   => auth()->id(),
             'order_id'  => $order->id,
             'clinic_id' => $request->input('clinic_id'),

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
@@ -178,7 +178,7 @@
                 fetchData() {
                     this.loadingData = true;
 
-                    const url = `{{ route('admin.orders.report-upload-data', ':id') }}`.replace(':id', this.entity.id);
+                    const url = '{{ route("admin.orders.report-upload-data", ":id") }}'.replace(':id', this.entity.id);
 
                     this.$axios.get(url)
                         .then(response => {
@@ -225,7 +225,7 @@
                         formData.append('check_ids[]', String(id));
                     });
 
-                    const url = `{{ route('admin.orders.report-upload.store', ':id') }}`.replace(':id', this.entity.id);
+                    const url = '{{ route("admin.orders.report-upload.store", ":id") }}'.replace(':id', this.entity.id);
 
                     this.$axios.post(url, formData)
                         .then(response => {

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
@@ -1,0 +1,255 @@
+@props([
+    'entity' => null,
+])
+
+<!-- Report Upload Button -->
+<div>
+    <button
+        class="flex h-[74px] w-[84px] flex-col items-center justify-center gap-1 rounded-lg border border-transparent bg-green-50 font-medium text-green-700 transition-all hover:border-green-300 dark:bg-green-900/20 dark:text-green-300 dark:hover:border-green-700"
+        @click="$refs.reportUploadComponent.openModal()"
+    >
+        <span class="icon-attachment text-2xl dark:!text-green-300"></span>
+
+        Rapportage
+    </button>
+
+    <!-- Report Upload Vue Component -->
+    <v-report-upload
+        ref="reportUploadComponent"
+        :entity="{{ json_encode($entity) }}"
+    ></v-report-upload>
+</div>
+
+@pushOnce('scripts')
+    <script type="text/x-template" id="v-report-upload-template">
+        <Teleport to="body">
+            <x-admin::form
+                v-slot="{ meta, errors, handleSubmit }"
+                as="div"
+                ref="modalForm"
+            >
+                <form @submit="handleSubmit($event, save)">
+                    <x-admin::modal
+                        ref="reportUploadModal"
+                        position="center"
+                    >
+                        <x-slot:header>
+                            <h3 class="text-base font-semibold dark:text-white">
+                                Rapportage uploaden
+                            </h3>
+                        </x-slot>
+
+                        <x-slot:content>
+                            <!-- Order ID (hidden) -->
+                            <x-admin::form.control-group.control
+                                type="hidden"
+                                name="order_id"
+                                ::value="entity.id"
+                            />
+
+                            <!-- Title -->
+                            <x-adminc::components.field
+                                type="text"
+                                name="title"
+                                label="Titel (optioneel)"
+                            />
+
+                            <!-- Clinic selector -->
+                            <div class="mb-4">
+                                <label class="mb-1 block text-xs font-medium text-gray-800 dark:text-white">
+                                    Kliniek <span class="text-red-500">*</span>
+                                </label>
+                                <div v-if="loadingData" class="text-sm text-gray-500">
+                                    Laden...
+                                </div>
+                                <div v-else-if="clinics.length === 0" class="text-sm text-gray-500">
+                                    Geen klinieken gevonden voor deze order.
+                                </div>
+                                <select
+                                    v-else
+                                    v-model="selectedClinicId"
+                                    name="clinic_id"
+                                    class="w-full rounded-md border px-3 py-2 text-sm text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
+                                    required
+                                >
+                                    <option value="" disabled>Selecteer een kliniek</option>
+                                    <option v-for="clinic in clinics" :key="clinic.id" :value="clinic.id">
+                                        @{{ clinic.name }}
+                                    </option>
+                                </select>
+                                <input type="hidden" name="clinic_id" :value="selectedClinicId" />
+                            </div>
+
+                            <!-- Checks selector (multi-select) -->
+                            <div class="mb-4">
+                                <label class="mb-1 block text-xs font-medium text-gray-800 dark:text-white">
+                                    Checks afvinken <span class="text-red-500">*</span>
+                                </label>
+                                <div v-if="loadingData" class="text-sm text-gray-500">
+                                    Laden...
+                                </div>
+                                <div v-else-if="checks.length === 0" class="text-sm text-gray-500">
+                                    Geen openstaande checks gevonden.
+                                </div>
+                                <div v-else class="max-h-48 space-y-2 overflow-y-auto rounded border border-gray-200 p-2 dark:border-gray-700">
+                                    <label
+                                        v-for="check in checks"
+                                        :key="check.id"
+                                        class="flex cursor-pointer items-center gap-2 rounded p-1 hover:bg-gray-50 dark:hover:bg-gray-800"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            :value="check.id"
+                                            v-model="selectedCheckIds"
+                                            class="h-4 w-4 shrink-0 rounded border-gray-300"
+                                        />
+                                        <span class="text-sm text-gray-700 dark:text-gray-300">
+                                            @{{ check.name }}
+                                        </span>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <!-- File input -->
+                            <x-adminc::components.field
+                                type="file"
+                                id="report_file"
+                                name="file"
+                                label="Bestand"
+                                rules="required"
+                                class="!mb-0"
+                            />
+
+                            <!-- Comment -->
+                            <x-adminc::components.field
+                                type="textarea"
+                                name="comment"
+                                label="Opmerking (optioneel)"
+                            />
+                        </x-slot>
+
+                        <x-slot:footer>
+                            <x-admin::button
+                                class="primary-button"
+                                title="Uploaden"
+                                ::loading="isStoring"
+                                ::disabled="isStoring || selectedCheckIds.length === 0 || !selectedClinicId"
+                            />
+                        </x-slot>
+                    </x-admin::modal>
+                </form>
+            </x-admin::form>
+        </Teleport>
+    </script>
+
+    <script type="module">
+        app.component('v-report-upload', {
+            template: '#v-report-upload-template',
+
+            props: {
+                entity: {
+                    type: Object,
+                    required: true,
+                    default: () => ({})
+                },
+            },
+
+            data() {
+                return {
+                    isStoring: false,
+                    loadingData: false,
+                    clinics: [],
+                    checks: [],
+                    selectedClinicId: '',
+                    selectedCheckIds: [],
+                };
+            },
+
+            methods: {
+                openModal() {
+                    this.selectedClinicId = '';
+                    this.selectedCheckIds = [];
+                    this.clinics = [];
+                    this.checks = [];
+                    this.$refs.reportUploadModal.open();
+                    this.fetchData();
+                },
+
+                fetchData() {
+                    this.loadingData = true;
+
+                    const url = `{{ route('admin.orders.report-upload-data', ':id') }}`.replace(':id', this.entity.id);
+
+                    this.$axios.get(url)
+                        .then(response => {
+                            this.clinics = response.data.clinics ?? [];
+                            this.checks = response.data.checks ?? [];
+
+                            if (this.clinics.length === 1) {
+                                this.selectedClinicId = this.clinics[0].id;
+                            }
+                        })
+                        .catch(() => {
+                            this.clinics = [];
+                            this.checks = [];
+                        })
+                        .finally(() => {
+                            this.loadingData = false;
+                        });
+                },
+
+                save(params, { setErrors }) {
+                    if (!this.selectedClinicId || this.selectedCheckIds.length === 0) {
+                        return;
+                    }
+
+                    this.isStoring = true;
+
+                    const formData = new FormData();
+
+                    Object.entries(params).forEach(([key, value]) => {
+                        if (value === null || value === undefined) return;
+                        if (key === 'clinic_id') return;
+                        if (value instanceof FileList) {
+                            Array.from(value).forEach(f => formData.append(key, f));
+                        } else if (value instanceof File || value instanceof Blob) {
+                            formData.append(key, value);
+                        } else {
+                            formData.append(key, String(value));
+                        }
+                    });
+
+                    formData.set('clinic_id', String(this.selectedClinicId));
+
+                    this.selectedCheckIds.forEach(id => {
+                        formData.append('check_ids[]', String(id));
+                    });
+
+                    const url = `{{ route('admin.orders.report-upload.store', ':id') }}`.replace(':id', this.entity.id);
+
+                    this.$axios.post(url, formData)
+                        .then(response => {
+                            this.isStoring = false;
+
+                            this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
+                            this.$emitter.emit('on-activity-added', response.data.data);
+
+                            this.$refs.reportUploadModal.close();
+                        })
+                        .catch(error => {
+                            this.isStoring = false;
+
+                            if (error.response && error.response.status === 422) {
+                                setErrors(error.response.data.errors);
+                            } else {
+                                this.$emitter.emit('add-flash', {
+                                    type: 'error',
+                                    message: error.response?.data?.message || 'Er is een fout opgetreden.',
+                                });
+                            }
+                        });
+                },
+            },
+        });
+    </script>
+@endPushOnce

--- a/packages/Webkul/Admin/src/Resources/views/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/view.blade.php
@@ -37,6 +37,9 @@
 
 
                         @if (bouncer()->hasPermission('activities.create'))
+                            <!-- Report Upload Action -->
+                            <x-admin::activities.actions.report :entity="$order"/>
+
                             <!-- File Activity Action -->
                             <x-admin::activities.actions.file :entity="$order" entity-control-name="order_id"/>
 

--- a/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
@@ -53,6 +53,10 @@ Route::controller(OrderController::class)->prefix('orders')->group(function () {
     Route::put('{orderId}/checks/{checkId}', 'updateCheck')->name('admin.orders.checks.update');
     Route::delete('{orderId}/checks/{checkId}', 'destroyCheck')->name('admin.orders.checks.destroy');
 
+    // Order report upload routes
+    Route::get('{orderId}/report-upload-data', 'reportUploadData')->name('admin.orders.report-upload-data');
+    Route::post('{orderId}/report-upload', 'storeReport')->name('admin.orders.report-upload.store');
+
     // Order activities routes
     Route::get('{id}/activities', 'activities')->name('admin.orders.activities.index');
     Route::get('{id}/emails/detach', 'emailsDetach')->name('admin.orders.emails.detach');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Kliniek rapportages aan order koppelen met automatische check-afvinken.

## Description
Voegt een "Rapportage" actie-knop toe aan de `admin/orders/view/{id}` pagina waarmee medewerkers rapportagebestanden van klinieken kunnen uploaden.

### Functionaliteit:
- **Rapportage knop**: Nieuwe groene actieknop in het Activity Actions blok op de order view pagina
- **Kliniek selectie**: Modal toont klinieken die gekoppeld zijn via resource bookings van de order items (vergelijkbaar met `OrderItem::retrievePartnerProductOrProductOrError`). Bij één kliniek wordt deze automatisch geselecteerd.
- **Check selectie**: Modal toont alle openstaande (niet-afgevinkte) checks van de order. Gebruiker kan één of meerdere checks selecteren die bij dit rapport horen.
- **Upload**: Bij het uploaden wordt:
  1. Een Activity van type `file` aangemaakt, gekoppeld aan de order (`order_id`) én de geselecteerde kliniek (`clinic_id`)
  2. De geselecteerde checks worden automatisch afgevinkt (`done = true`)
  3. Activity wordt aangemaakt met `is_done = false` zodat het bestand zichtbaar is in de "Bestanden" tab

### Zichtbaarheid na upload:
- **Order view → Activiteiten → Bestanden**: Rapportage verschijnt direct (met amber "te verwerken" indicator)
- **Clinic view → Activiteiten → Bestanden**: Rapportage verschijnt ook hier via `clinic_id` koppeling
- De activity heeft zowel `order_id` als `clinic_id` ingesteld, waardoor het in beide contexten terugkomt

### Technische wijzigingen:
- `OrderController`: Twee nieuwe methods (`reportUploadData`, `storeReport`)
- Routes: `GET {orderId}/report-upload-data` en `POST {orderId}/report-upload`
- Blade component: `x-admin::activities.actions.report` (Vue component `v-report-upload`)
- View: Report button toegevoegd aan `orders/view.blade.php`

## How To Test This?
1. Ga naar `admin/orders/view/{id}` voor een order met geplande items (resource bookings) en openstaande checks
2. Klik op de groene "Rapportage" knop
3. In de modal:
   - Kliniek wordt automatisch geladen uit order items
   - Selecteer een kliniek
   - Vink één of meerdere openstaande checks aan
   - Upload een bestand
4. Controleer dat:
   - Een nieuwe file Activity is aangemaakt met `order_id` en `clinic_id` ingesteld
   - De geselecteerde checks nu als "done" zijn gemarkeerd
   - Het bestand zichtbaar is onder "Bestanden" tab bij de activiteiten van de order
   - Het bestand ook zichtbaar is onder "Bestanden" tab bij de activiteiten van de kliniek

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: development

## Tailwind Reordering
Tailwind classes volgen de bestaande conventies in het project.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c00e97e-bfbf-43ef-8a1f-82c581e8d482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c00e97e-bfbf-43ef-8a1f-82c581e8d482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

