### PR TITLE
fix: default to no template in appointment confirmation email step

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
@@ -1,5 +1,4 @@
 @php
-    use App\Enums\EmailTemplateCode;
     use App\Enums\EmailTemplateType;
 @endphp
 <x-admin::layouts>
@@ -1048,11 +1047,7 @@
 
                             this.emailSubject = payload.subject || '';
 
-                            const defaultTpl = @json(EmailTemplateCode::ACKNOWLEDGE_ORDER_MAIL->value);
-                            if (this.emailTemplates.some(t => (t.code || t.name) === defaultTpl)) {
-                                this.emailSelectedTemplate = defaultTpl;
-                                this.$nextTick(() => this.loadEmailTemplate());
-                            } else if (payload.body) {
+                            if (payload.body) {
                                 this.emailBody = payload.body;
                                 this.$nextTick(() => this.setTinyMCEContent('wizard-email-editor', payload.body));
                             }


### PR DESCRIPTION
## Summary
- Removes the automatic pre-selection of the "Afspraak bevestiging Augusta" template (`ACKNOWLEDGE_ORDER_MAIL`) when entering the email step of the appointment confirmation wizard
- The template selector now defaults to "Geen template", as requested
- Users can still manually select any template from the dropdown

## Test plan
- [ ] Open an order and go to confirm: `/admin/orders/{id}/confirm`
- [ ] Complete step 1 (generate letter) and step 2 (upload files / skip)
- [ ] Verify that step 3 (Email versturen) starts with "Geen template" selected in the template dropdown
- [ ] Verify that manually selecting a template still loads its content correctly

Fixes MBS-165

🤖 Generated with [Claude Code](https://claude.com/claude-code)