### PR TITLE
fix: order items not set to LOST when order moves to verloren (MBS-163)

### DIFF
--- a/app/Enums/PipelineStage.php
+++ b/app/Enums/PipelineStage.php
@@ -581,6 +581,11 @@ enum PipelineStage: string
         );
     }
 
+    public static function getLostOrderStageIds(): array
+    {
+        return [self::ORDER_VERLOREN->id(), self::ORDER_VERLOREN_HERNIA->id()];
+    }
+
     // Used for operational grids:
 
     public static function getFrontOfficeStageIds(): array

--- a/app/Observers/OrderObserver.php
+++ b/app/Observers/OrderObserver.php
@@ -8,6 +8,7 @@ use App\Models\Order;
 use App\Models\OrderItem;
 use App\Services\OrderNumberGenerator;
 use App\Services\OrderStatusService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 
@@ -48,6 +49,14 @@ class OrderObserver
             Log::info('Updating order items to WON for order '.$order->id);
             OrderItem::forOrderAndNotLost($order->id)
                 ->update(['status' => OrderItemStatus::WON->value]);
+        }
+
+        if ($stageChange && in_array($order->pipeline_stage_id, PipelineStage::getLostOrderStageIds(), true)) {
+            Log::info('Updating order items to LOST for order '.$order->id);
+            $orderItemIds = OrderItem::where('order_id', $order->id)->pluck('id');
+            OrderItem::where('order_id', $order->id)
+                ->update(['status' => OrderItemStatus::LOST->value]);
+            DB::table('resource_orderitem')->whereIn('orderitem_id', $orderItemIds)->delete();
         }
     }
 }

--- a/tests/Feature/Orders/OrderObserverTest.php
+++ b/tests/Feature/Orders/OrderObserverTest.php
@@ -88,6 +88,71 @@ test('order items from other orders are not affected when one order moves to won
         ->and($itemB->fresh()->status)->toBe(OrderItemStatus::NEW);
 });
 
+test('updating to verloren stage marks all order items as lost', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id(),
+    ]);
+
+    $newItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::NEW->value]);
+    $plannedItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+    $wonItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::WON->value]);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $order->save();
+
+    expect($newItem->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($plannedItem->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($wonItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('updating to verloren stage removes resource_orderitem planning slots', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id(),
+    ]);
+
+    $item = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+    \Illuminate\Support\Facades\DB::table('resource_orderitem')->insert([
+        'orderitem_id' => $item->id,
+        'resource_id'  => 1,
+        'from'         => now()->toDateTimeString(),
+        'to'           => now()->addHour()->toDateTimeString(),
+    ]);
+
+    expect(\Illuminate\Support\Facades\DB::table('resource_orderitem')->where('orderitem_id', $item->id)->count())->toBe(1);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $order->save();
+
+    expect(\Illuminate\Support\Facades\DB::table('resource_orderitem')->where('orderitem_id', $item->id)->count())->toBe(0);
+});
+
+test('updating to hernia verloren stage marks all order items as lost', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND_HERNIA->id(),
+    ]);
+
+    $plannedItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN_HERNIA->id();
+    $order->save();
+
+    expect($plannedItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('items from other orders are not affected when one order moves to verloren', function () {
+    $orderA = Order::factory()->create(['pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id()]);
+    $orderB = Order::factory()->create(['pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id()]);
+
+    $itemA = OrderItem::factory()->create(['order_id' => $orderA->id, 'status' => OrderItemStatus::PLANNED->value]);
+    $itemB = OrderItem::factory()->create(['order_id' => $orderB->id, 'status' => OrderItemStatus::PLANNED->value]);
+
+    $orderA->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $orderA->save();
+
+    expect($itemA->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($itemB->fresh()->status)->toBe(OrderItemStatus::PLANNED);
+});
+
 test('created dispatches order.update_stage.after event', function () {
     Event::fake(['order.update_stage.after']);
 


### PR DESCRIPTION
## Summary

- When an order is moved to **ORDER_VERLOREN** or **ORDER_VERLOREN_HERNIA**, all order items are now set to `LOST` status
- The corresponding `resource_orderitem` planning slots are deleted, removing the items from resource planning (monitor)
- Added `PipelineStage::getLostOrderStageIds()` helper mirroring the existing WON helpers
- 4 new tests covering Privatescan and Hernia pipelines, order isolation, and resource_orderitem cleanup

## Root cause

`OrderObserver::updated()` had logic to mark items `WON` when an order reached a post-execution stage, but no corresponding logic for the LOST case. Items remained `PLANNED` and stayed in `resource_orderitem`, making them visible in the resource planning monitor.

## Test plan

- [ ] `php artisan test --filter=OrderObserverTest` — all tests pass
- [ ] Move an existing order to "Verloren" in the UI and verify all order lines switch to "Verloren" status
- [ ] Verify the items no longer appear in the resource planning monitor after marking as verloren

🤖 Generated with [Claude Code](https://claude.com/claude-code)