### PR TITLE
Improve planning monitor order view: z-index fix, edit/delete bookings, central order item labels

### DIFF
--- a/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
+++ b/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
@@ -71,6 +71,14 @@ class OrderItemPlanningController extends Controller
 
             $replace = $request->boolean('replace_existing', true);
 
+            $existingCount = ResourceOrderItem::where('orderitem_id', $orderItem->id)->count();
+
+            if (! $replace && $existingCount > 0) {
+                return response()->json([
+                    'message' => 'Dit orderitem is al ingepland. Gebruik de optie "vervang bestaande afspraak" of bewerk de bestaande boeking.',
+                ], 422);
+            }
+
             $booking = DB::transaction(function () use ($request, $orderItem, $replace) {
                 if ($replace) {
                     ResourceOrderItem::where('orderitem_id', $orderItem->id)->delete();

--- a/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+++ b/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
@@ -166,6 +166,14 @@ class ResourcePlanningMonitorController extends Controller
                 return $error;
             }
 
+            $existingCount = ResourceOrderItem::where('orderitem_id', $orderItem->id)->count();
+
+            if (! $replace && $existingCount > 0) {
+                return response()->json([
+                    'message' => 'Dit orderitem is al ingepland. Gebruik de optie "vervang bestaande afspraak" of bewerk de bestaande boeking.',
+                ], 422);
+            }
+
             $booking = DB::transaction(function () use ($request, $orderItem, $replace) {
                 if ($replace) {
                     ResourceOrderItem::where('orderitem_id', $orderItem->id)->delete();

--- a/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+++ b/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
@@ -679,7 +679,7 @@ class ResourcePlanningMonitorController extends Controller
 
         // Get order items with their existing bookings
         $orderItems = $order->orderItems()->with([
-            'product',
+            'product.partnerProducts',
             'person',
             'resourceType',
             'product.productType',
@@ -712,9 +712,10 @@ class ResourcePlanningMonitorController extends Controller
                 'id'                     => $item->id,
                 'product_name'           => $item->product?->name ?? 'Onbekend product',
                 'person_name'            => $item->person?->name ?? null,
-                'quantity'               => $item->quantity,
-                'status'                 => $item->status,
                 'required_resource_type' => $item->resolvedResourceTypeName(),
+                'quantity'               => $item->quantity,
+                'duration'               => $item->product?->partnerProducts?->first()?->duration,
+                'status'                 => $item->status,
                 'can_plan'               => $item->isPlannable(),
                 'bookings'               => $item->resourceOrderItems->map(fn ($booking) => [
                     'id'            => $booking->id,
@@ -766,7 +767,7 @@ class ResourcePlanningMonitorController extends Controller
 
         // Get order items with their existing bookings
         $orderItems = $order->orderItems()->with([
-            'product',
+            'product.partnerProducts',
             'person',
             'resourceType',
             'product.productType',
@@ -799,9 +800,10 @@ class ResourcePlanningMonitorController extends Controller
                 'id'                     => $item->id,
                 'product_name'           => $item->product?->name ?? 'Onbekend product',
                 'person_name'            => $item->person?->name ?? null,
-                'quantity'               => $item->quantity,
-                'status'                 => $item->status,
                 'required_resource_type' => $item->resolvedResourceTypeName(),
+                'quantity'               => $item->quantity,
+                'duration'               => $item->product?->partnerProducts?->first()?->duration,
+                'status'                 => $item->status,
                 'can_plan'               => $item->isPlannable(),
                 'bookings'               => $item->resourceOrderItems->map(fn ($booking) => [
                     'id'            => $booking->id,

--- a/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+++ b/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
@@ -198,6 +198,90 @@ class ResourcePlanningMonitorController extends Controller
         }
     }
 
+    public function updateBooking(Request $request, int $bookingId): JsonResponse
+    {
+        try {
+            $request->validate([
+                'resource_id' => ['required', 'integer', 'exists:resources,id'],
+                'from'        => ['required', 'date'],
+                'to'          => ['required', 'date', 'after:from'],
+            ]);
+
+            $booking = ResourceOrderItem::with([
+                'orderItem.product.resourceType',
+                'orderItem.resourceType',
+                'orderItem.product.productType',
+            ])->findOrFail($bookingId);
+
+            $resource = Resource::with('resourceType', 'shifts')->findOrFail((int) $request->input('resource_id'));
+
+            $requiredType = $booking->orderItem->resolvedResourceTypeName();
+            $resourceTypeName = $resource->resourceType?->name;
+            if ($requiredType !== $resourceTypeName) {
+                return response()->json([
+                    'message'       => sprintf(
+                        'Dit orderregel vereist \'%s\', maar de gekozen resource is van het type \'%s\'.',
+                        $requiredType ?? 'Onbekend',
+                        $resourceTypeName ?? 'Onbekend'
+                    ),
+                    'required_type' => $requiredType,
+                    'resource_type' => $resourceTypeName,
+                ], 422);
+            }
+
+            $from = CarbonImmutable::parse($request->input('from'));
+            $to = CarbonImmutable::parse($request->input('to'));
+
+            if ($error = $this->validateBookingAvailability($resource, $from, $to)) {
+                return $error;
+            }
+
+            $booking->update([
+                'resource_id' => (int) $request->input('resource_id'),
+                'from'        => Carbon::parse($request->input('from')),
+                'to'          => Carbon::parse($request->input('to')),
+                'updated_by'  => auth()->id(),
+            ]);
+
+            return response()->json([
+                'message' => 'Boeking bijgewerkt',
+                'data'    => $booking->fresh(),
+            ]);
+        } catch (Exception $e) {
+            Log::error('Error updating ResourceOrderItem from monitor', [
+                'error'        => $e->getMessage(),
+                'trace'        => $e->getTraceAsString(),
+                'request_data' => $request->all(),
+            ]);
+
+            return response()->json([
+                'message' => 'Fout bij bijwerken: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function deleteBooking(Request $request, int $bookingId): JsonResponse
+    {
+        try {
+            $booking = ResourceOrderItem::findOrFail($bookingId);
+            $booking->delete();
+
+            return response()->json([
+                'message' => 'Boeking verwijderd',
+            ]);
+        } catch (Exception $e) {
+            Log::error('Error deleting ResourceOrderItem from monitor', [
+                'error'      => $e->getMessage(),
+                'trace'      => $e->getTraceAsString(),
+                'booking_id' => $bookingId,
+            ]);
+
+            return response()->json([
+                'message' => 'Fout bij verwijderen: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+
     private function getWeekAvailability(Request $request): JsonResponse
     {
         $start = CarbonImmutable::parse($request->query('start', Carbon::now()->startOfWeek()));
@@ -442,6 +526,7 @@ class ResourcePlanningMonitorController extends Controller
                         'resource_name'        => $resource->name,
                         'clickable'            => false,
                         'booking_id'           => $occupancy->id,
+                        'order_item_id'        => $occupancy->orderitem_id,
                         'lead_name'            => $leadName,
                         'person_name'          => $personName,
                         'product_name'         => $productName,
@@ -595,6 +680,7 @@ class ResourcePlanningMonitorController extends Controller
         // Get order items with their existing bookings
         $orderItems = $order->orderItems()->with([
             'product',
+            'person',
             'resourceType',
             'product.productType',
             'product.resourceType',
@@ -625,10 +711,10 @@ class ResourcePlanningMonitorController extends Controller
             'order_items' => $orderItems->map(fn ($item) => [
                 'id'                     => $item->id,
                 'product_name'           => $item->product?->name ?? 'Onbekend product',
+                'person_name'            => $item->person?->name ?? null,
                 'quantity'               => $item->quantity,
                 'status'                 => $item->status,
                 'required_resource_type' => $item->resolvedResourceTypeName(),
-                // Only plan if product has partner products linked to active clinics
                 'can_plan'               => $item->isPlannable(),
                 'bookings'               => $item->resourceOrderItems->map(fn ($booking) => [
                     'id'            => $booking->id,
@@ -681,6 +767,7 @@ class ResourcePlanningMonitorController extends Controller
         // Get order items with their existing bookings
         $orderItems = $order->orderItems()->with([
             'product',
+            'person',
             'resourceType',
             'product.productType',
             'product.resourceType',
@@ -711,6 +798,7 @@ class ResourcePlanningMonitorController extends Controller
             'order_items' => $orderItems->map(fn ($item) => [
                 'id'                     => $item->id,
                 'product_name'           => $item->product?->name ?? 'Onbekend product',
+                'person_name'            => $item->person?->name ?? null,
                 'quantity'               => $item->quantity,
                 'status'                 => $item->status,
                 'required_resource_type' => $item->resolvedResourceTypeName(),

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -244,6 +244,22 @@ class OrderItem extends Model
     }
 
     /**
+     * Central display label: product name + person name.
+     * Single source of truth for UI presentation of order items.
+     */
+    public function getDisplayLabel(): string
+    {
+        $parts = [$this->getProductName() ?: 'Onbekend product'];
+
+        $personName = $this->person?->name;
+        if (! empty($personName)) {
+            $parts[] = $personName;
+        }
+
+        return implode(' — ', $parts);
+    }
+
+    /**
      * 1. description order item
      * 2. description partner product
      * 3. description product (designed as template for partner product)

--- a/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
@@ -107,4 +107,6 @@ Route::middleware(['user'])->controller(ResourcePlanningMonitorController::class
     Route::get('order/{orderId}/availability', 'orderAvailability')->name('admin.planning.monitor.order.availability');
     Route::get('order/{orderId}/resource-types', 'orderResourceTypes')->name('admin.planning.monitor.order.resource_types');
     Route::post('order-item/{orderItemId}/book', 'bookOrderItem')->name('admin.planning.monitor.order_item.book');
+    Route::put('booking/{bookingId}', 'updateBooking')->name('admin.planning.monitor.booking.update');
+    Route::delete('booking/{bookingId}', 'deleteBooking')->name('admin.planning.monitor.booking.delete');
 });

--- a/resources/views/adminc/planning/components/booking-modal.blade.php
+++ b/resources/views/adminc/planning/components/booking-modal.blade.php
@@ -1,7 +1,7 @@
 <!-- Book modal -->
 <x-admin::modal ref="bookModal">
     <x-slot:header>
-        Inboeken
+        @{{ isEditing ? 'Boeking bewerken' : 'Inboeken' }}
     </x-slot:header>
     <x-slot:content>
         <div class="space-y-6" style="pointer-events: auto; z-index: 1000; position: relative;">
@@ -27,7 +27,7 @@
                             :key="item.id"
                             :value="item.id"
                         >
-                            ✓ @{{ item.product_name }} (Aantal: @{{ item.quantity }})
+                            ✓ @{{ orderItemLabel(item) }}
                         </option>
                     </optgroup>
                     <optgroup v-if="plannedItems.length > 0"
@@ -37,7 +37,7 @@
                             :key="item.id"
                             :value="item.id"
                         >
-                            📅 @{{ item.product_name }} (Aantal: @{{ item.quantity }}) - @{{ item.bookings.length }}x ingepland
+                            📅 @{{ orderItemLabel(item) }} - @{{ item.bookings.length }}x ingepland
                         </option>
                     </optgroup>
                     <optgroup v-if="notPlanableItems.length > 0"
@@ -48,7 +48,7 @@
                             :value="item.id"
                             disabled
                         >
-                            ⚠ @{{ item.product_name }} (Aantal: @{{ item.quantity }}) - Niet planbaar
+                            ⚠ @{{ orderItemLabel(item) }} - Niet planbaar
                         </option>
                     </optgroup>
                 </select>
@@ -134,8 +134,9 @@
                 </span>
             </div>
 
-            <!-- Replace existing -->
+            <!-- Replace existing (only for new bookings) -->
             <x-adminc::components.field
+                v-if="!isEditing"
                 type="checkbox"
                 name="replace_existing"
                 label="Vervang bestaande afspraak (verwijdert eerdere boekingen voor deze orderitem)"
@@ -145,15 +146,26 @@
         </div>
     </x-slot:content>
     <x-slot:footer>
-        <div class="flex justify-end gap-3">
-            <button
-                class="secondary-button"
-                @click="$refs.bookModal.toggle()">Annuleren
-            </button>
-            <button
-                class="primary-button"
-                @click="submitBooking">Opslaan
-            </button>
+        <div class="flex justify-between">
+            <div>
+                <button
+                    v-if="isEditing && editingBookingId"
+                    class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors"
+                    @click="deleteBooking"
+                >
+                    Verwijderen
+                </button>
+            </div>
+            <div class="flex gap-3">
+                <button
+                    class="secondary-button"
+                    @click="$refs.bookModal.toggle()">Annuleren
+                </button>
+                <button
+                    class="primary-button"
+                    @click="submitBooking">@{{ isEditing ? 'Bijwerken' : 'Opslaan' }}
+                </button>
+            </div>
         </div>
     </x-slot:footer>
 </x-admin::modal>

--- a/resources/views/adminc/planning/components/booking-modal.blade.php
+++ b/resources/views/adminc/planning/components/booking-modal.blade.php
@@ -134,14 +134,6 @@
                 </span>
             </div>
 
-            <!-- Replace existing (only for new bookings) -->
-            <x-adminc::components.field
-                v-if="!isEditing"
-                type="checkbox"
-                name="replace_existing"
-                label="Vervang bestaande afspraak (verwijdert eerdere boekingen voor deze orderitem)"
-                v-model="form.replace_existing"
-            />
 
         </div>
     </x-slot:content>

--- a/resources/views/adminc/planning/components/booking-modal.blade.php
+++ b/resources/views/adminc/planning/components/booking-modal.blade.php
@@ -37,7 +37,7 @@
                             :key="item.id"
                             :value="item.id"
                         >
-                            📅 @{{ orderItemLabel(item) }} - @{{ item.bookings.length }}x ingepland
+                            📅 @{{ orderItemLabel(item) }}
                         </option>
                     </optgroup>
                     <optgroup v-if="notPlanableItems.length > 0"

--- a/resources/views/adminc/planning/components/order-items-panel.blade.php
+++ b/resources/views/adminc/planning/components/order-items-panel.blade.php
@@ -18,7 +18,7 @@
             <div
                 class="border border-gray-200 dark:border-gray-700 rounded-lg p-3 {{ $canPlan ? 'bg-activity-note-bg dark:bg-blue-900/20' : 'bg-gray-50 dark:bg-gray-800' }}">
                 <div class="flex justify-between items-start mb-2">
-                    <h4 class="font-medium text-sm">{{ $item->getProductName() ?: 'Onbekend product' }}</h4>
+                    <h4 class="font-medium text-sm">{{ $item->getDisplayLabel() }}</h4>
                     <span
                         class="text-xs px-2 py-1 rounded-full {{ $statusValue === 'planned' ? 'bg-green-100 text-green-800' : 'bg-neutral-bg text-gray-800' }}">
                         {{ $statusLabel }}

--- a/resources/views/adminc/planning/components/planning-calendar.blade.php
+++ b/resources/views/adminc/planning/components/planning-calendar.blade.php
@@ -17,7 +17,7 @@
         .calendar-block-available { cursor: pointer; }
         .calendar-block-available:hover { transform: translateY(-1px); box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
         .calendar-block-occupied { cursor: default; min-height: 20px; font-size: 12px; line-height: 1.25; }
-        .filters-bar { position: relative; z-index: 10; }
+        .filters-bar { position: relative; z-index: 50; }
         .loading-overlay { position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: rgba(255,255,255,0.8); display: flex; align-items: center; justify-content: center; z-index: 20; }
         .loading-spinner { width: 32px; height: 32px; border: 3px solid #e5e7eb; border-top: 3px solid #3b82f6; border-radius: 50%; animation: spin 1s linear infinite; }
         @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
@@ -36,6 +36,8 @@
         .month-block-available { background: rgba(16, 185, 129, 0.2); border: 1px solid rgba(16, 185, 129, 0.4); }
         .month-block-occupied { background: rgba(239, 68, 68, 0.2); border: 1px solid rgba(239, 68, 68, 0.4); cursor: not-allowed; }
         .calendar-block-outside-availability { border: 2px dashed #dc2626 !important; }
+        .calendar-block-editable { cursor: pointer !important; }
+        .calendar-block-editable:hover { transform: translateY(-1px); box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
     </style>
 
     <script type="text/x-template" id="v-planning-calendar-template">
@@ -96,10 +98,10 @@
 
                         <!-- Rendered blocks from server -->
                         <div v-for="block in getBlocksForDay(d-1)" :key="block.key"
-                             :class="['calendar-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied', block.outside_availability ? 'calendar-block-outside-availability' : '']"
+                             :class="['calendar-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied', block.outside_availability ? 'calendar-block-outside-availability' : '', isEditableBlock(block) ? 'calendar-block-editable' : '']"
                              :style="blockStyle(block)"
                              :title="getBlockTooltip(block)"
-                             @click.stop="block.clickable ? handleBlockClick(block) : null">
+                             @click.stop="handleAnyBlockClick(block)">
                             <template v-if="block.type === 'occupied'">
                                 <div class="flex flex-col gap-0.5 min-h-0 min-w-0 flex-1">
                                     <div class="flex items-start justify-between gap-1 min-w-0">
@@ -151,9 +153,9 @@
 
                     <!-- Blocks for this day -->
                     <div v-for="block in getBlocksForMonthDay(day.date)" :key="block.key"
-                         :class="['month-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied']"
+                         :class="['month-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied', isEditableBlock(block) ? 'calendar-block-editable' : '']"
                          :title="getBlockTooltip(block)"
-                         @click="block.clickable ? handleBlockClick(block) : null">
+                         @click="handleAnyBlockClick(block)">
                         <template v-if="block.type === 'occupied'">
                             <div class="flex items-start justify-between gap-1">
                                 <div class="font-semibold truncate">@{{ block.person_name || block.lead_name || 'Onbekend' }}</div>
@@ -189,6 +191,7 @@
                 viewType: { type: String, default: 'week' },
                 availabilityUrl: { type: String, required: true },
                 autoLoad: { type: Boolean, default: true },
+                currentOrderId: { type: Number, default: null },
             },
             data() {
                 return {
@@ -616,6 +619,18 @@
                     from.setHours(Math.floor(totalMinutes / 60) + 8, totalMinutes % 60, 0, 0);
 
                     this.$emit('column-click', { from });
+                },
+                isEditableBlock(block) {
+                    return block.type === 'occupied'
+                        && this.currentOrderId !== null
+                        && block.order_id === this.currentOrderId;
+                },
+                handleAnyBlockClick(block) {
+                    if (block.clickable) {
+                        this.handleBlockClick(block);
+                    } else if (this.isEditableBlock(block)) {
+                        this.$emit('occupied-block-click', block);
+                    }
                 },
                 handleBlockClick(block) {
                     this.$emit('block-click', block);

--- a/resources/views/adminc/planning/order_monitor.blade.php
+++ b/resources/views/adminc/planning/order_monitor.blade.php
@@ -55,7 +55,7 @@
              class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 p-4">
             <v-order-resource-planning
                 :order-id="{{ $order->id }}"
-                :order-items='@json($orderItems)'
+                :initial-order-items='@json($orderItems)'
             ></v-order-resource-planning>
         </div>
     </div>
@@ -217,19 +217,22 @@
                         await this.$refs.calendar.loadAvailability(params);
                     },
                     onCalendarLoaded(data) {
-                        // Handle any post-load logic if needed
                         this.resources = data.resources || [];
+                        if (data.order_items) {
+                            this.orderItems = data.order_items;
+                        }
                     }
                 }
             };
 
             app.component('v-order-resource-planning', {
                 template: '#v-order-resource-planning-template',
-                props: ['orderId', 'orderItems'],
+                props: ['orderId', 'initialOrderItems'],
                 mixins: [planningCalendarMixin],
                 data() {
                     return {
                         ...planningCalendarMixin.data(),
+                        orderItems: JSON.parse(JSON.stringify(this.initialOrderItems)),
                         filters: {
                             ...planningCalendarMixin.data().filters,
                             order_item_ids: [],

--- a/resources/views/adminc/planning/order_monitor.blade.php
+++ b/resources/views/adminc/planning/order_monitor.blade.php
@@ -243,7 +243,6 @@
                             resource_id: null,
                             from: '',
                             to: '',
-                            replace_existing: true
                         },
                         isEditing: false,
                         editingBookingId: null,
@@ -473,7 +472,6 @@
                         this.form.resource_id = block.resource_id;
                         this.form.from = toLocal(new Date(block.from));
                         this.form.to = toLocal(new Date(block.to));
-                        this.form.replace_existing = false;
                         this.$refs.bookModal.toggle();
                     },
                     async submitBooking() {
@@ -513,7 +511,7 @@
                                     resource_id: this.form.resource_id,
                                     from: this.form.from,
                                     to: this.form.to,
-                                    replace_existing: !!this.form.replace_existing
+                                    replace_existing: true
                                 });
                             }
 
@@ -604,7 +602,6 @@
                             resource_id: null,
                             from: '',
                             to: '',
-                            replace_existing: true
                         };
                         this.resetEditState();
                         setTimeout(() => {

--- a/resources/views/adminc/planning/order_monitor.blade.php
+++ b/resources/views/adminc/planning/order_monitor.blade.php
@@ -33,6 +33,7 @@
                 return [
                     'id' => $item->id,
                     'product_name' => $item->getProductName() ?: 'Onbekend product',
+                    'person_name' => $item->person?->name ?? null,
                     'required_resource_type' => $item->resolvedResourceTypeName(),
                     'quantity' => $item->quantity,
                     'duration' => $duration, // Duration in minutes
@@ -67,8 +68,10 @@
                     :view-type="viewType"
                     :availability-url="availabilityUrl"
                     :auto-load="false"
+                    :current-order-id="orderId"
                     @loaded="onCalendarLoaded"
                     @block-click="openBook"
+                    @occupied-block-click="openEditBooking"
                     @column-click="openBookAtTime"
                 >
                     <template #filters>
@@ -239,11 +242,15 @@
                             to: '',
                             replace_existing: true
                         },
+                        isEditing: false,
+                        editingBookingId: null,
                         resources: [],
                         resourceTypes: @json($resourceTypes),
                         clinics: @json($clinics),
                         availabilityUrl: "{{ route('admin.planning.monitor.order.availability', ['orderId' => $order->id]) }}",
-                        resourceTypesUrl: "{{ route('admin.planning.monitor.order.resource_types', ['orderId' => $order->id]) }}"
+                        resourceTypesUrl: "{{ route('admin.planning.monitor.order.resource_types', ['orderId' => $order->id]) }}",
+                        updateBookingUrlTemplate: "{{ route('admin.planning.monitor.booking.update', ['bookingId' => '___ID___']) }}",
+                        deleteBookingUrlTemplate: "{{ route('admin.planning.monitor.booking.delete', ['bookingId' => '___ID___']) }}"
                     };
                 },
                 computed: {
@@ -251,8 +258,7 @@
                     orderItemOptions() {
                         return this.orderItems.map(item => ({
                             value: item.id,
-                            label: item.product_name
-                                + ' (Aantal: ' + item.quantity + ')'
+                            label: this.orderItemLabel(item)
                                 + (!item.can_plan ? ' - Niet planbaar' : '')
                         }));
                     },
@@ -334,6 +340,17 @@
                 methods: {
                     ...planningCalendarMixin.methods,
                     /**
+                     * Central label for order items: product name + person name.
+                     * Single source of truth for how order items are displayed in dropdowns, modals, etc.
+                     */
+                    orderItemLabel(item) {
+                        const parts = [item.product_name || 'Onbekend product'];
+                        if (item.person_name) {
+                            parts.push(item.person_name);
+                        }
+                        return parts.join(' — ') + ' (Aantal: ' + item.quantity + ')';
+                    },
+                    /**
                      * Als het orderregel wisselt: resource laten matchen met vereist type indien mogelijk.
                      */
                     syncBookingResourceId() {
@@ -408,7 +425,12 @@
                             (item) => item.required_resource_type === resourceTypeName
                         ) ?? null;
                     },
+                    resetEditState() {
+                        this.isEditing = false;
+                        this.editingBookingId = null;
+                    },
                     openBookAtTime({ from }) {
+                        this.resetEditState();
                         const pad = (n) => String(n).padStart(2, '0');
                         const toLocal = (dt) => `${dt.getFullYear()}-${pad(dt.getMonth()+1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
                         this.form.from = toLocal(from);
@@ -422,6 +444,7 @@
                         this.$nextTick(() => this.syncBookingResourceId());
                     },
                     openBook(block) {
+                        this.resetEditState();
                         this.form.resource_id = block.resource_id;
                         const pad = (n) => String(n).padStart(2, '0');
                         const toLocal = (dt) => `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
@@ -438,6 +461,18 @@
                         this.$refs.bookModal.toggle();
                         this.$nextTick(() => this.syncBookingResourceId());
                     },
+                    openEditBooking(block) {
+                        this.isEditing = true;
+                        this.editingBookingId = block.booking_id;
+                        const pad = (n) => String(n).padStart(2, '0');
+                        const toLocal = (dt) => `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+                        this.form.order_item_id = block.order_item_id;
+                        this.form.resource_id = block.resource_id;
+                        this.form.from = toLocal(new Date(block.from));
+                        this.form.to = toLocal(new Date(block.to));
+                        this.form.replace_existing = false;
+                        this.$refs.bookModal.toggle();
+                    },
                     async submitBooking() {
                         if (this.$refs.calendar.loading) return;
 
@@ -453,46 +488,50 @@
 
                         this.$refs.calendar.loading = true;
                         try {
-                            const url = "{{ route('admin.planning.monitor.order_item.book', ['orderItemId' => '___ID___']) }}".replace('___ID___', this.form.order_item_id);
                             const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
-
                             if (!csrfToken) {
                                 throw new Error('CSRF token niet gevonden');
                             }
 
+                            let url, method, body;
+
+                            if (this.isEditing && this.editingBookingId) {
+                                url = this.updateBookingUrlTemplate.replace('___ID___', this.editingBookingId);
+                                method = 'PUT';
+                                body = JSON.stringify({
+                                    resource_id: this.form.resource_id,
+                                    from: this.form.from,
+                                    to: this.form.to,
+                                });
+                            } else {
+                                url = "{{ route('admin.planning.monitor.order_item.book', ['orderItemId' => '___ID___']) }}".replace('___ID___', this.form.order_item_id);
+                                method = 'POST';
+                                body = JSON.stringify({
+                                    resource_id: this.form.resource_id,
+                                    from: this.form.from,
+                                    to: this.form.to,
+                                    replace_existing: !!this.form.replace_existing
+                                });
+                            }
+
                             const res = await fetch(url, {
-                                method: 'POST',
+                                method,
                                 headers: {
                                     'Content-Type': 'application/json',
                                     'Accept': 'application/json',
                                     'X-CSRF-TOKEN': csrfToken,
                                     'X-Requested-With': 'XMLHttpRequest'
                                 },
-                                body: JSON.stringify({
-                                    resource_id: this.form.resource_id,
-                                    from: this.form.from,
-                                    to: this.form.to,
-                                    replace_existing: !!this.form.replace_existing
-                                })
+                                body
                             });
 
                             if (res.ok) {
                                 this.$refs.bookModal.toggle();
-                                this.$emitter.emit('add-flash', {type: 'success', message: 'Ingeboekt'});
-                                this.form = {
-                                    order_item_id: null,
-                                    resource_id: null,
-                                    from: '',
-                                    to: '',
-                                    replace_existing: true
-                                };
-                                setTimeout(() => {
-                                    this.$refs.calendar.loading = false;
-                                    this.loadAvailability().catch(error => {
-                                        console.error('Error reloading availability:', error);
-                                        this.$refs.calendar.loading = false;
-                                    });
-                                }, 100);
+                                this.$emitter.emit('add-flash', {
+                                    type: 'success',
+                                    message: this.isEditing ? 'Boeking bijgewerkt' : 'Ingeboekt'
+                                });
+                                this.resetFormAndReload();
                             } else {
                                 const data = await res.json().catch(() => ({}));
                                 let errMsg = data.message;
@@ -507,11 +546,71 @@
                         } catch (error) {
                             this.$emitter.emit('add-flash', {
                                 type: 'error',
-                                message: `Fout bij inboeken: ${error.message}`
+                                message: `Fout bij ${this.isEditing ? 'bijwerken' : 'inboeken'}: ${error.message}`
                             });
                         } finally {
                             this.$refs.calendar.loading = false;
                         }
+                    },
+                    async deleteBooking() {
+                        if (!this.editingBookingId) return;
+                        if (!confirm('Weet je zeker dat je deze boeking wilt verwijderen?')) return;
+
+                        if (this.$refs.calendar.loading) return;
+                        this.$refs.calendar.loading = true;
+
+                        try {
+                            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+                            if (!csrfToken) {
+                                throw new Error('CSRF token niet gevonden');
+                            }
+
+                            const url = this.deleteBookingUrlTemplate.replace('___ID___', this.editingBookingId);
+                            const res = await fetch(url, {
+                                method: 'DELETE',
+                                headers: {
+                                    'Accept': 'application/json',
+                                    'X-CSRF-TOKEN': csrfToken,
+                                    'X-Requested-With': 'XMLHttpRequest'
+                                }
+                            });
+
+                            if (res.ok) {
+                                this.$refs.bookModal.toggle();
+                                this.$emitter.emit('add-flash', {type: 'success', message: 'Boeking verwijderd'});
+                                this.resetFormAndReload();
+                            } else {
+                                const data = await res.json().catch(() => ({}));
+                                this.$emitter.emit('add-flash', {
+                                    type: 'error',
+                                    message: data.message || `HTTP ${res.status}: ${res.statusText}`
+                                });
+                            }
+                        } catch (error) {
+                            this.$emitter.emit('add-flash', {
+                                type: 'error',
+                                message: `Fout bij verwijderen: ${error.message}`
+                            });
+                        } finally {
+                            this.$refs.calendar.loading = false;
+                        }
+                    },
+                    resetFormAndReload() {
+                        this.form = {
+                            order_item_id: null,
+                            resource_id: null,
+                            from: '',
+                            to: '',
+                            replace_existing: true
+                        };
+                        this.resetEditState();
+                        setTimeout(() => {
+                            this.$refs.calendar.loading = false;
+                            this.loadAvailability().catch(error => {
+                                console.error('Error reloading availability:', error);
+                                this.$refs.calendar.loading = false;
+                            });
+                        }, 100);
                     }
                 }
             });

--- a/tests/Feature/Planning/ResourcePlanningMonitorBookingTest.php
+++ b/tests/Feature/Planning/ResourcePlanningMonitorBookingTest.php
@@ -67,49 +67,7 @@ test('monitor book returns 422 with readable message when resource type mismatch
         ->and($message)->toContain('Dit orderregel vereist');
 });
 
-test('monitor book rejects duplicate booking when replace_existing is false', function () {
-    $resourceType = ResourceType::firstOrCreate(
-        ['name' => 'MRI scanner'],
-        ['description' => null]
-    );
-
-    $product = Product::factory()->create([
-        'resource_type_id' => $resourceType->id,
-    ]);
-
-    $orderItem = OrderItem::factory()->create([
-        'product_id' => $product->id,
-    ]);
-
-    $resource = Resource::factory()->create([
-        'resource_type_id' => $resourceType->id,
-    ]);
-
-    ResourceOrderItem::factory()->create([
-        'orderitem_id' => $orderItem->id,
-        'resource_id'  => $resource->id,
-    ]);
-
-    $from = Carbon::tomorrow()->setTime(14, 0);
-    $to = $from->copy()->addHour();
-
-    $response = $this->postJson(
-        route('admin.planning.monitor.order_item.book', ['orderItemId' => $orderItem->id]),
-        [
-            'resource_id'      => $resource->id,
-            'from'             => $from->toIso8601String(),
-            'to'               => $to->toIso8601String(),
-            'replace_existing' => false,
-        ]
-    );
-
-    $response->assertStatus(422);
-    expect($response->json('message'))->toContain('al ingepland');
-
-    expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
-});
-
-test('monitor book allows replacing existing booking when replace_existing is true', function () {
+test('monitor book replaces existing booking and keeps exactly one', function () {
     $resourceType = ResourceType::firstOrCreate(
         ['name' => 'MRI scanner'],
         ['description' => null]
@@ -151,7 +109,7 @@ test('monitor book allows replacing existing booking when replace_existing is tr
     expect(ResourceOrderItem::find($oldBooking->id))->toBeNull();
 });
 
-test('monitor book allows first booking when replace_existing is false', function () {
+test('monitor book rejects duplicate when replace_existing is false', function () {
     $resourceType = ResourceType::firstOrCreate(
         ['name' => 'MRI scanner'],
         ['description' => null]
@@ -169,7 +127,12 @@ test('monitor book allows first booking when replace_existing is false', functio
         'resource_type_id' => $resourceType->id,
     ]);
 
-    $from = Carbon::tomorrow()->setTime(10, 0);
+    ResourceOrderItem::factory()->create([
+        'orderitem_id' => $orderItem->id,
+        'resource_id'  => $resource->id,
+    ]);
+
+    $from = Carbon::tomorrow()->setTime(14, 0);
     $to = $from->copy()->addHour();
 
     $response = $this->postJson(
@@ -182,6 +145,47 @@ test('monitor book allows first booking when replace_existing is false', functio
         ]
     );
 
+    $response->assertStatus(422);
+    expect($response->json('message'))->toContain('al ingepland');
+    expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
+});
+
+test('monitor book defaults to replace_existing true when not specified', function () {
+    $resourceType = ResourceType::firstOrCreate(
+        ['name' => 'MRI scanner'],
+        ['description' => null]
+    );
+
+    $product = Product::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $orderItem = OrderItem::factory()->create([
+        'product_id' => $product->id,
+    ]);
+
+    $resource = Resource::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $oldBooking = ResourceOrderItem::factory()->create([
+        'orderitem_id' => $orderItem->id,
+        'resource_id'  => $resource->id,
+    ]);
+
+    $from = Carbon::tomorrow()->setTime(10, 0);
+    $to = $from->copy()->addHour();
+
+    $response = $this->postJson(
+        route('admin.planning.monitor.order_item.book', ['orderItemId' => $orderItem->id]),
+        [
+            'resource_id' => $resource->id,
+            'from'        => $from->toIso8601String(),
+            'to'          => $to->toIso8601String(),
+        ]
+    );
+
     $response->assertStatus(201);
     expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
+    expect(ResourceOrderItem::find($oldBooking->id))->toBeNull();
 });

--- a/tests/Feature/Planning/ResourcePlanningMonitorBookingTest.php
+++ b/tests/Feature/Planning/ResourcePlanningMonitorBookingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Planning;
 use App\Models\OrderItem;
 use App\Models\ProductType;
 use App\Models\Resource;
+use App\Models\ResourceOrderItem;
 use App\Models\ResourceType;
 use Carbon\Carbon;
 use Webkul\Installer\Http\Middleware\CanInstall;
@@ -64,4 +65,123 @@ test('monitor book returns 422 with readable message when resource type mismatch
     expect($message)->toContain('MRI scanner')
         ->and($message)->toContain('CT scanner')
         ->and($message)->toContain('Dit orderregel vereist');
+});
+
+test('monitor book rejects duplicate booking when replace_existing is false', function () {
+    $resourceType = ResourceType::firstOrCreate(
+        ['name' => 'MRI scanner'],
+        ['description' => null]
+    );
+
+    $product = Product::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $orderItem = OrderItem::factory()->create([
+        'product_id' => $product->id,
+    ]);
+
+    $resource = Resource::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    ResourceOrderItem::factory()->create([
+        'orderitem_id' => $orderItem->id,
+        'resource_id'  => $resource->id,
+    ]);
+
+    $from = Carbon::tomorrow()->setTime(14, 0);
+    $to = $from->copy()->addHour();
+
+    $response = $this->postJson(
+        route('admin.planning.monitor.order_item.book', ['orderItemId' => $orderItem->id]),
+        [
+            'resource_id'      => $resource->id,
+            'from'             => $from->toIso8601String(),
+            'to'               => $to->toIso8601String(),
+            'replace_existing' => false,
+        ]
+    );
+
+    $response->assertStatus(422);
+    expect($response->json('message'))->toContain('al ingepland');
+
+    expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
+});
+
+test('monitor book allows replacing existing booking when replace_existing is true', function () {
+    $resourceType = ResourceType::firstOrCreate(
+        ['name' => 'MRI scanner'],
+        ['description' => null]
+    );
+
+    $product = Product::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $orderItem = OrderItem::factory()->create([
+        'product_id' => $product->id,
+    ]);
+
+    $resource = Resource::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $oldBooking = ResourceOrderItem::factory()->create([
+        'orderitem_id' => $orderItem->id,
+        'resource_id'  => $resource->id,
+    ]);
+
+    $from = Carbon::tomorrow()->setTime(14, 0);
+    $to = $from->copy()->addHour();
+
+    $response = $this->postJson(
+        route('admin.planning.monitor.order_item.book', ['orderItemId' => $orderItem->id]),
+        [
+            'resource_id'      => $resource->id,
+            'from'             => $from->toIso8601String(),
+            'to'               => $to->toIso8601String(),
+            'replace_existing' => true,
+        ]
+    );
+
+    $response->assertStatus(201);
+
+    expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
+    expect(ResourceOrderItem::find($oldBooking->id))->toBeNull();
+});
+
+test('monitor book allows first booking when replace_existing is false', function () {
+    $resourceType = ResourceType::firstOrCreate(
+        ['name' => 'MRI scanner'],
+        ['description' => null]
+    );
+
+    $product = Product::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $orderItem = OrderItem::factory()->create([
+        'product_id' => $product->id,
+    ]);
+
+    $resource = Resource::factory()->create([
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $from = Carbon::tomorrow()->setTime(10, 0);
+    $to = $from->copy()->addHour();
+
+    $response = $this->postJson(
+        route('admin.planning.monitor.order_item.book', ['orderItemId' => $orderItem->id]),
+        [
+            'resource_id'      => $resource->id,
+            'from'             => $from->toIso8601String(),
+            'to'               => $to->toIso8601String(),
+            'replace_existing' => false,
+        ]
+    );
+
+    $response->assertStatus(201);
+    expect(ResourceOrderItem::where('orderitem_id', $orderItem->id)->count())->toBe(1);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Planning monitor order view usability improvements.

## Description
Improvements to the `admin/planning/monitor/order/{id}` view:

### 1. Fix filter dropdown z-index
The multiselect dropdown menus in the filter bar were rendered behind the calendar planning blocks. Fixed by increasing the `.filters-bar` z-index from 10 to 50 (calendar blocks use z-index 25+).

### 2. Edit/delete functionality on planned blocks
Users can now click on occupied calendar blocks that belong to the current order to edit them:
- Occupied blocks for the current order show a pointer cursor and hover effect
- Clicking opens the booking modal in **edit mode** with pre-filled data
- Modal header changes to "Boeking bewerken" and save button to "Bijwerken"
- A red **Verwijderen** button is added to the modal footer (left-aligned)
- New backend endpoints: `PUT booking/{id}` and `DELETE booking/{id}`

### 3. Central order item label with person name
Order item labels now include the person name for clarity:
- **Server-side**: `OrderItem::getDisplayLabel()` returns `"Product — Persoon"`
- **Client-side**: `orderItemLabel(item)` returns `"Product — Persoon (Aantal: X)"`
- Used consistently in: filter dropdown, booking modal select options, order items panel header

### 4. Simplified booking flow
- Removed "Vervang bestaande afspraak" checkbox — booking always replaces existing (order item max 1 booking)
- Removed "Xx ingepland" suffix from planned items in modal select (redundant)
- Server-side validation rejects duplicate bookings when `replace_existing=false` (safety guard)

### 5. Refresh order items after booking changes
After creating, updating, or deleting a booking, the order items list refreshes via the availability API response so unplanned/planned status updates immediately without page reload.

### Files changed
- `ResourcePlanningMonitorController.php` — `updateBooking()`, `deleteBooking()`, duplicate validation, `order_item_id`/`person_name`/`duration` in responses
- `OrderItemPlanningController.php` — duplicate booking validation
- `OrderItem.php` — `getDisplayLabel()` method
- `orders-routes.php` — PUT and DELETE routes for bookings
- `booking-modal.blade.php` — edit mode, central label, removed checkbox and "Xx ingepland"
- `order-items-panel.blade.php` — uses `getDisplayLabel()`
- `planning-calendar.blade.php` — z-index fix, editable block handling
- `order_monitor.blade.php` — edit state, mutable orderItems with API refresh, always replace
- `ResourcePlanningMonitorBookingTest.php` — tests for replace behavior and duplicate rejection

## How To Test This?
1. Navigate to `admin/planning/monitor/order/{id}` for an order with planned items
2. **Z-index**: Open filter dropdowns → verify they appear above calendar blocks
3. **Edit**: Click an occupied (red) block → modal opens in edit mode → change time → click "Bijwerken"
4. **Delete**: Click occupied block → "Verwijderen" → confirm → booking removed; click calendar again → item shows as "Nog niet ingepland" (no refresh needed)
5. **Labels**: Verify "Product — Persoon (Aantal: X)" format everywhere
6. **Replace**: Book an already-planned item → old booking is replaced, exactly 1 booking exists

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: development

## Tailwind Reordering
All Tailwind classes follow existing patterns in the codebase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6feae43d-6da9-4820-bf88-901e11198f9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6feae43d-6da9-4820-bf88-901e11198f9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

