### PR TITLE
fix: set order items to LOST when order moves to verloren [MBS-163]

### DIFF
--- a/app/Enums/PipelineStage.php
+++ b/app/Enums/PipelineStage.php
@@ -581,6 +581,11 @@ enum PipelineStage: string
         );
     }
 
+    public static function getLostOrderStageIds(): array
+    {
+        return [self::ORDER_VERLOREN->id(), self::ORDER_VERLOREN_HERNIA->id()];
+    }
+
     // Used for operational grids:
 
     public static function getFrontOfficeStageIds(): array

--- a/app/Http/Controllers/Admin/Planning/Concerns/ResourceAvailabilityTrait.php
+++ b/app/Http/Controllers/Admin/Planning/Concerns/ResourceAvailabilityTrait.php
@@ -91,7 +91,7 @@ trait ResourceAvailabilityTrait
     protected function getOccupancy($resources, CarbonImmutable $start, CarbonImmutable $end): Collection
     {
         return ResourceOrderItem::query()
-            ->with(['orderItem.order.salesLead.lead'])
+            ->with(['orderItem.order.salesLead.lead', 'orderItem.person'])
             ->whereIn('resource_id', $resources->pluck('id'))
             ->where(function ($q) use ($start, $end) {
                 $q->whereBetween('from', [$start, $end])

--- a/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
+++ b/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
@@ -297,6 +297,11 @@ class OrderItemPlanningController extends Controller
                 $productName = $occupancy->orderItem?->product?->name;
                 $leadName .= ' - '.$productName;
 
+                $personName = $occupancy->orderItem?->person?->name;
+                $order = $occupancy->orderItem?->order;
+                $orderNumber = $order?->order_number;
+                $orderId = $order?->id;
+
                 $outsideAvailability = empty($availabilityWindows)
                     ? false
                     : ! $this->overlapsWithWindows($blockStart, $blockEnd, $availabilityWindows);
@@ -310,6 +315,9 @@ class OrderItemPlanningController extends Controller
                     'clickable'            => false,
                     'booking_id'           => $occupancy->id,
                     'lead_name'            => $leadName,
+                    'person_name'          => $personName,
+                    'order_number'         => $orderNumber,
+                    'order_id'             => $orderId,
                     'outside_availability' => $outsideAvailability,
                 ];
             }

--- a/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+++ b/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
@@ -424,6 +424,11 @@ class ResourcePlanningMonitorController extends Controller
                                $occupancy->orderItem?->order?->salesLead?->name ??
                                'Onbekend';
 
+                    $personName = $occupancy->orderItem?->person?->name;
+                    $order = $occupancy->orderItem?->order;
+                    $orderNumber = $order?->order_number;
+                    $orderId = $order?->id;
+
                     $outsideAvailability = empty($availabilityWindows)
                         ? false
                         : ! $this->overlapsWithWindows($blockStart, $blockEnd, $availabilityWindows);
@@ -437,6 +442,9 @@ class ResourcePlanningMonitorController extends Controller
                         'clickable'            => false,
                         'booking_id'           => $occupancy->id,
                         'lead_name'            => $leadName,
+                        'person_name'          => $personName,
+                        'order_number'         => $orderNumber,
+                        'order_id'             => $orderId,
                         'outside_availability' => $outsideAvailability,
                     ];
                 }

--- a/app/Observers/OrderObserver.php
+++ b/app/Observers/OrderObserver.php
@@ -8,6 +8,7 @@ use App\Models\Order;
 use App\Models\OrderItem;
 use App\Services\OrderNumberGenerator;
 use App\Services\OrderStatusService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 
@@ -48,6 +49,14 @@ class OrderObserver
             Log::info('Updating order items to WON for order '.$order->id);
             OrderItem::forOrderAndNotLost($order->id)
                 ->update(['status' => OrderItemStatus::WON->value]);
+        }
+
+        if ($stageChange && in_array($order->pipeline_stage_id, PipelineStage::getLostOrderStageIds(), true)) {
+            Log::info('Updating order items to LOST for order '.$order->id);
+            $orderItemIds = OrderItem::where('order_id', $order->id)->pluck('id');
+            OrderItem::where('order_id', $order->id)
+                ->update(['status' => OrderItemStatus::LOST->value]);
+            DB::table('resource_orderitem')->whereIn('orderitem_id', $orderItemIds)->delete();
         }
     }
 }

--- a/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
@@ -1,5 +1,4 @@
 @php
-    use App\Enums\EmailTemplateCode;
     use App\Enums\EmailTemplateType;
 @endphp
 <x-admin::layouts>
@@ -1048,11 +1047,7 @@
 
                             this.emailSubject = payload.subject || '';
 
-                            const defaultTpl = @json(EmailTemplateCode::ACKNOWLEDGE_ORDER_MAIL->value);
-                            if (this.emailTemplates.some(t => (t.code || t.name) === defaultTpl)) {
-                                this.emailSelectedTemplate = defaultTpl;
-                                this.$nextTick(() => this.loadEmailTemplate());
-                            } else if (payload.body) {
+                            if (payload.body) {
                                 this.emailBody = payload.body;
                                 this.$nextTick(() => this.setTinyMCEContent('wizard-email-editor', payload.body));
                             }

--- a/resources/views/adminc/planning/components/planning-calendar.blade.php
+++ b/resources/views/adminc/planning/components/planning-calendar.blade.php
@@ -99,9 +99,27 @@
                              :style="blockStyle(block)"
                              :title="getBlockTooltip(block)"
                              @click.stop="block.clickable ? handleBlockClick(block) : null">
-                            <div v-if="block.type === 'occupied'" class="font-semibold text-xs">@{{ block.lead_name || 'Onbekend' }}</div>
-                            <div v-else-if="block.type === 'available'" class="text-xs font-medium">Beschikbaar</div>
-                            <div class="text-xs" :class="block.type === 'occupied' ? 'opacity-75' : ''">@{{ timeRange(block.from, block.to) }}</div>
+                            <template v-if="block.type === 'occupied'">
+                                <div class="flex items-start justify-between gap-1">
+                                    <div class="font-semibold text-xs truncate">@{{ block.person_name || block.lead_name || 'Onbekend' }}</div>
+                                    <a v-if="block.order_id"
+                                       :href="`${'{{ route('admin.orders.view', ['id' => 'REPLACE']) }}'.replace('REPLACE', block.order_id)}`"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="text-white opacity-75 hover:opacity-100 flex-shrink-0"
+                                       :title="`Order ${block.order_number || block.order_id}`"
+                                       @click.stop>
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                        </svg>
+                                    </a>
+                                </div>
+                                <div class="text-xs opacity-75">@{{ timeRange(block.from, block.to) }}</div>
+                            </template>
+                            <template v-else-if="block.type === 'available'">
+                                <div class="text-xs font-medium">Beschikbaar</div>
+                                <div class="text-xs">@{{ timeRange(block.from, block.to) }}</div>
+                            </template>
                         </div>
                     </div>
                 </div>
@@ -133,8 +151,25 @@
                          :class="['month-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied']"
                          :title="getBlockTooltip(block)"
                          @click="block.clickable ? handleBlockClick(block) : null">
-                        <div v-if="block.type === 'occupied'" class="font-semibold">@{{ block.lead_name || 'Onbekend' }}</div>
-                        <div v-else-if="block.type === 'available'" class="font-medium">Beschikbaar</div>
+                        <template v-if="block.type === 'occupied'">
+                            <div class="flex items-start justify-between gap-1">
+                                <div class="font-semibold truncate">@{{ block.person_name || block.lead_name || 'Onbekend' }}</div>
+                                <a v-if="block.order_id"
+                                   :href="`${'{{ route('admin.orders.view', ['id' => 'REPLACE']) }}'.replace('REPLACE', block.order_id)}`"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   class="opacity-75 hover:opacity-100 flex-shrink-0"
+                                   :title="`Order ${block.order_number || block.order_id}`"
+                                   @click.stop>
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                    </svg>
+                                </a>
+                            </div>
+                        </template>
+                        <template v-else-if="block.type === 'available'">
+                            <div class="font-medium">Beschikbaar</div>
+                        </template>
                         <div class="text-xs">@{{ timeRange(block.from, block.to) }}</div>
                     </div>
                 </div>
@@ -487,8 +522,12 @@
                     const timeStr = `${from.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} tot ${to.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 
                     if (block.type === 'occupied') {
-                        const leadName = block.lead_name || 'Onbekend';
-                        return `${name}${notes}\nGeboekt: ${leadName}\nTijd: ${timeStr}`;
+                        const displayName = block.person_name || block.lead_name || 'Onbekend';
+                        let tooltip = `${name}${notes}\nPersoon: ${displayName}\nTijd: ${timeStr}`;
+                        if (block.order_number) {
+                            tooltip += `\nOrder: ${block.order_number}`;
+                        }
+                        return tooltip;
                     }
 
                     return `${name}${notes} - ${timeStr}`;

--- a/tests/Feature/Orders/OrderObserverTest.php
+++ b/tests/Feature/Orders/OrderObserverTest.php
@@ -88,6 +88,71 @@ test('order items from other orders are not affected when one order moves to won
         ->and($itemB->fresh()->status)->toBe(OrderItemStatus::NEW);
 });
 
+test('updating to verloren stage marks all order items as lost', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id(),
+    ]);
+
+    $newItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::NEW->value]);
+    $plannedItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+    $wonItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::WON->value]);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $order->save();
+
+    expect($newItem->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($plannedItem->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($wonItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('updating to verloren stage removes resource_orderitem planning slots', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id(),
+    ]);
+
+    $item = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+    \Illuminate\Support\Facades\DB::table('resource_orderitem')->insert([
+        'orderitem_id' => $item->id,
+        'resource_id'  => 1,
+        'from'         => now()->toDateTimeString(),
+        'to'           => now()->addHour()->toDateTimeString(),
+    ]);
+
+    expect(\Illuminate\Support\Facades\DB::table('resource_orderitem')->where('orderitem_id', $item->id)->count())->toBe(1);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $order->save();
+
+    expect(\Illuminate\Support\Facades\DB::table('resource_orderitem')->where('orderitem_id', $item->id)->count())->toBe(0);
+});
+
+test('updating to hernia verloren stage marks all order items as lost', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND_HERNIA->id(),
+    ]);
+
+    $plannedItem = OrderItem::factory()->create(['order_id' => $order->id, 'status' => OrderItemStatus::PLANNED->value]);
+
+    $order->pipeline_stage_id = PipelineStage::ORDER_VERLOREN_HERNIA->id();
+    $order->save();
+
+    expect($plannedItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('items from other orders are not affected when one order moves to verloren', function () {
+    $orderA = Order::factory()->create(['pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id()]);
+    $orderB = Order::factory()->create(['pipeline_stage_id' => PipelineStage::ORDER_INGEPLAND->id()]);
+
+    $itemA = OrderItem::factory()->create(['order_id' => $orderA->id, 'status' => OrderItemStatus::PLANNED->value]);
+    $itemB = OrderItem::factory()->create(['order_id' => $orderB->id, 'status' => OrderItemStatus::PLANNED->value]);
+
+    $orderA->pipeline_stage_id = PipelineStage::ORDER_VERLOREN->id();
+    $orderA->save();
+
+    expect($itemA->fresh()->status)->toBe(OrderItemStatus::LOST)
+        ->and($itemB->fresh()->status)->toBe(OrderItemStatus::PLANNED);
+});
+
 test('created dispatches order.update_stage.after event', function () {
     Event::fake(['order.update_stage.after']);
 


### PR DESCRIPTION
## Summary

- Sets order items to LOST status and clears resource planning when an order moves to verloren stage (via `OrderObserver`)
- Shows person name instead of order title in planning calendar blocks (MBS-164)
- Fixes default to no template in appointment confirmation email step

## Test plan

- [ ] Move an order to verloren stage and verify order items are set to LOST
- [ ] Verify resource planning is cleared for order items when order moves to verloren
- [ ] Check planning calendar shows person name on calendar blocks
- [ ] Run `sail artisan test --filter=OrderObserverTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)