### PR TITLE
feat: show person name in planning calendar blocks [MBS-164]

### DIFF
--- a/app/Enums/PipelineStage.php
+++ b/app/Enums/PipelineStage.php
@@ -581,6 +581,11 @@ enum PipelineStage: string
         );
     }
 
+    public static function getLostOrderStageIds(): array
+    {
+        return [self::ORDER_VERLOREN->id(), self::ORDER_VERLOREN_HERNIA->id()];
+    }
+
     // Used for operational grids:
 
     public static function getFrontOfficeStageIds(): array

--- a/app/Http/Controllers/Admin/Planning/Concerns/ResourceAvailabilityTrait.php
+++ b/app/Http/Controllers/Admin/Planning/Concerns/ResourceAvailabilityTrait.php
@@ -91,7 +91,7 @@ trait ResourceAvailabilityTrait
     protected function getOccupancy($resources, CarbonImmutable $start, CarbonImmutable $end): Collection
     {
         return ResourceOrderItem::query()
-            ->with(['orderItem.order.salesLead.lead'])
+            ->with(['orderItem.order.salesLead.lead', 'orderItem.person'])
             ->whereIn('resource_id', $resources->pluck('id'))
             ->where(function ($q) use ($start, $end) {
                 $q->whereBetween('from', [$start, $end])

--- a/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
+++ b/app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
@@ -297,6 +297,11 @@ class OrderItemPlanningController extends Controller
                 $productName = $occupancy->orderItem?->product?->name;
                 $leadName .= ' - '.$productName;
 
+                $personName = $occupancy->orderItem?->person?->name;
+                $order = $occupancy->orderItem?->order;
+                $orderNumber = $order?->order_number;
+                $orderId = $order?->id;
+
                 $outsideAvailability = empty($availabilityWindows)
                     ? false
                     : ! $this->overlapsWithWindows($blockStart, $blockEnd, $availabilityWindows);
@@ -310,6 +315,9 @@ class OrderItemPlanningController extends Controller
                     'clickable'            => false,
                     'booking_id'           => $occupancy->id,
                     'lead_name'            => $leadName,
+                    'person_name'          => $personName,
+                    'order_number'         => $orderNumber,
+                    'order_id'             => $orderId,
                     'outside_availability' => $outsideAvailability,
                 ];
             }

--- a/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+++ b/app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
@@ -424,6 +424,11 @@ class ResourcePlanningMonitorController extends Controller
                                $occupancy->orderItem?->order?->salesLead?->name ??
                                'Onbekend';
 
+                    $personName = $occupancy->orderItem?->person?->name;
+                    $order = $occupancy->orderItem?->order;
+                    $orderNumber = $order?->order_number;
+                    $orderId = $order?->id;
+
                     $outsideAvailability = empty($availabilityWindows)
                         ? false
                         : ! $this->overlapsWithWindows($blockStart, $blockEnd, $availabilityWindows);
@@ -437,6 +442,9 @@ class ResourcePlanningMonitorController extends Controller
                         'clickable'            => false,
                         'booking_id'           => $occupancy->id,
                         'lead_name'            => $leadName,
+                        'person_name'          => $personName,
+                        'order_number'         => $orderNumber,
+                        'order_id'             => $orderId,
                         'outside_availability' => $outsideAvailability,
                     ];
                 }

--- a/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
@@ -1,5 +1,4 @@
 @php
-    use App\Enums\EmailTemplateCode;
     use App\Enums\EmailTemplateType;
 @endphp
 <x-admin::layouts>
@@ -1048,11 +1047,7 @@
 
                             this.emailSubject = payload.subject || '';
 
-                            const defaultTpl = @json(EmailTemplateCode::ACKNOWLEDGE_ORDER_MAIL->value);
-                            if (this.emailTemplates.some(t => (t.code || t.name) === defaultTpl)) {
-                                this.emailSelectedTemplate = defaultTpl;
-                                this.$nextTick(() => this.loadEmailTemplate());
-                            } else if (payload.body) {
+                            if (payload.body) {
                                 this.emailBody = payload.body;
                                 this.$nextTick(() => this.setTinyMCEContent('wizard-email-editor', payload.body));
                             }

--- a/resources/views/adminc/planning/components/planning-calendar.blade.php
+++ b/resources/views/adminc/planning/components/planning-calendar.blade.php
@@ -99,9 +99,27 @@
                              :style="blockStyle(block)"
                              :title="getBlockTooltip(block)"
                              @click.stop="block.clickable ? handleBlockClick(block) : null">
-                            <div v-if="block.type === 'occupied'" class="font-semibold text-xs">@{{ block.lead_name || 'Onbekend' }}</div>
-                            <div v-else-if="block.type === 'available'" class="text-xs font-medium">Beschikbaar</div>
-                            <div class="text-xs" :class="block.type === 'occupied' ? 'opacity-75' : ''">@{{ timeRange(block.from, block.to) }}</div>
+                            <template v-if="block.type === 'occupied'">
+                                <div class="flex items-start justify-between gap-1">
+                                    <div class="font-semibold text-xs truncate">@{{ block.person_name || block.lead_name || 'Onbekend' }}</div>
+                                    <a v-if="block.order_id"
+                                       :href="`${'{{ route('admin.orders.view', ['id' => 'REPLACE']) }}'.replace('REPLACE', block.order_id)}`"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="text-white opacity-75 hover:opacity-100 flex-shrink-0"
+                                       :title="`Order ${block.order_number || block.order_id}`"
+                                       @click.stop>
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                        </svg>
+                                    </a>
+                                </div>
+                                <div class="text-xs opacity-75">@{{ timeRange(block.from, block.to) }}</div>
+                            </template>
+                            <template v-else-if="block.type === 'available'">
+                                <div class="text-xs font-medium">Beschikbaar</div>
+                                <div class="text-xs">@{{ timeRange(block.from, block.to) }}</div>
+                            </template>
                         </div>
                     </div>
                 </div>
@@ -133,8 +151,25 @@
                          :class="['month-block', block.clickable ? 'calendar-block-available' : 'calendar-block-occupied']"
                          :title="getBlockTooltip(block)"
                          @click="block.clickable ? handleBlockClick(block) : null">
-                        <div v-if="block.type === 'occupied'" class="font-semibold">@{{ block.lead_name || 'Onbekend' }}</div>
-                        <div v-else-if="block.type === 'available'" class="font-medium">Beschikbaar</div>
+                        <template v-if="block.type === 'occupied'">
+                            <div class="flex items-start justify-between gap-1">
+                                <div class="font-semibold truncate">@{{ block.person_name || block.lead_name || 'Onbekend' }}</div>
+                                <a v-if="block.order_id"
+                                   :href="`${'{{ route('admin.orders.view', ['id' => 'REPLACE']) }}'.replace('REPLACE', block.order_id)}`"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   class="opacity-75 hover:opacity-100 flex-shrink-0"
+                                   :title="`Order ${block.order_number || block.order_id}`"
+                                   @click.stop>
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                    </svg>
+                                </a>
+                            </div>
+                        </template>
+                        <template v-else-if="block.type === 'available'">
+                            <div class="font-medium">Beschikbaar</div>
+                        </template>
                         <div class="text-xs">@{{ timeRange(block.from, block.to) }}</div>
                     </div>
                 </div>
@@ -487,8 +522,12 @@
                     const timeStr = `${from.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} tot ${to.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 
                     if (block.type === 'occupied') {
-                        const leadName = block.lead_name || 'Onbekend';
-                        return `${name}${notes}\nGeboekt: ${leadName}\nTijd: ${timeStr}`;
+                        const displayName = block.person_name || block.lead_name || 'Onbekend';
+                        let tooltip = `${name}${notes}\nPersoon: ${displayName}\nTijd: ${timeStr}`;
+                        if (block.order_number) {
+                            tooltip += `\nOrder: ${block.order_number}`;
+                        }
+                        return tooltip;
                     }
 
                     return `${name}${notes} - ${timeStr}`;


### PR DESCRIPTION
## Summary

- Shows person name instead of order title in planning calendar blocks for better identification
- Restores `getLostOrderStageIds` helper that was accidentally removed by linter
- Fixes default to no template in appointment confirmation email step

## Test plan

- [ ] Check planning calendar blocks show person name instead of order title
- [ ] Verify appointment confirmation email step has correct default template behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)