### PR TITLE
feat: add onderzoeksdatum column to payment overview [MBS-145]

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -1246,7 +1246,7 @@ class OrderController extends SimpleEntityController
         $orders = Order::query()
             ->with('payments')
             ->whereIn('pipeline_stage_id', $stageIds)
-            ->orderBy('order_number')
+            ->orderByRaw('first_examination_at IS NULL, first_examination_at ASC')
             ->get()
             ->filter(fn (Order $o) => $o->netPaidAmount() < round((float) ($o->total_price ?? 0), 2))
             ->values();

--- a/resources/views/adminc/orders/payment-overview.blade.php
+++ b/resources/views/adminc/orders/payment-overview.blade.php
@@ -97,6 +97,9 @@
                             <th class="px-3 py-3 text-right text-xs font-semibold text-amber-600 dark:text-amber-500 uppercase tracking-wider">
                                 Nog open
                             </th>
+                            <th class="px-3 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+                                Onderzoeksdatum
+                            </th>
 
                             {{-- Editable columns (visually separated by dashed border) --}}
                             <th class="px-3 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border-l-2 border-dashed border-gray-300 dark:border-gray-600">
@@ -155,6 +158,11 @@
                                 {{-- Nog open --}}
                                 <td class="px-3 py-2 text-right font-semibold text-amber-600 dark:text-amber-500 whitespace-nowrap tabular-nums">
                                     {{ Currency::formatMoney($defaultCurrencyCode, $openAmount) }}
+                                </td>
+
+                                {{-- Onderzoeksdatum --}}
+                                <td class="px-3 py-2 whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                    {{ $order->first_examination_at?->format('d-m-Y') ?? '—' }}
                                 </td>
 
                                 {{-- === Editable: Bedrag === --}}


### PR DESCRIPTION
## Summary

- Adds onderzoeksdatum (investigation date) column to the payment overview
- Sorts payment overview oldest first for better review order

## Test plan

- [ ] Navigate to payment overview and verify onderzoeksdatum column is visible
- [ ] Verify sorting is oldest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)