### PR TITLE
feat: update name combination display in CRM [MBS-88]

### DIFF
--- a/packages/Webkul/Contact/src/Models/Person.php
+++ b/packages/Webkul/Contact/src/Models/Person.php
@@ -26,13 +26,14 @@ use Webkul\Activity\Traits\LogsActivity;
 use Webkul\Attribute\Traits\CustomAttribute;
 use Webkul\Contact\Contracts\Person as PersonContract;
 use Webkul\Contact\Database\Factories\PersonFactory;
+use Webkul\Contact\Traits\HasPersonName;
 use Webkul\Lead\Models\Lead;
 use Webkul\Tag\Models\TagProxy;
 use Webkul\User\Models\UserProxy;
 
 class Person extends Model implements PersonContract
 {
-    use CustomAttribute, HasDefaultContactInfo, HasFactory, LogsActivity, SoftDeletes;
+    use CustomAttribute, HasDefaultContactInfo, HasFactory, HasPersonName, LogsActivity, SoftDeletes;
 
     /**
      * Database columns required to compute the name accessor (getNameAttribute).
@@ -414,40 +415,6 @@ class Person extends Model implements PersonContract
         return implode(' ', array_filter($parts));
     }
 
-    /**
-     * Get the full name attribute.
-     */
-    public function getFullLastNameParts(): array
-    {
-        $parts = [];
-        if ($this->lastname_prefix) {
-            $parts[] = trim($this->lastname_prefix);
-        }
-        $rawLastName = $this->attributes['last_name'] ?? null;
-        if ($rawLastName) {
-            $parts[] = trim($rawLastName);
-        }
-        if (! empty($this->married_name)) {
-            $marriedNameParts = [];
-            if ($this->married_name_prefix) {
-                $marriedNameParts[] = trim($this->married_name_prefix);
-            }
-            if ($this->married_name) {
-                $marriedNameParts[] = trim($this->married_name);
-            }
-            $parts[] = '/ '.implode(' ', array_filter($marriedNameParts));
-        }
-
-        return $parts;
-    }
-
-    /**
-     * Get the full name attribute.
-     */
-    public function getFullLastNameAttribute(): string
-    {
-        return implode(' ', array_filter($this->getFullLastNameParts()));
-    }
 
     /**
      * Calculate and return the age of the person based on date_of_birth

--- a/packages/Webkul/Contact/src/Traits/HasPersonName.php
+++ b/packages/Webkul/Contact/src/Traits/HasPersonName.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Webkul\Contact\Traits;
+
+trait HasPersonName
+{
+    /**
+     * Build the full last name parts based on the Dutch naming convention.
+     *
+     * When a married name is present, the married name comes first (prefix after surname),
+     * followed by the birth name (prefix after surname), separated by a dash:
+     *   {married_name} {married_name_prefix} - {last_name} {lastname_prefix}
+     *
+     * Without a married name, the traditional format is used:
+     *   {lastname_prefix} {last_name}
+     */
+    public function getFullLastNameParts(): array
+    {
+        $parts = [];
+        $rawLastName = $this->attributes['last_name'] ?? null;
+
+        if (! empty($this->married_name)) {
+            $marriedParts = [trim($this->married_name)];
+            if ($this->married_name_prefix) {
+                $marriedParts[] = trim($this->married_name_prefix);
+            }
+            $marriedStr = implode(' ', array_filter($marriedParts));
+
+            $birthParts = [];
+            if ($rawLastName) {
+                $birthParts[] = trim($rawLastName);
+            }
+            if ($this->lastname_prefix) {
+                $birthParts[] = trim($this->lastname_prefix);
+            }
+            $birthStr = implode(' ', array_filter($birthParts));
+
+            if ($marriedStr && $birthStr) {
+                $parts[] = $marriedStr.' - '.$birthStr;
+            } elseif ($marriedStr) {
+                $parts[] = $marriedStr;
+            } elseif ($birthStr) {
+                $parts[] = $birthStr;
+            }
+        } else {
+            if ($this->lastname_prefix) {
+                $parts[] = trim($this->lastname_prefix);
+            }
+            if ($rawLastName) {
+                $parts[] = trim($rawLastName);
+            }
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Get the full last name (without first name).
+     */
+    public function getFullLastNameAttribute(): string
+    {
+        return implode(' ', array_filter($this->getFullLastNameParts()));
+    }
+}

--- a/packages/Webkul/Lead/src/Models/Lead.php
+++ b/packages/Webkul/Lead/src/Models/Lead.php
@@ -25,6 +25,7 @@ use Throwable;
 use Webkul\Activity\Models\ActivityProxy;
 use Webkul\Activity\Traits\LogsActivity;
 use Webkul\Contact\Models\Organization;
+use Webkul\Contact\Traits\HasPersonName;
 use Webkul\Contact\Models\Person;
 use Webkul\Email\Models\EmailProxy;
 use Webkul\Lead\Contracts\Lead as LeadContract;
@@ -37,7 +38,7 @@ use App\Services\LeadStatusTransitionValidator;
 
 class Lead extends Model implements LeadContract
 {
-    use HasDefaultContactInfo, HasFactory, LogsActivity, SoftDeletes;
+    use HasDefaultContactInfo, HasFactory, HasPersonName, LogsActivity, SoftDeletes;
 
     protected $casts = [
         'closed_at'           => 'datetime',
@@ -572,23 +573,7 @@ class Lead extends Model implements LeadContract
             $parts[] = trim($this->first_name);
         }
 
-        if ($this->lastname_prefix) {
-            $parts[] = trim($this->lastname_prefix);
-        }
-
-        if ($this->last_name) {
-            $parts[] = trim($this->last_name);
-        }
-        if(!empty($this->married_name)) {
-            $marriedNameParts = [];
-            if ($this->married_name_prefix) {
-                $marriedNameParts[] = trim($this->married_name_prefix);
-            }
-            if ($this->married_name) {
-                $marriedNameParts[] = trim($this->married_name);
-            }
-            $parts[] = '/ '.implode(' ', array_filter($marriedNameParts));
-        }
+        $parts = array_merge($parts, $this->getFullLastNameParts());
 
         return implode(' ', array_filter($parts));
     }

--- a/tests/Feature/Persons/PersonNameTest.php
+++ b/tests/Feature/Persons/PersonNameTest.php
@@ -33,7 +33,7 @@ test('person name: with lastname prefix', function () {
     expect($person->name)->toBe('Jan van Jansen');
 });
 
-test('person name: with married name', function () {
+test('person name: with married name (no birth prefix, no married prefix)', function () {
     $person = Person::factory()->create([
         'first_name'   => 'Jan',
         'last_name'    => 'Jansen',
@@ -41,20 +41,20 @@ test('person name: with married name', function () {
         'is_active'    => true,
     ]);
 
-    expect($person->name)->toBe('Jan Jansen / Vries');
+    expect($person->name)->toBe('Jan Vries - Jansen');
 });
 
 test('person name: with all name parts', function () {
     $person = Person::factory()->create([
-        'first_name'          => 'Jan',
+        'first_name'          => 'Bart',
         'lastname_prefix'     => 'van',
         'last_name'           => 'Jansen',
-        'married_name_prefix' => 'van de',
-        'married_name'        => 'Vries',
+        'married_name_prefix' => 'opt',
+        'married_name'        => 'Nijhuis',
         'is_active'           => true,
     ]);
 
-    expect($person->name)->toBe('Jan van Jansen / van de Vries');
+    expect($person->name)->toBe('Bart Nijhuis opt - Jansen van');
 });
 
 test('person name: inactive person appends inactief label', function () {
@@ -65,4 +65,29 @@ test('person name: inactive person appends inactief label', function () {
     ]);
 
     expect($person->name)->toBe('Jan Jansen [Inactief]');
+});
+
+test('person name: married name only (no birth last name)', function () {
+    $person = Person::factory()->create([
+        'first_name'          => 'Jan',
+        'last_name'           => null,
+        'married_name'        => 'Vries',
+        'married_name_prefix' => 'van de',
+        'is_active'           => true,
+    ]);
+
+    expect($person->name)->toBe('Jan Vries van de');
+});
+
+test('person full_last_name: married name with all parts', function () {
+    $person = Person::factory()->create([
+        'first_name'          => 'Bart',
+        'lastname_prefix'     => 'van',
+        'last_name'           => 'Jansen',
+        'married_name_prefix' => 'opt',
+        'married_name'        => 'Nijhuis',
+        'is_active'           => true,
+    ]);
+
+    expect($person->full_last_name)->toBe('Nijhuis opt - Jansen van');
 });


### PR DESCRIPTION
## Summary

- Displays married name before birth name with prefix after surname for correct Dutch name formatting

## Test plan

- [ ] Create/view a contact with married name and verify the name combination is displayed correctly
- [ ] Check surname prefix (tussenvoegsel) appears in correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)