### PR TITLE
feat: block order item status Gewonnen until Uitgevoerd stage [MBS-128]

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderItemController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderItemController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin\Settings;
 use App\DataGrids\Settings\OrderItemDataGrid;
 use App\Enums\Currency;
 use App\Enums\OrderItemStatus;
+use App\Enums\PipelineStage;
 use App\Enums\PurchasePriceType;
 use App\Models\OrderItem;
 use App\Models\PurchasePrice;
@@ -14,6 +15,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Webkul\Contact\Repositories\PersonRepository;
 use Webkul\Product\Models\Product;
 
@@ -118,6 +121,18 @@ class OrderItemController extends SimpleEntityController
     protected function validateUpdate(Request $request, int $id): void
     {
         $this->validateStore($request);
+
+        if ($request->input('status') === OrderItemStatus::WON->value) {
+            $item = OrderItem::with('order')->findOrFail($id);
+            $allowedStageIds = PipelineStage::getStageIdsAtOrAfterExecution();
+
+            if (! in_array($item->order->pipeline_stage_id, $allowedStageIds, true)) {
+                $validator = Validator::make([], []);
+                $validator->errors()->add('status', 'Een orderregel kan alleen op "Gewonnen" worden gezet nadat het onderzoek is uitgevoerd.');
+
+                throw new ValidationException($validator);
+            }
+        }
     }
 
     protected function saveOrderItemPurchasePrice(OrderItem $entity, Request $request): void

--- a/tests/Feature/Orders/OrderItemCrudTest.php
+++ b/tests/Feature/Orders/OrderItemCrudTest.php
@@ -2,16 +2,24 @@
 
 namespace Tests\Feature\Settings;
 
+use App\Enums\OrderItemStatus;
+use App\Enums\PipelineStage;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\ResourceType;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Webkul\Contact\Models\Person;
 use Webkul\Installer\Http\Middleware\CanInstall;
 use Webkul\Product\Models\Product;
 
+uses(RefreshDatabase::class);
+
 beforeEach(function () {
     config(['api.keys' => ['valid-api-key-123', 'another-valid-key']]);
     test()->withoutMiddleware(CanInstall::class);
+
+    $this->seed(TestSeeder::class);
 
     $user = makeUser();
     $this->actingAs($user, 'user');
@@ -113,4 +121,67 @@ test('can delete order_item', function () {
     $this->assertDatabaseMissing('order_items', [
         'id' => $item->id,
     ]);
+});
+
+test('cannot set order_item status to gewonnen when order stage is before uitgevoerd', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_WACHTEN_UITVOERING->id(),
+    ]);
+    $item = OrderItem::factory()->create(['order_id' => $order->id]);
+
+    $payload = [
+        'order_id'   => $order->id,
+        'product_id' => $item->product_id,
+        'person_id'  => test()->person->id,
+        'quantity'   => 1,
+        'status'     => OrderItemStatus::WON->value,
+        '_method'    => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.order_items.update', ['id' => $item->id]), $payload);
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['status']);
+});
+
+test('can set order_item status to gewonnen when order stage is uitgevoerd', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_UITGEVOERD->id(),
+    ]);
+    $item = OrderItem::factory()->create(['order_id' => $order->id]);
+
+    $payload = [
+        'order_id'   => $order->id,
+        'product_id' => $item->product_id,
+        'person_id'  => test()->person->id,
+        'quantity'   => 1,
+        'status'     => OrderItemStatus::WON->value,
+        '_method'    => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.order_items.update', ['id' => $item->id]), $payload);
+    $response->assertOk();
+
+    $this->assertDatabaseHas('order_items', [
+        'id'     => $item->id,
+        'status' => OrderItemStatus::WON->value,
+    ]);
+});
+
+test('can set order_item status to gewonnen when hernia order stage is uitgevoerd', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_UITGEVOERD_HERNIA->id(),
+    ]);
+    $item = OrderItem::factory()->create(['order_id' => $order->id]);
+
+    $payload = [
+        'order_id'   => $order->id,
+        'product_id' => $item->product_id,
+        'person_id'  => test()->person->id,
+        'quantity'   => 1,
+        'status'     => OrderItemStatus::WON->value,
+        '_method'    => 'put',
+    ];
+
+    $response = $this->postJson(route('admin.order_items.update', ['id' => $item->id]), $payload);
+    $response->assertOk();
 });


### PR DESCRIPTION
## Summary

- Blocks order items from being set to status Gewonnen unless the order stage is at or after Uitgevoerd
- Prevents premature marking of orders as won before investigation is completed

## Test plan

- [ ] Try to set an order item to Gewonnen when order is not yet at Uitgevoerd stage — should be blocked
- [ ] Set order to Uitgevoerd stage and verify Gewonnen status can now be set

🤖 Generated with [Claude Code](https://claude.com/claude-code)