### PR TITLE
feat: AFB handmatig verzenden – nieuw scherm met email samensteller

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -15,7 +15,11 @@ use App\Enums\PipelineType;
 use App\Events\OrderMarkedAsSent;
 use App\Events\PatientNotifyEvent;
 use App\Http\Requests\Admin\OrderPaymentRequest;
+use App\Enums\AfbDispatchStatus;
+use App\Enums\AfbDispatchType;
+use App\Models\AfbDispatch;
 use App\Models\AfbPersonDocument;
+use App\Models\ClinicDepartment;
 use App\Models\Order;
 use App\Models\OrderCheck;
 use App\Models\OrderPayment;
@@ -24,6 +28,7 @@ use App\Models\SalesLead;
 use App\Repositories\OrderRepository;
 use App\Repositories\SalesLeadRepository;
 use App\Services\Afb\AfbDispatchService;
+use App\Services\Afb\AfbDocumentGenerator;
 use App\Services\FormService;
 use App\Services\Mail\CrmMailService;
 use App\Services\OrderCheckService;
@@ -46,6 +51,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\ValidationException;
@@ -80,6 +87,7 @@ class OrderController extends SimpleEntityController
         protected PipelineCookieService $pipelineCookieService,
         private readonly CrmMailService $crmMailService,
         private AfbDispatchService $afbDispatchService,
+        private readonly AfbDocumentGenerator $afbDocumentGenerator,
         private readonly AttachmentRepository $attachmentRepository,
     ) {
         parent::__construct($orderRepository);
@@ -674,6 +682,378 @@ class OrderController extends SimpleEntityController
             Log::error('AFB dispatch mislukt', ['order_id' => $id, 'error' => $e->getMessage()]);
 
             return response()->json(['message' => 'AFB versturen mislukt: '.$e->getMessage()], 500);
+        }
+    }
+
+    public function afbSendPage(int $orderId): View
+    {
+        $order = $this->orderRepository->with([
+            'salesLead.persons',
+            'orderItems.product',
+            'orderItems.person',
+            'orderItems.resourceOrderItems.resource.clinicDepartment.clinic',
+            'afbPersonDocuments.dispatch.clinicDepartment',
+        ])->findOrFail($orderId);
+
+        $latestAfbDocs = $order->latestSuccessfulAfbDocuments()
+            ->keyBy(fn ($doc) => ($doc->person_id ?? '').'_'.$doc->dispatch?->clinic_department_id);
+
+        $afbStatusRows = $order->orderItems
+            ->flatMap(function ($item) {
+                return $item->resourceOrderItems
+                    ->map(fn ($roi) => $roi->resource?->clinicDepartment)
+                    ->filter()
+                    ->map(fn ($dept) => [
+                        'department' => $dept,
+                        'person_id'  => $item->person_id !== null ? (int) $item->person_id : null,
+                    ]);
+            })
+            ->unique(fn ($row) => $row['department']->id.'|'.($row['person_id'] ?? ''))
+            ->sortBy(fn ($row) => $row['department']->name.'|'.($row['person_id'] ?? ''))
+            ->map(function ($row) use ($order, $latestAfbDocs) {
+                $personId = $row['person_id'];
+                $deptId = $row['department']->id;
+                $docKey = ($personId ?? '').'_'.$deptId;
+
+                return [
+                    'department' => $row['department'],
+                    'person'     => $personId !== null
+                        ? $order->orderItems->pluck('person')->filter()->firstWhere('id', $personId)
+                        : null,
+                    'dispatch'   => $latestAfbDocs->get($docKey),
+                ];
+            })
+            ->values();
+
+        return view('admin::orders.afb-send', [
+            'order'         => $order,
+            'afbStatusRows' => $afbStatusRows,
+        ]);
+    }
+
+    public function afbSendPrepare(int $orderId, int $departmentId): JsonResponse
+    {
+        $order = $this->orderRepository->with([
+            'salesLead.persons',
+            'orderItems.product.partnerProducts.clinics',
+            'orderItems.person',
+            'orderItems.resourceOrderItems.resource.clinicDepartment.clinic',
+        ])->findOrFail($orderId);
+
+        $department = ClinicDepartment::with('clinic')->findOrFail($departmentId);
+        $personId = request()->query('person_id') ? (int) request()->query('person_id') : null;
+
+        $recipientEmail = $department->email ?? '';
+        $clinic = $department->clinic;
+
+        $person = $personId
+            ? $order->orderItems->pluck('person')->filter()->firstWhere('id', $personId)
+            : null;
+
+        $subject = sprintf(
+            'AFB Manuell - %s (Order %s)',
+            $clinic->registration_form_clinic_name ?: $clinic->name,
+            $order->order_number ?: $order->id
+        );
+
+        $body = view('adminc.afb.dispatch_email', [
+            'clinic'       => $clinic,
+            'type'         => AfbDispatchType::INDIVIDUAL->value,
+            'orderNumbers' => [$order->order_number ?: (string) $order->id],
+            'sentAt'       => now()->format('d-m-Y H:i'),
+        ])->render();
+
+        $attachmentPreviews = [];
+
+        $afbResult = $this->afbDocumentGenerator->renderHtmlForOrderAndDepartment($order, $department, $person);
+        if ($afbResult['person']) {
+            $attachmentPreviews[] = [
+                'name' => sprintf('AFB - %s.pdf', $afbResult['person']->name ?? 'Patiënt'),
+                'type' => 'afb',
+            ];
+        } else {
+            $attachmentPreviews[] = [
+                'name' => 'AFB - Patiënt.pdf',
+                'type' => 'afb',
+            ];
+        }
+
+        if ($person) {
+            $anamnesis = \App\Models\Anamnesis::where('person_id', $person->id)
+                ->whereNotNull('gvl_form_link')
+                ->latest()
+                ->first();
+
+            if ($anamnesis) {
+                $formId = $this->formService->extractFormIdFromUrl($anamnesis->gvl_form_link);
+                if ($formId) {
+                    try {
+                        $formStatus = $this->formService->getFormStatusAsString($formId);
+                        if ($formStatus === \App\Enums\FormStatus::Completed) {
+                            $attachmentPreviews[] = [
+                                'name' => sprintf('GVL - %s.pdf', $person->name ?? 'Patiënt'),
+                                'type' => 'gvl',
+                            ];
+                        }
+                    } catch (Throwable $e) {
+                        // GVL not available
+                    }
+                }
+            }
+        }
+
+        return response()->json([
+            'subject'         => $subject,
+            'body'            => $body,
+            'recipient_email' => $recipientEmail,
+            'clinic_name'     => $clinic->name,
+            'department_name' => $department->name,
+            'person_name'     => $person?->name,
+            'attachments'     => $attachmentPreviews,
+        ]);
+    }
+
+    public function afbSendManual(Request $request, int $orderId, int $departmentId): JsonResponse
+    {
+        $request->validate([
+            'subject'   => 'required|string|max:500',
+            'reply'     => 'required|string',
+            'reply_to'  => 'required|email',
+            'person_id' => 'nullable|integer',
+        ]);
+
+        $order = Order::with([
+            'salesLead.persons',
+            'orderItems.product.partnerProducts.clinics',
+            'orderItems.person.address',
+            'orderItems.resourceOrderItems.resource.clinicDepartment.clinic',
+        ])->findOrFail($orderId);
+
+        $department = ClinicDepartment::with('clinic')->findOrFail($departmentId);
+        $personId = $request->input('person_id') ? (int) $request->input('person_id') : null;
+        $person = $personId
+            ? $order->orderItems->pluck('person')->filter()->firstWhere('id', $personId)
+            : null;
+
+        try {
+            $dispatch = AfbDispatch::create([
+                'clinic_id'            => $department->clinic_id,
+                'clinic_department_id' => $departmentId,
+                'type'                 => AfbDispatchType::INDIVIDUAL->value,
+                'status'               => AfbDispatchStatus::FAILED->value,
+                'attempt'              => 1,
+                'last_attempt_at'      => now(),
+            ]);
+
+            $generatedDocs = $this->afbDocumentGenerator->generateForOrderAndDepartment($order, $department);
+
+            if ($person) {
+                $generatedDocs = array_values(array_filter($generatedDocs, fn ($doc) => $doc['person_id'] === $personId || $doc['person_id'] === null));
+            }
+
+            $email = $this->crmMailService->createEmail([
+                'subject'   => $request->input('subject'),
+                'reply'     => $request->input('reply'),
+                'reply_to'  => [$request->input('reply_to')],
+                'name'      => 'AFB handmatige verzending',
+                'source'    => 'web',
+                'user_type' => 'user',
+                'clinic_id' => $department->clinic_id,
+            ]);
+
+            foreach ($generatedDocs as $doc) {
+                $this->syncToMailDisk($doc['file_path']);
+
+                $email->attachments()->create([
+                    'name'         => $doc['file_name'],
+                    'path'         => $doc['file_path'],
+                    'size'         => Storage::size($doc['file_path']),
+                    'content_type' => 'application/pdf',
+                ]);
+            }
+
+            $this->attachGvlPdfsForManualSend($email, $generatedDocs);
+
+            if ($request->hasFile('attachments')) {
+                foreach ($request->file('attachments') as $uploadedFile) {
+                    $path = $uploadedFile->store('afb/manual-attachments', 'public');
+                    $email->attachments()->create([
+                        'name'         => $uploadedFile->getClientOriginalName(),
+                        'path'         => $path,
+                        'size'         => $uploadedFile->getSize(),
+                        'content_type' => $uploadedFile->getMimeType(),
+                    ]);
+                }
+            }
+
+            $this->crmMailService->sendEmail($email);
+
+            DB::transaction(function () use ($generatedDocs, $dispatch, $email, $order) {
+                foreach ($generatedDocs as $doc) {
+                    AfbPersonDocument::create([
+                        'afb_dispatch_id' => $dispatch->id,
+                        'order_id'        => $order->id,
+                        'order_item_ids'  => $doc['order_item_ids'],
+                        'person_id'       => $doc['person_id'],
+                        'patient_name'    => $doc['patient_name'],
+                        'file_name'       => $doc['file_name'],
+                        'file_path'       => $doc['file_path'],
+                        'sent_at'         => now(),
+                    ]);
+                }
+
+                $dispatch->update([
+                    'email_id' => $email->id,
+                    'status'   => AfbDispatchStatus::SUCCESS->value,
+                    'sent_at'  => now(),
+                ]);
+            });
+
+            return response()->json([
+                'message' => 'AFB succesvol verzonden naar '.$department->name.'.',
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Handmatige AFB dispatch mislukt', [
+                'order_id'             => $orderId,
+                'clinic_department_id' => $departmentId,
+                'error'                => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'message' => 'AFB versturen mislukt: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function afbSendAttachment(int $orderId, int $departmentId, string $type, ?int $personId = null): Response
+    {
+        $order = Order::with([
+            'salesLead.persons',
+            'orderItems.product.partnerProducts.clinics',
+            'orderItems.person.address',
+            'orderItems.resourceOrderItems.resource.clinicDepartment.clinic',
+        ])->findOrFail($orderId);
+
+        $department = ClinicDepartment::with('clinic')->findOrFail($departmentId);
+
+        if ($type === 'afb') {
+            $person = $personId
+                ? $order->orderItems->pluck('person')->filter()->firstWhere('id', $personId)
+                : null;
+
+            $result = $this->afbDocumentGenerator->renderHtmlForOrderAndDepartment($order, $department, $person);
+
+            $pdf = Pdf::loadHTML($result['html'])
+                ->setPaper('A4', 'portrait');
+
+            return $pdf->download(sprintf('afb_%s_%s.pdf',
+                Str::slug($department->clinic->name),
+                $order->order_number ?: $order->id
+            ));
+        }
+
+        if ($type === 'gvl' && $personId) {
+            $anamnesis = \App\Models\Anamnesis::where('person_id', $personId)
+                ->whereNotNull('gvl_form_link')
+                ->latest()
+                ->first();
+
+            if (! $anamnesis) {
+                abort(404, 'Geen GVL formulier gevonden.');
+            }
+
+            $formId = $this->formService->extractFormIdFromUrl($anamnesis->gvl_form_link);
+
+            if (! $formId) {
+                abort(404, 'Geen geldig GVL formulier ID.');
+            }
+
+            $response = $this->formService->downloadForm($formId);
+
+            if (! $response->successful()) {
+                abort(502, 'GVL PDF ophalen mislukt.');
+            }
+
+            return response($response->body(), 200, [
+                'Content-Type'        => 'application/pdf',
+                'Content-Disposition' => sprintf('attachment; filename="gvl-%d.pdf"', $personId),
+            ]);
+        }
+
+        abort(404);
+    }
+
+    private function syncToMailDisk(string $path): void
+    {
+        if (Storage::exists($path)) {
+            return;
+        }
+
+        $localDisk = Storage::disk('local');
+
+        if (! $localDisk->exists($path)) {
+            throw new \RuntimeException("AFB bestand niet gevonden op enige disk: {$path}");
+        }
+
+        Storage::put($path, $localDisk->get($path));
+    }
+
+    private function attachGvlPdfsForManualSend(\Webkul\Email\Models\Email $email, array $generatedDocuments): void
+    {
+        $personIds = collect($generatedDocuments)
+            ->pluck('person_id')
+            ->filter()
+            ->unique()
+            ->values();
+
+        foreach ($personIds as $personId) {
+            $anamnesis = \App\Models\Anamnesis::query()
+                ->where('person_id', $personId)
+                ->whereNotNull('gvl_form_link')
+                ->latest()
+                ->first();
+
+            if (! $anamnesis) {
+                continue;
+            }
+
+            $formId = $this->formService->extractFormIdFromUrl($anamnesis->gvl_form_link);
+
+            if (! $formId) {
+                continue;
+            }
+
+            try {
+                $formStatus = $this->formService->getFormStatusAsString($formId);
+
+                if ($formStatus !== \App\Enums\FormStatus::Completed) {
+                    continue;
+                }
+
+                $response = $this->formService->downloadForm($formId);
+
+                if (! $response->successful()) {
+                    continue;
+                }
+
+                $fileName = sprintf('gvl-%d-%s.pdf', $personId, now()->format('Ymd'));
+                $filePath = sprintf('afb/gvl/%d/%s', $personId, $fileName);
+
+                Storage::put($filePath, $response->body());
+
+                $email->attachments()->create([
+                    'name'         => $fileName,
+                    'path'         => $filePath,
+                    'size'         => strlen($response->body()),
+                    'content_type' => 'application/pdf',
+                ]);
+            } catch (Throwable $e) {
+                Log::warning('GVL PDF bijlage mislukt bij handmatige AFB', [
+                    'person_id'     => $personId,
+                    'form_id'       => $formId,
+                    'error_message' => $e->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -725,9 +725,22 @@ class OrderController extends SimpleEntityController
             })
             ->values();
 
+        $initialRows = $afbStatusRows->map(fn ($row) => [
+            'department_id'    => $row['department']->id,
+            'department_name'  => $row['department']->name,
+            'clinic_id'        => $row['department']->clinic_id,
+            'clinic_name'      => $row['department']->clinic?->name,
+            'person_id'        => $row['person']?->id,
+            'person_name'      => $row['person']?->name,
+            'dispatch_id'      => $row['dispatch']?->id,
+            'dispatch_sent_at' => $row['dispatch']?->sent_at?->format('d-m-Y H:i'),
+            'dispatch_pdf_url' => $row['dispatch'] ? route('admin.clinic-guide.afb-pdf.view', ['personDocumentId' => $row['dispatch']->id]) : null,
+            'delete_url'       => $row['dispatch'] ? route('admin.orders.afb.delete', ['orderId' => $order->id, 'personDocumentId' => $row['dispatch']->id]) : null,
+        ])->values();
+
         return view('admin::orders.afb-send', [
-            'order'         => $order,
-            'afbStatusRows' => $afbStatusRows,
+            'order'       => $order,
+            'initialRows' => $initialRows,
         ]);
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/orders/afb-send.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/afb-send.blade.php
@@ -33,18 +33,7 @@
         <div class="rounded-lg border bg-white dark:border-gray-800 dark:bg-gray-900">
             <v-afb-send-wizard
                 :order-id="{{ $order->id }}"
-                :initial-rows='@json($afbStatusRows->map(fn ($row) => [
-                    "department_id" => $row["department"]->id,
-                    "department_name" => $row["department"]->name,
-                    "clinic_id" => $row["department"]->clinic_id,
-                    "clinic_name" => $row["department"]->clinic?->name,
-                    "person_id" => $row["person"]?->id,
-                    "person_name" => $row["person"]?->name,
-                    "dispatch_id" => $row["dispatch"]?->id,
-                    "dispatch_sent_at" => $row["dispatch"]?->sent_at?->format("d-m-Y H:i"),
-                    "dispatch_pdf_url" => $row["dispatch"] ? route("admin.clinic-guide.afb-pdf.view", ["personDocumentId" => $row["dispatch"]->id]) : null,
-                    "delete_url" => $row["dispatch"] ? route("admin.orders.afb.delete", ["orderId" => $order->id, "personDocumentId" => $row["dispatch"]->id]) : null,
-                ])->values())'
+                :initial-rows='@json($initialRows)'
                 view-url="{{ route('admin.orders.view', $order->id) }}"
             ></v-afb-send-wizard>
         </div>

--- a/packages/Webkul/Admin/src/Resources/views/orders/afb-send.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/afb-send.blade.php
@@ -1,0 +1,516 @@
+<x-admin::layouts>
+    <x-slot:title>
+        AFB handmatig verzenden
+    </x-slot>
+
+    <div class="flex flex-col gap-4">
+        {{-- TinyMCE scripts + hidden boot editor must live inside #app so <v-tinymce> mounts --}}
+        <div class="pointer-events-none fixed left-[-9999px] top-0 h-px w-px overflow-hidden opacity-0"
+             aria-hidden="true">
+            <textarea id="__afb-send-tinymce-boot" tabindex="-1"></textarea>
+            <x-admin::tinymce selector="textarea#__afb-send-tinymce-boot"/>
+        </div>
+
+        {{-- Header --}}
+        <div
+            class="flex items-center justify-between rounded-lg border bg-white px-4 py-3 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+            <div class="flex flex-col gap-2">
+                <x-admin::breadcrumbs name="orders.afb-send" :entity="$order"/>
+                <div class="flex items-center gap-3">
+                    <div class="text-xl font-bold dark:text-gray-300">AFB handmatig verzenden</div>
+                    <span
+                        class="inline-flex items-center px-3 py-1 text-sm font-medium rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
+                        #{{ $order->order_number ?: $order->name }}
+                    </span>
+                </div>
+            </div>
+            <a href="{{ route('admin.orders.view', $order->id) }}" class="secondary-button">
+                Terug naar order
+            </a>
+        </div>
+
+        {{-- Main content --}}
+        <div class="rounded-lg border bg-white dark:border-gray-800 dark:bg-gray-900">
+            <v-afb-send-wizard
+                :order-id="{{ $order->id }}"
+                :initial-rows='@json($afbStatusRows->map(fn ($row) => [
+                    "department_id" => $row["department"]->id,
+                    "department_name" => $row["department"]->name,
+                    "clinic_id" => $row["department"]->clinic_id,
+                    "clinic_name" => $row["department"]->clinic?->name,
+                    "person_id" => $row["person"]?->id,
+                    "person_name" => $row["person"]?->name,
+                    "dispatch_id" => $row["dispatch"]?->id,
+                    "dispatch_sent_at" => $row["dispatch"]?->sent_at?->format("d-m-Y H:i"),
+                    "dispatch_pdf_url" => $row["dispatch"] ? route("admin.clinic-guide.afb-pdf.view", ["personDocumentId" => $row["dispatch"]->id]) : null,
+                    "delete_url" => $row["dispatch"] ? route("admin.orders.afb.delete", ["orderId" => $order->id, "personDocumentId" => $row["dispatch"]->id]) : null,
+                ])->values())'
+                view-url="{{ route('admin.orders.view', $order->id) }}"
+            ></v-afb-send-wizard>
+        </div>
+    </div>
+
+    @pushOnce('scripts')
+        <script type="text/x-template" id="v-afb-send-wizard-template">
+            <div>
+                {{-- Document overview --}}
+                <div v-if="!composing">
+                    <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-white">AFB documenten overzicht</h3>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                            Overzicht van alle AFB documenten per afdeling. Klik op "Email samenstellen" om handmatig een AFB te verzenden.
+                        </p>
+                    </div>
+
+                    <div class="p-6">
+                        <div v-if="rows.length === 0"
+                             class="text-center py-12 text-gray-500 dark:text-gray-400">
+                            <p class="text-lg font-medium">Geen AFB documenten gevonden</p>
+                            <p class="text-sm mt-1">Er zijn geen kliniekafdelingen gekoppeld aan de order items.</p>
+                        </div>
+
+                        <div v-else class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead class="bg-gray-50 dark:bg-gray-800">
+                                    <tr>
+                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Kliniek / Afdeling
+                                        </th>
+                                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Persoon
+                                        </th>
+                                        <th class="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Status
+                                        </th>
+                                        <th class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Actie
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
+                                    <tr v-for="row in rows" :key="row.department_id + '_' + (row.person_id || '')"
+                                        class="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                                        <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-white">
+                                            <div class="font-medium">@{{ row.clinic_name }}</div>
+                                            <div class="text-xs text-gray-500 dark:text-gray-400">@{{ row.department_name }}</div>
+                                        </td>
+                                        <td class="whitespace-nowrap px-4 py-4 text-sm text-gray-700 dark:text-gray-300">
+                                            @{{ row.person_name || '-' }}
+                                        </td>
+                                        <td class="px-4 py-4 text-center">
+                                            <span v-if="row.dispatch_sent_at"
+                                                  class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                                                ✓ Verzonden @{{ row.dispatch_sent_at }}
+                                            </span>
+                                            <span v-else
+                                                  class="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                                Nog niet verzonden
+                                            </span>
+                                        </td>
+                                        <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                                            <div class="flex items-center justify-end gap-2">
+                                                <a v-if="row.dispatch_pdf_url"
+                                                   :href="row.dispatch_pdf_url"
+                                                   target="_blank" rel="noopener noreferrer"
+                                                   class="text-xs text-indigo-600 hover:underline dark:text-indigo-400">
+                                                    Bekijk formulier
+                                                </a>
+                                                <button v-if="row.dispatch_id"
+                                                        type="button"
+                                                        class="text-xs font-medium text-red-600 hover:underline dark:text-red-400"
+                                                        :disabled="deletingRow === row.dispatch_id"
+                                                        @click="deleteDispatch(row)">
+                                                    @{{ deletingRow === row.dispatch_id ? 'Bezig...' : 'Verwijder' }}
+                                                </button>
+                                                <button type="button"
+                                                        class="primary-button text-xs !px-3 !py-1.5"
+                                                        @click="startCompose(row)">
+                                                    Email samenstellen
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Email composer --}}
+                <div v-if="composing">
+                    {{-- Back header --}}
+                    <div class="flex items-center gap-3 border-b border-gray-200 px-6 py-3 dark:border-gray-800 bg-blue-50 dark:bg-blue-900/20">
+                        <button type="button" @click="exitCompose"
+                                class="text-sm font-medium text-brandColor hover:underline">&larr; Terug naar overzicht
+                        </button>
+                        <span class="text-sm text-gray-500 dark:text-gray-400">|</span>
+                        <span class="text-sm font-medium text-gray-900 dark:text-white">
+                            @{{ composeTarget.clinic_name }} › @{{ composeTarget.department_name }}
+                            <span v-if="composeTarget.person_name"> › @{{ composeTarget.person_name }}</span>
+                        </span>
+                    </div>
+
+                    {{-- Loading state --}}
+                    <div v-if="loadingCompose" class="p-6 text-center text-gray-500 dark:text-gray-400">
+                        <p class="text-lg font-medium">Email voorbereiden...</p>
+                    </div>
+
+                    {{-- Compose form --}}
+                    <div v-else class="p-6">
+                        <div class="space-y-6">
+                            <div class="flex flex-col gap-1">
+                                <h3 class="text-lg font-medium text-gray-900 dark:text-white">Email samenstellen</h3>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                    Stel de AFB email op en verstuur deze naar de kliniek afdeling.
+                                    De AFB documenten en GVL formulieren worden automatisch bijgevoegd.
+                                </p>
+                            </div>
+
+                            <div class="space-y-4">
+                                {{-- To --}}
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Aan
+                                        <span class="text-red-500">*</span></label>
+                                    <input type="email" v-model="emailTo"
+                                           placeholder="E-mailadres afdeling"
+                                           class="w-full rounded border border-gray-200 px-2.5 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300"/>
+                                </div>
+
+                                {{-- Subject --}}
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Onderwerp
+                                        <span class="text-red-500">*</span></label>
+                                    <input type="text" v-model="emailSubject" placeholder="Onderwerp"
+                                           class="w-full rounded border border-gray-200 px-2.5 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300"/>
+                                </div>
+
+                                {{-- Body --}}
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Bericht
+                                        <span class="text-red-500">*</span></label>
+                                    <textarea
+                                        id="afb-email-editor"
+                                        v-model="emailBody"
+                                        class="w-full rounded border border-gray-200 px-2.5 py-2 text-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300"
+                                        rows="12"
+                                    ></textarea>
+                                    <v-tinymce selector="textarea#afb-email-editor"
+                                               :field="emailBodyField"></v-tinymce>
+                                </div>
+
+                                {{-- Auto-generated attachments --}}
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Automatische bijlagen</label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                                        Deze bijlagen worden automatisch gegenereerd en bijgevoegd bij het versturen.
+                                    </p>
+                                    <div v-if="autoAttachments.length" class="space-y-1">
+                                        <div v-for="(att, i) in autoAttachments" :key="i"
+                                             class="flex items-center gap-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 p-2 text-sm text-gray-600 dark:text-gray-400">
+                                            <span class="icon-attachment text-lg text-blue-600"></span>
+                                            <span>@{{ att.name }}</span>
+                                            <span class="ml-auto text-xs text-blue-600 font-medium">Automatisch</span>
+                                        </div>
+                                    </div>
+                                    <div v-else class="text-sm text-gray-400">Geen automatische bijlagen beschikbaar.</div>
+                                </div>
+
+                                {{-- Extra attachments --}}
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Extra bijlagen</label>
+                                    <input
+                                        type="file"
+                                        ref="extraAttachmentInput"
+                                        multiple
+                                        @change="onExtraAttachmentChange"
+                                        class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 dark:file:bg-gray-700 dark:file:text-gray-200"
+                                    />
+                                    <div v-if="extraAttachments.length" class="mt-2 space-y-1">
+                                        <div v-for="(att, i) in extraAttachments" :key="i"
+                                             class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                                            <span class="icon-attachment text-lg"></span>
+                                            <span>@{{ att.name }}</span>
+                                            <button type="button" @click="removeExtraAttachment(i)"
+                                                    class="text-red-500 hover:text-red-700 text-xs ml-auto">
+                                                Verwijderen
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {{-- Navigation --}}
+                    <div v-if="!loadingCompose"
+                         class="flex items-center justify-between border-t border-gray-200 dark:border-gray-800 px-6 py-4">
+                        <button type="button" class="secondary-button" @click="exitCompose">
+                            Annuleren
+                        </button>
+                        <button type="button"
+                                class="primary-button"
+                                :disabled="isSending"
+                                @click="sendEmail">
+                            <span v-if="isSending">Versturen...</span>
+                            <span v-else>Verstuur AFB email</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </script>
+
+        <script type="module">
+            app.component('v-afb-send-wizard', {
+                template: '#v-afb-send-wizard-template',
+
+                props: {
+                    orderId: { type: Number, required: true },
+                    initialRows: { type: Array, default: () => [] },
+                    viewUrl: { type: String, required: true },
+                },
+
+                data() {
+                    return {
+                        rows: JSON.parse(JSON.stringify(this.initialRows || [])),
+                        deletingRow: null,
+
+                        composing: false,
+                        composeTarget: null,
+                        loadingCompose: false,
+
+                        emailTo: '',
+                        emailSubject: '',
+                        emailBody: '',
+                        autoAttachments: [],
+                        extraAttachments: [],
+                        extraAttachmentFiles: [],
+                        isSending: false,
+                    };
+                },
+
+                computed: {
+                    emailBodyField() {
+                        return {
+                            onInput: (content) => {
+                                this.emailBody = content;
+                            },
+                        };
+                    },
+                },
+
+                methods: {
+                    getCsrfToken() {
+                        return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+                            || document.querySelector('input[name="_token"]')?.value
+                            || '';
+                    },
+
+                    emitFlash(type, message) {
+                        try {
+                            const emitter = window.app?.config?.globalProperties?.$emitter || window.app?.$emitter;
+                            if (emitter) emitter.emit('add-flash', { type, message });
+                        } catch (e) {
+                            console[type === 'error' ? 'error' : 'log'](message);
+                        }
+                    },
+
+                    async startCompose(row) {
+                        this.composeTarget = row;
+                        this.composing = true;
+                        this.loadingCompose = true;
+                        this.emailTo = '';
+                        this.emailSubject = '';
+                        this.emailBody = '';
+                        this.autoAttachments = [];
+                        this.extraAttachments = [];
+                        this.extraAttachmentFiles = [];
+
+                        try {
+                            let url = `/admin/orders/${this.orderId}/afb-send/${row.department_id}/prepare`;
+                            if (row.person_id) {
+                                url += `?person_id=${row.person_id}`;
+                            }
+
+                            const response = await fetch(url, {
+                                headers: { 'Accept': 'application/json' },
+                            });
+
+                            if (!response.ok) {
+                                const err = await response.json().catch(() => ({}));
+                                throw new Error(err.message || 'Fout bij voorbereiden email');
+                            }
+
+                            const data = await response.json();
+
+                            this.emailTo = data.recipient_email || '';
+                            this.emailSubject = data.subject || '';
+                            this.emailBody = data.body || '';
+                            this.autoAttachments = data.attachments || [];
+
+                            this.$nextTick(() => {
+                                this.initTinyMCE();
+                            });
+                        } catch (e) {
+                            this.emitFlash('error', e.message || 'Fout bij voorbereiden email');
+                            this.composing = false;
+                            this.composeTarget = null;
+                        } finally {
+                            this.loadingCompose = false;
+                        }
+                    },
+
+                    exitCompose() {
+                        this.composing = false;
+                        this.composeTarget = null;
+
+                        if (window.tinymce) {
+                            try {
+                                const editor = window.tinymce.get('afb-email-editor');
+                                if (editor) editor.remove();
+                            } catch (e) { /* ok */ }
+                        }
+                    },
+
+                    async deleteDispatch(row) {
+                        if (!row.delete_url || this.deletingRow) return;
+
+                        if (!confirm('Weet u zeker dat u deze AFB wilt verwijderen?')) return;
+
+                        this.deletingRow = row.dispatch_id;
+                        try {
+                            const response = await fetch(row.delete_url, {
+                                method: 'DELETE',
+                                headers: {
+                                    'Accept': 'application/json',
+                                    'X-CSRF-TOKEN': this.getCsrfToken(),
+                                    'X-Requested-With': 'XMLHttpRequest',
+                                },
+                            });
+                            const data = await response.json().catch(() => ({}));
+                            if (!response.ok) throw new Error(data.message || 'Verwijderen mislukt');
+
+                            this.emitFlash('success', data.message || 'AFB verwijderd.');
+
+                            row.dispatch_id = null;
+                            row.dispatch_sent_at = null;
+                            row.dispatch_pdf_url = null;
+                            row.delete_url = null;
+                        } catch (e) {
+                            this.emitFlash('error', e.message || 'Verwijderen mislukt');
+                        } finally {
+                            this.deletingRow = null;
+                        }
+                    },
+
+                    onExtraAttachmentChange(event) {
+                        const files = Array.from(event.target.files || []);
+                        files.forEach(f => {
+                            this.extraAttachmentFiles.push(f);
+                            this.extraAttachments.push({ name: f.name });
+                        });
+                        event.target.value = '';
+                    },
+
+                    removeExtraAttachment(index) {
+                        this.extraAttachments.splice(index, 1);
+                        this.extraAttachmentFiles.splice(index, 1);
+                    },
+
+                    async sendEmail() {
+                        window.tinymce?.triggerSave?.();
+
+                        const body = this.getTinyMCEContent('afb-email-editor');
+                        if (!this.emailTo) {
+                            this.emitFlash('error', 'Vul een e-mailadres in');
+                            return;
+                        }
+                        if (!this.emailSubject) {
+                            this.emitFlash('error', 'Vul een onderwerp in');
+                            return;
+                        }
+                        if (!body) {
+                            this.emitFlash('error', 'Vul een bericht in');
+                            return;
+                        }
+
+                        this.isSending = true;
+
+                        const formData = new FormData();
+                        formData.append('subject', this.emailSubject);
+                        formData.append('reply', body);
+                        formData.append('reply_to', this.emailTo);
+
+                        if (this.composeTarget.person_id) {
+                            formData.append('person_id', this.composeTarget.person_id);
+                        }
+
+                        this.extraAttachmentFiles.forEach((file, i) => {
+                            formData.append(`attachments[${i}]`, file);
+                        });
+
+                        try {
+                            const url = `/admin/orders/${this.orderId}/afb-send/${this.composeTarget.department_id}/send`;
+                            const response = await fetch(url, {
+                                method: 'POST',
+                                headers: {
+                                    'Accept': 'application/json',
+                                    'X-CSRF-TOKEN': this.getCsrfToken(),
+                                    'X-Requested-With': 'XMLHttpRequest',
+                                },
+                                body: formData,
+                            });
+
+                            const data = await response.json().catch(() => ({}));
+
+                            if (!response.ok) {
+                                throw new Error(data.message || 'Versturen mislukt');
+                            }
+
+                            this.emitFlash('success', data.message || 'AFB verstuurd');
+
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 500);
+                        } catch (e) {
+                            this.emitFlash('error', e.message || 'Versturen mislukt');
+                        } finally {
+                            this.isSending = false;
+                        }
+                    },
+
+                    initTinyMCE() {
+                        this.setTinyMCEContent('afb-email-editor', this.emailBody, 30);
+                    },
+
+                    setTinyMCEContent(editorId, content, retries = 25) {
+                        if (!content || !content.trim()) return;
+                        if (window.tinymce) {
+                            try {
+                                const editor = window.tinymce.get(editorId);
+                                if (editor && !editor.removed && editor.initialized) {
+                                    editor.setContent(content);
+                                    return;
+                                }
+                            } catch (e) { /* not ready */ }
+                        }
+                        if (retries > 0) {
+                            setTimeout(() => this.setTinyMCEContent(editorId, content, retries - 1), 200);
+                        }
+                    },
+
+                    getTinyMCEContent(editorId) {
+                        if (window.tinymce) {
+                            try {
+                                const editor = window.tinymce.get(editorId);
+                                if (editor && !editor.removed && editor.initialized) {
+                                    return editor.getContent();
+                                }
+                            } catch (e) { /* fallback */ }
+                        }
+                        return this.emailBody || '';
+                    },
+                },
+            });
+        </script>
+    @endPushOnce
+</x-admin::layouts>

--- a/packages/Webkul/Admin/src/Resources/views/orders/view/tab-general.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/view/tab-general.blade.php
@@ -38,7 +38,13 @@
                         </p>
                     @endif
                 </div>
-                <v-order-afb-send-button send-url="{{ $afbSendUrl }}"></v-order-afb-send-button>
+                <div class="flex flex-col gap-2 shrink-0">
+                    <v-order-afb-send-button send-url="{{ $afbSendUrl }}"></v-order-afb-send-button>
+                    <a href="{{ route('admin.orders.afb_send', $order->id) }}"
+                       class="secondary-button text-center text-xs whitespace-nowrap">
+                        Email samenstellen
+                    </a>
+                </div>
             </div>
         </div>
     @endif
@@ -287,8 +293,15 @@
 
     <!-- AFB Status Card -->
     <div class="rounded-lg border bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
-        <div class="mb-3">
+        <div class="mb-3 flex items-center justify-between">
             <h3 class="text-base font-semibold text-gray-900 dark:text-white">AFB status</h3>
+            @if (bouncer()->hasPermission('orders.edit'))
+                <a href="{{ route('admin.orders.afb_send', $order->id) }}"
+                   class="secondary-button flex items-center gap-1 border text-xs hover:border-neutral-text hover:text-neutral-text">
+                    <span class="icon-mail text-sm"></span>
+                    <span>Handmatig verzenden</span>
+                </a>
+            @endif
         </div>
 
         {{-- AFB dispatch status --}}

--- a/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
@@ -34,6 +34,12 @@ Route::controller(OrderController::class)->prefix('orders')->group(function () {
     Route::post('{id}/send-afb', 'sendAfb')->name('admin.orders.send_afb');
     Route::delete('{orderId}/afb/{personDocumentId}', [OrderController::class, 'deleteAfbPersonDocument'])->name('admin.orders.afb.delete');
 
+    // Manual AFB send screen
+    Route::get('{orderId}/afb-send', 'afbSendPage')->name('admin.orders.afb_send');
+    Route::get('{orderId}/afb-send/{departmentId}/prepare', 'afbSendPrepare')->name('admin.orders.afb_send.prepare');
+    Route::post('{orderId}/afb-send/{departmentId}/send', 'afbSendManual')->name('admin.orders.afb_send.send');
+    Route::get('{orderId}/afb-send/{departmentId}/attachment/{type}/{personId?}', 'afbSendAttachment')->name('admin.orders.afb_send.attachment');
+
     // Order confirmation letter routes
     Route::get('confirmation/templates', 'getConfirmationTemplates')->name('admin.orders.confirmation.templates');
     Route::get('{orderId}/confirmation/template-content', 'getConfirmationTemplateContent')->name('admin.orders.confirmation.template-content');

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -218,6 +218,16 @@ Breadcrumbs::for('orders.edit', function (BreadcrumbTrail $trail, $order) {
     $trail->push('Order bewerken', route('admin.orders.edit', $order->id));
 });
 
+// Orders > AFB Send
+Breadcrumbs::for('orders.afb-send', function (BreadcrumbTrail $trail, $order) {
+    $trail->parent('orders');
+    if ($order->salesLead) {
+        $trail->push($order->salesLead->name, route('admin.sales-leads.view', $order->salesLead->id));
+    }
+    $trail->push('Order bewerken', route('admin.orders.edit', $order->id));
+    $trail->push('AFB handmatig verzenden', route('admin.orders.afb_send', $order->id));
+});
+
 // Orders > Confirm
 Breadcrumbs::for('orders.confirm', function (BreadcrumbTrail $trail, $order) {
     $trail->parent('orders');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
N/A – Feature request: meer controle over AFB email inhoud en bijlagen bij handmatige verzending.

## Description

Voegt een nieuw scherm toe voor het handmatig samenstellen en verzenden van AFB emails per kliniek afdeling. Dit geeft gebruikers meer controle over de emailinhoud en bijlagen.

### Wat is er veranderd:

**Nieuw scherm: `/admin/orders/{id}/afb-send`**
- Overzicht van alle AFB documenten per afdeling/persoon (zelfde lijst als in de order view)
- Toont verzendstatus (verzonden/nog niet verzonden)
- "Bekijk formulier" en "Verwijder" knoppen voor al verzonden documenten (voor correcties)
- "Email samenstellen" knop per rij om de email composer te openen

**Email composer (vergelijkbaar met stap 3 van order bevestigen)**
- TinyMCE HTML editor voor de email inhoud
- Voorgevuld met het AFB dispatch email template
- Ontvanger (Aan) voorgevuld met het email adres van de kliniek afdeling
- Automatische bijlagen: AFB PDF per persoon + GVL PDF (indien beschikbaar)
- Mogelijkheid om extra bijlagen handmatig toe te voegen
- Na versturen: creëert AfbDispatch + AfbPersonDocument records

**Navigatie vanuit order view**
- "Handmatig verzenden" knop in de AFB status kaart
- "Email samenstellen" link in het amber waarschuwingsbanner (naast de bestaande snelle verzendknop)

### Technische details:

| Bestand | Wijziging |
|---------|-----------|
| `OrderController.php` | 4 nieuwe methodes: `afbSendPage`, `afbSendPrepare`, `afbSendManual`, `afbSendAttachment` |
| `afb-send.blade.php` | Nieuw Blade template met inline Vue component `v-afb-send-wizard` |
| `tab-general.blade.php` | Knop "Handmatig verzenden" + link "Email samenstellen" toegevoegd |
| `orders-routes.php` | 4 nieuwe routes onder `orders/{orderId}/afb-send/...` |
| `breadcrumbs.php` | Breadcrumb `orders.afb-send` toegevoegd |

### Code hergebruik:
- TinyMCE editor integratie: zelfde patroon als `confirm.blade.php` stap 3
- Email verzendlogica: hergebruikt `CrmMailService`, `AfbDocumentGenerator`, `AfbDispatch`/`AfbPersonDocument` models
- GVL bijlage logica: zelfde patroon als `AfbDispatchService::attachGvlPdfsToEmail`
- UI patronen: zelfde Tailwind classes en Vue component structuur als de bevestigingswizard

## How To Test This?

1. Ga naar een order view pagina (`/admin/orders/view/{id}`)
2. In de AFB status kaart, klik op "Handmatig verzenden"
3. Op het nieuwe scherm: bekijk de lijst van AFB documenten per afdeling
4. Klik "Email samenstellen" voor een niet-verzonden rij
5. Controleer dat het email formulier voorgevuld is met:
   - Ontvanger email van de kliniek afdeling
   - Onderwerp met kliniek naam en ordernummer
   - Email body met het AFB dispatch template
   - Automatische bijlagen (AFB PDF en eventueel GVL)
6. Bewerk de email inhoud in de TinyMCE editor
7. Voeg optioneel extra bijlagen toe
8. Klik "Verstuur AFB email"
9. Controleer dat het document als verzonden gemarkeerd wordt

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: development

## Tailwind Reordering
Tailwind classes volgen bestaande conventies in het project.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e13f1415-2326-414f-81cf-dd2e5978dcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e13f1415-2326-414f-81cf-dd2e5978dcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

