### PR TITLE
fix: exclude LOST order items from clinic guide (dagplanning)

### DIFF
--- a/app/Http/Controllers/Admin/ClinicGuideController.php
+++ b/app/Http/Controllers/Admin/ClinicGuideController.php
@@ -57,11 +57,12 @@ class ClinicGuideController extends Controller
                 'salesLead.lead',
                 'salesLead.contactPerson',
                 'orderItems' => function ($query) {
-                    $query->whereHas('product', function ($q) {
-                        $q->whereHas('partnerProducts', function ($q) {
-                            $q->whereHas('clinics');
-                        });
-                    })->with(['product', 'person', 'resourceOrderItems']);
+                    $query->where('status', '!=', OrderItemStatus::LOST->value)
+                        ->whereHas('product', function ($q) {
+                            $q->whereHas('partnerProducts', function ($q) {
+                                $q->whereHas('clinics');
+                            });
+                        })->with(['product', 'person', 'resourceOrderItems']);
                 },
                 'stage',
                 'user',


### PR DESCRIPTION
## Summary
- Order items with status `LOST` (Verloren) were incorrectly appearing in the dagplanning (clinic guide)
- Root cause: the `orderItems` eager-load in `ClinicGuideController::get()` did not filter out `LOST` items — only the outer query condition excluded them from triggering order inclusion, but once an order was included (e.g. via `first_examination_at`), all its items were loaded
- Fix: added `->where('status', '!=', OrderItemStatus::LOST->value)` to the `orderItems` eager-load constraint

## Test plan
- [ ] Open the dagplanning for a date where an order has at least one `Verloren` orderregel
- [ ] Verify the `Verloren` item no longer appears in the clinic guide
- [ ] Verify other (non-LOST) items on the same order still appear correctly
- [ ] Verify the AFB tab still excludes LOST items (already had its own filter — unchanged)

Closes MBS-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)