### PR TITLE
fix: order status change does not close open activities (MBS-185)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/view/stages.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/stages.blade.php
@@ -334,8 +334,8 @@
 
                     const performUpdate = async (extra = {}) => {
                         try {
-                            const response = await this.$axios.put("{!! $updateUrl !!}", params ?? {
-                                'lead_pipeline_stage_id': stage.id,
+                            const response = await this.$axios.put("{!! $updateUrl !!}", {
+                                ...(params ?? { 'lead_pipeline_stage_id': stage.id }),
                                 ...extra,
                             });
                             this.isUpdating = false;


### PR DESCRIPTION
## Summary

- **Bug**: When changing an order's status (e.g. to "verloren"), open activities were not being closed even when the user confirmed the prompt.
- **Root cause**: In `stages.blade.php`, the `performUpdate` closure used `params ?? { lead_pipeline_stage_id, ...extra }`. When `params` was already set (won/lost modal case), the `??` operator returned `params` as-is — silently dropping the `close_open_activities: true` flag from `extra`.
- **Fix**: Changed to `{ ...(params ?? { lead_pipeline_stage_id }), ...extra }` so the flag is always merged into the final payload regardless of whether a modal was used.

## Affected flow

1. User changes order stage to "verloren" or "gewonnen" → modal appears for closed_at / lost_reason.
2. User submits modal → `handleFormSubmit` → `update(stage, params)`.
3. Backend check finds open activities → confirm dialog appears.
4. User clicks "Ja" → `performUpdate({ close_open_activities: true })`.
5. ✅ (after fix) `close_open_activities` is merged into the PUT payload and sent to `OrderController::updateStage`.

## Test plan

- [ ] Set an order to a non-won/lost stage while it has open activities → confirm dialog appears → confirm → activities are marked done.
- [ ] Set an order to "verloren" (fill modal) while it has open activities → confirm dialog appears → confirm → activities are marked done.
- [ ] Set an order to "gewonnen" (fill modal) while it has open activities → confirm dialog appears → decline → activities remain open, stage is NOT updated.
- [ ] Lead and sales-lead stage changes still work correctly.

Closes MBS-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)