### PR TITLE
fix: strip _clear meta key from address fields before normalization

### DIFF
--- a/app/Repositories/AddressRepository.php
+++ b/app/Repositories/AddressRepository.php
@@ -48,6 +48,9 @@ class AddressRepository extends Repository
             return null;
         }
 
+        // Strip UI-only meta keys (e.g. _clear) before processing address fields
+        $addressFields = array_diff_key($addressData, array_flip(['_clear']));
+
         // Normalize empty strings to null so cleared fields are stored as null
         $normalized = array_map(function ($value) {
             if (is_string($value) && trim($value) === '') {
@@ -55,7 +58,7 @@ class AddressRepository extends Repository
             }
 
             return $value;
-        }, $addressData);
+        }, $addressFields);
 
         // Filter to filled fields only for update behavior decision
         $filled = array_filter($normalized, function ($value) {

--- a/tests/Feature/Leads/LeadAddressClearTest.php
+++ b/tests/Feature/Leads/LeadAddressClearTest.php
@@ -117,6 +117,31 @@ test('_clear flag 0 keeps the existing address', function () {
     $this->assertEquals($originalAddressId, $lead->address_id);
 });
 
+test('clearing all address fields with _clear=0 (form default) deletes the address', function () {
+    $lead = Lead::factory()->withAddress()->create();
+    $originalAddressId = $lead->address_id;
+
+    $this->assertNotNull($originalAddressId);
+    $this->assertDatabaseHas('addresses', ['id' => $originalAddressId]);
+
+    // Simulate what the HTML form sends: _clear='0' (hidden default) + all fields empty
+    $this->addressRepository->upsertForEntity($lead, [
+        '_clear'              => '0',
+        'street'              => '',
+        'house_number'        => '',
+        'house_number_suffix' => '',
+        'postal_code'         => '',
+        'city'                => '',
+        'state'               => '',
+        'country'             => '',
+    ]);
+
+    $lead->refresh();
+
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});
+
 test('_clear flag 1 when lead has no address does nothing and returns null', function () {
     $lead = Lead::factory()->create(['address_id' => null]);
 


### PR DESCRIPTION
## Summary

- **Bug**: When the HTML form sends `_clear='0'` (the hidden default value) alongside all empty address fields, the `_clear` key was included in the normalized array. Because `'0'` is not null, it kept `$filled` non-empty, preventing deletion of the existing address.
- **Fix**: Strip UI-only meta key `_clear` from `$addressData` before normalization in `AddressRepository::upsertForEntity`.
- **Test**: Added test case `_clear=0 with empty fields deletes address` to `LeadAddressClearTest`.

## Files changed

- `app/Repositories/AddressRepository.php` — strip `_clear` before normalizing fields
- `tests/Feature/Leads/LeadAddressClearTest.php` — add edge case test

## Test plan

- [ ] Run `php artisan test --filter=LeadAddressClearTest` — all tests pass
- [ ] Verify lead address form: clearing all fields while `_clear` hidden input is `0` correctly deletes the address

Related unfinished branch: `daan/mbs-22-lead-adres-leegmaken`

🤖 Generated with [Claude Code](https://claude.com/claude-code)