### PR TITLE
feat: add queue:monitor-failed-jobs scheduled command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,3 +129,10 @@ PATIENT_PORTAL_NOTIFY_EMAIL_INTERVAL_MINUTES=120
 # RevOps alerts: comma-separated recipients for no-lead-in-24h alerts per department.
 # Leave empty to disable this feature entirely.
 REVOPS_NO_LEAD_ALERT_RECIPIENTS=
+
+# Failed jobs queue monitoring (runs every 5 minutes).
+# Leave FAILED_JOBS_ALERT_EMAIL empty to disable alerting entirely.
+# Supports multiple addresses as comma-separated values, e.g. "ops@example.com,dev@example.com"
+FAILED_JOBS_ALERT_EMAIL=
+FAILED_JOBS_WARNING_THRESHOLD=5
+FAILED_JOBS_CRITICAL_THRESHOLD=10

--- a/app/Console/Commands/MonitorFailedJobs.php
+++ b/app/Console/Commands/MonitorFailedJobs.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\FailedJobsCriticalAlert;
+use App\Mail\FailedJobsWarningAlert;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class MonitorFailedJobs extends Command
+{
+    private const CACHE_TTL_MINUTES = 30;
+
+    protected $signature = 'queue:monitor-failed-jobs';
+
+    protected $description = 'Monitor the failed_jobs table and send alerts when thresholds are exceeded.';
+
+    public function handle(): int
+    {
+        $alertEmail = (string) config('failed_jobs.alert_email', '');
+
+        if (empty($alertEmail)) {
+            $this->info('Failed jobs monitoring disabled (FAILED_JOBS_ALERT_EMAIL not set).');
+
+            return Command::SUCCESS;
+        }
+
+        $recipients = array_values(array_filter(array_map('trim', explode(',', $alertEmail))));
+
+        $count = (int) DB::table('failed_jobs')->count();
+        $warningThresh = (int) config('failed_jobs.warning_threshold', 5);
+        $criticalThresh = (int) config('failed_jobs.critical_threshold', 10);
+
+        Log::info('Failed jobs monitor: checked failed_jobs count.', [
+            'count'              => $count,
+            'warning_threshold'  => $warningThresh,
+            'critical_threshold' => $criticalThresh,
+        ]);
+
+        $this->info("Failed jobs: {$count} (warning ≥ {$warningThresh}, critical ≥ {$criticalThresh})");
+
+        if ($count >= $criticalThresh) {
+            Cache::forget('failed_jobs.alert.warning');
+            $this->sendAlert('critical', $count, $recipients, fn () => new FailedJobsCriticalAlert($count));
+        } elseif ($count >= $warningThresh) {
+            Cache::forget('failed_jobs.alert.critical');
+            $this->sendAlert('warning', $count, $recipients, fn () => new FailedJobsWarningAlert($count));
+        } else {
+            Cache::forget('failed_jobs.alert.warning');
+            Cache::forget('failed_jobs.alert.critical');
+
+            $this->info('Failed jobs count is below all thresholds – no alert needed.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param  \Closure(): \Illuminate\Mail\Mailable  $mailableFactory
+     */
+    private function sendAlert(string $level, int $count, array $recipients, \Closure $mailableFactory): void
+    {
+        $cacheKey = "failed_jobs.alert.{$level}";
+
+        if (Cache::has($cacheKey)) {
+            $this->info("Failed jobs [{$level}] alert already sent within the last ".self::CACHE_TTL_MINUTES.' minutes – skipping.');
+
+            return;
+        }
+
+        foreach ($recipients as $recipient) {
+            Mail::to($recipient)->send($mailableFactory());
+        }
+
+        Cache::put($cacheKey, true, now()->addMinutes(self::CACHE_TTL_MINUTES));
+
+        Log::warning("Failed jobs [{$level}] alert sent.", [
+            'count'      => $count,
+            'level'      => $level,
+            'recipients' => $recipients,
+        ]);
+
+        $this->info("Failed jobs [{$level}] alert sent to: ".implode(', ', $recipients));
+    }
+}

--- a/app/Mail/FailedJobsCriticalAlert.php
+++ b/app/Mail/FailedJobsCriticalAlert.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailable;
+
+class FailedJobsCriticalAlert extends Mailable
+{
+    public readonly string $environment;
+
+    public readonly string $timestamp;
+
+    public function __construct(public readonly int $failedJobCount)
+    {
+        $this->environment = app()->environment();
+        $this->timestamp = now()->format('d-m-Y H:i:s');
+    }
+
+    public function build(): self
+    {
+        return $this
+            ->subject("[{$this->environment}] KRITIEK – {$this->failedJobCount} mislukte jobs in de queue")
+            ->view('emails.failed-jobs.critical');
+    }
+}

--- a/app/Mail/FailedJobsWarningAlert.php
+++ b/app/Mail/FailedJobsWarningAlert.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailable;
+
+class FailedJobsWarningAlert extends Mailable
+{
+    public readonly string $environment;
+
+    public readonly string $timestamp;
+
+    public function __construct(public readonly int $failedJobCount)
+    {
+        $this->environment = app()->environment();
+        $this->timestamp = now()->format('d-m-Y H:i:s');
+    }
+
+    public function build(): self
+    {
+        return $this
+            ->subject("[{$this->environment}] Queue Warning – {$this->failedJobCount} mislukte jobs")
+            ->view('emails.failed-jobs.warning');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -91,6 +91,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
         $schedule->command('afb:send-daily')->dailyAt(AfbDispatchService::AFB_LATE_BOOKING_CUTOFF_HOUR.':00')->withoutOverlapping();
         $schedule->command('revops:check-lead-activity')->hourly()->withoutOverlapping();
         $schedule->command('email-templates:verify-codes')->hourly();
+        $schedule->command('queue:monitor-failed-jobs')->everyFiveMinutes()->withoutOverlapping();
     })
     ->withExceptions(function (Exceptions $exceptions) {
         Integration::handles($exceptions);

--- a/config/failed_jobs.php
+++ b/config/failed_jobs.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    /*
+     * Comma-separated list of email addresses that receive queue-monitoring alerts.
+     * Leave empty to disable alerting entirely.
+     * Example: "ops@example.com,dev@example.com"
+     */
+    'alert_email' => env('FAILED_JOBS_ALERT_EMAIL', ''),
+
+    /*
+     * Number of failed jobs that triggers a WARNING email.
+     */
+    'warning_threshold' => (int) env('FAILED_JOBS_WARNING_THRESHOLD', 5),
+
+    /*
+     * Number of failed jobs that triggers a CRITICAL email.
+     */
+    'critical_threshold' => (int) env('FAILED_JOBS_CRITICAL_THRESHOLD', 10),
+];

--- a/resources/views/emails/failed-jobs/critical.blade.php
+++ b/resources/views/emails/failed-jobs/critical.blade.php
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KRITIEK – Mislukte jobs in de queue</title>
+    <style>
+        body { font-family: Arial, sans-serif; background: #f5f5f5; margin: 0; padding: 20px; }
+        .container { max-width: 560px; margin: 0 auto; background: #ffffff; border-radius: 6px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,.1); }
+        .header { background: #c0392b; padding: 20px 30px; }
+        .header h1 { color: #ffffff; margin: 0; font-size: 18px; }
+        .banner { background: #fde8e8; border-top: 3px solid #c0392b; padding: 12px 30px; font-size: 13px; font-weight: bold; color: #c0392b; letter-spacing: 0.5px; text-align: center; }
+        .body { padding: 28px 30px; color: #333333; line-height: 1.6; }
+        .body h2 { margin-top: 0; font-size: 16px; color: #c0392b; }
+        .count { font-size: 48px; font-weight: bold; color: #c0392b; text-align: center; padding: 20px 0 10px; }
+        .count-label { text-align: center; font-size: 13px; color: #999999; margin-bottom: 20px; }
+        .meta { background: #f9f9f9; border-left: 4px solid #c0392b; padding: 12px 16px; margin: 20px 0; font-size: 14px; }
+        .meta div { margin-bottom: 6px; }
+        .meta strong { display: inline-block; min-width: 160px; }
+        .tip { background: #fff5f5; border: 1px solid #f0b0b0; border-radius: 4px; padding: 12px 16px; font-size: 13px; color: #7a0000; margin-top: 16px; }
+        .tip code { background: #f0c0c0; padding: 1px 4px; border-radius: 3px; }
+        .footer { padding: 16px 30px; background: #f0f0f0; font-size: 12px; color: #888888; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>&#128680; KRITIEK – Groot aantal mislukte queue-jobs</h1>
+        </div>
+        <div class="banner">KRITIEKE DREMPELWAARDE OVERSCHREDEN – DIRECTE ACTIE VEREIST</div>
+        <div class="body">
+            <h2>Kritieke situatie: het aantal mislukte jobs vereist directe aandacht</h2>
+            <p>
+                Er zijn <strong>{{ $failedJobCount }} mislukte jobs</strong> gevonden in de queue.
+                Dit overschrijdt de <strong>kritieke drempelwaarde</strong> en vereist directe actie.
+                Controleer de applicatiestatus en onderzoek de oorzaak van de fouten.
+            </p>
+
+            <div class="count">{{ $failedJobCount }}</div>
+            <div class="count-label">mislukte jobs</div>
+
+            <div class="meta">
+                <div>
+                    <strong>Aantal mislukte jobs:</strong>
+                    {{ $failedJobCount }}
+                </div>
+                <div>
+                    <strong>Omgeving:</strong>
+                    {{ $environment }}
+                </div>
+                <div>
+                    <strong>Tijdstip:</strong>
+                    {{ $timestamp }}
+                </div>
+            </div>
+
+            <div class="tip">
+                <strong>Aanbevolen acties:</strong><br>
+                1. Controleer de applicatielogs voor foutmeldingen<br>
+                2. Gebruik <code>php artisan queue:failed</code> voor een overzicht<br>
+                3. Gebruik <code>php artisan queue:retry &lt;id&gt;</code> voor individuele jobs<br>
+                4. Gebruik <code>php artisan queue:retry all</code> om alle jobs opnieuw te proberen<br>
+                5. Controleer de database- en servicestatus
+            </div>
+        </div>
+        <div class="footer">
+            Dit is een automatisch bericht van het Privatescan CRM queue-monitoringsysteem.
+            Mails worden maximaal eens per 30 minuten verstuurd per drempelniveau.
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/emails/failed-jobs/warning.blade.php
+++ b/resources/views/emails/failed-jobs/warning.blade.php
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Queue Warning – Mislukte jobs</title>
+    <style>
+        body { font-family: Arial, sans-serif; background: #f5f5f5; margin: 0; padding: 20px; }
+        .container { max-width: 560px; margin: 0 auto; background: #ffffff; border-radius: 6px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,.1); }
+        .header { background: #e67e22; padding: 20px 30px; }
+        .header h1 { color: #ffffff; margin: 0; font-size: 18px; }
+        .body { padding: 28px 30px; color: #333333; line-height: 1.6; }
+        .body h2 { margin-top: 0; font-size: 16px; color: #e67e22; }
+        .count { font-size: 48px; font-weight: bold; color: #e67e22; text-align: center; padding: 20px 0 10px; }
+        .count-label { text-align: center; font-size: 13px; color: #999999; margin-bottom: 20px; }
+        .meta { background: #f9f9f9; border-left: 4px solid #e67e22; padding: 12px 16px; margin: 20px 0; font-size: 14px; }
+        .meta div { margin-bottom: 6px; }
+        .meta strong { display: inline-block; min-width: 160px; }
+        .tip { background: #fff8f0; border: 1px solid #f0c080; border-radius: 4px; padding: 12px 16px; font-size: 13px; color: #7a5000; margin-top: 16px; }
+        .tip code { background: #f0e0c0; padding: 1px 4px; border-radius: 3px; }
+        .footer { padding: 16px 30px; background: #f0f0f0; font-size: 12px; color: #888888; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>&#9888; Queue Warning – Mislukte jobs gedetecteerd</h1>
+        </div>
+        <div class="body">
+            <h2>Waarschuwing: het aantal mislukte queue-jobs overschrijdt de drempelwaarde</h2>
+            <p>
+                Er zijn <strong>{{ $failedJobCount }} mislukte jobs</strong> gevonden in de queue.
+                Dit overschrijdt de ingestelde waarschuwingsdrempel.
+            </p>
+
+            <div class="count">{{ $failedJobCount }}</div>
+            <div class="count-label">mislukte jobs</div>
+
+            <div class="meta">
+                <div>
+                    <strong>Aantal mislukte jobs:</strong>
+                    {{ $failedJobCount }}
+                </div>
+                <div>
+                    <strong>Omgeving:</strong>
+                    {{ $environment }}
+                </div>
+                <div>
+                    <strong>Tijdstip:</strong>
+                    {{ $timestamp }}
+                </div>
+            </div>
+
+            <div class="tip">
+                <strong>Wat te doen?</strong><br>
+                Controleer de <code>failed_jobs</code> tabel of gebruik:<br>
+                &bull; <code>php artisan queue:retry all</code> – jobs opnieuw proberen<br>
+                &bull; <code>php artisan queue:failed</code> – overzicht van mislukte jobs<br>
+                &bull; <code>php artisan queue:flush</code> – alle mislukte jobs verwijderen
+            </div>
+        </div>
+        <div class="footer">
+            Dit is een automatisch bericht van het Privatescan CRM queue-monitoringsysteem.
+            Mails worden maximaal eens per 30 minuten verstuurd per drempelniveau.
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/Feature/Console/MonitorFailedJobsCommandTest.php
+++ b/tests/Feature/Console/MonitorFailedJobsCommandTest.php
@@ -1,0 +1,333 @@
+<?php
+
+use App\Mail\FailedJobsCriticalAlert;
+use App\Mail\FailedJobsWarningAlert;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+/**
+ * Insert N fake failed_jobs rows for testing.
+ */
+function insertFailedJobs(int $count): void
+{
+    for ($i = 0; $i < $count; $i++) {
+        DB::table('failed_jobs')->insert([
+            'uuid'       => Str::uuid()->toString(),
+            'connection' => 'sync',
+            'queue'      => 'default',
+            'payload'    => json_encode(['job' => 'TestJob', 'data' => []]),
+            'exception'  => 'RuntimeException: test',
+            'failed_at'  => now(),
+        ]);
+    }
+}
+
+// ─── Disabled when no email configured ──────────────────────────────────────
+
+test('does nothing when FAILED_JOBS_ALERT_EMAIL is empty', function () {
+    Mail::fake();
+    config(['failed_jobs.alert_email' => '']);
+
+    insertFailedJobs(20);
+
+    $exitCode = Artisan::call('queue:monitor-failed-jobs');
+
+    expect($exitCode)->toBe(0);
+    Mail::assertNothingSent();
+});
+
+// ─── Below threshold ─────────────────────────────────────────────────────────
+
+test('sends no mail when failed jobs count is below warning threshold', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(3);
+
+    $exitCode = Artisan::call('queue:monitor-failed-jobs');
+
+    expect($exitCode)->toBe(0);
+    Mail::assertNothingSent();
+});
+
+// ─── Warning threshold ───────────────────────────────────────────────────────
+
+test('sends warning mail when count equals warning threshold', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(5);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsWarningAlert::class);
+    Mail::assertNotSent(FailedJobsCriticalAlert::class);
+});
+
+test('sends warning mail when count is between warning and critical thresholds', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(7);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsWarningAlert::class, 1);
+    Mail::assertNotSent(FailedJobsCriticalAlert::class);
+});
+
+test('sends warning mail to all configured recipients', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com,dev@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(6);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsWarningAlert::class, 2);
+});
+
+// ─── Critical threshold ──────────────────────────────────────────────────────
+
+test('sends critical mail when count equals critical threshold', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(10);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsCriticalAlert::class);
+    Mail::assertNotSent(FailedJobsWarningAlert::class);
+});
+
+test('sends critical mail when count exceeds critical threshold', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(15);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsCriticalAlert::class, 1);
+    Mail::assertNotSent(FailedJobsWarningAlert::class);
+});
+
+test('sends critical mail to all configured recipients', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com,dev@example.com,manager@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(12);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsCriticalAlert::class, 3);
+});
+
+// ─── Cache throttling ────────────────────────────────────────────────────────
+
+test('does not send duplicate warning mail within 30-minute throttle window', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    Cache::put('failed_jobs.alert.warning', true, now()->addMinutes(30));
+
+    insertFailedJobs(6);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertNothingSent();
+});
+
+test('does not send duplicate critical mail within 30-minute throttle window', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    Cache::put('failed_jobs.alert.critical', true, now()->addMinutes(30));
+
+    insertFailedJobs(12);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertNothingSent();
+});
+
+test('sets cache after sending warning alert to prevent duplicate mails', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(6);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    expect(Cache::has('failed_jobs.alert.warning'))->toBeTrue();
+});
+
+test('sets cache after sending critical alert to prevent duplicate mails', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(12);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    expect(Cache::has('failed_jobs.alert.critical'))->toBeTrue();
+});
+
+// ─── Cache reset ─────────────────────────────────────────────────────────────
+
+test('clears cache keys when count drops below thresholds', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    Cache::put('failed_jobs.alert.warning', true, now()->addMinutes(30));
+    Cache::put('failed_jobs.alert.critical', true, now()->addMinutes(30));
+
+    insertFailedJobs(2);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    expect(Cache::has('failed_jobs.alert.warning'))->toBeFalse();
+    expect(Cache::has('failed_jobs.alert.critical'))->toBeFalse();
+    Mail::assertNothingSent();
+});
+
+test('clears critical cache when count drops to warning level', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    Cache::put('failed_jobs.alert.critical', true, now()->addMinutes(30));
+
+    insertFailedJobs(7);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    expect(Cache::has('failed_jobs.alert.critical'))->toBeFalse();
+});
+
+// ─── Mailable content ────────────────────────────────────────────────────────
+
+test('warning mailable carries correct failed job count', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(7);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsWarningAlert::class, function (FailedJobsWarningAlert $mail) {
+        return $mail->failedJobCount === 7;
+    });
+});
+
+test('critical mailable carries correct failed job count', function () {
+    Mail::fake();
+    config([
+        'failed_jobs.alert_email'         => 'ops@example.com',
+        'failed_jobs.warning_threshold'   => 5,
+        'failed_jobs.critical_threshold'  => 10,
+    ]);
+
+    insertFailedJobs(12);
+
+    Artisan::call('queue:monitor-failed-jobs');
+
+    Mail::assertSent(FailedJobsCriticalAlert::class, function (FailedJobsCriticalAlert $mail) {
+        return $mail->failedJobCount === 12;
+    });
+});
+
+test('warning mailable subject contains environment and job count', function () {
+    config(['app.env' => 'testing']);
+
+    $mailable = new FailedJobsWarningAlert(7);
+    $mailable->build();
+
+    expect($mailable->subject)->toContain('7')
+        ->and($mailable->subject)->toContain('testing');
+});
+
+test('critical mailable subject contains environment and job count', function () {
+    config(['app.env' => 'testing']);
+
+    $mailable = new FailedJobsCriticalAlert(12);
+    $mailable->build();
+
+    expect($mailable->subject)->toContain('12')
+        ->and($mailable->subject)->toContain('testing');
+});
+
+test('warning mailable exposes environment and timestamp properties', function () {
+    $mailable = new FailedJobsWarningAlert(5);
+
+    expect($mailable->environment)->not->toBeEmpty()
+        ->and($mailable->timestamp)->not->toBeEmpty();
+});
+
+test('critical mailable exposes environment and timestamp properties', function () {
+    $mailable = new FailedJobsCriticalAlert(10);
+
+    expect($mailable->environment)->not->toBeEmpty()
+        ->and($mailable->timestamp)->not->toBeEmpty();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Laravel scheduled Artisan command `queue:monitor-failed-jobs` that monitors the `failed_jobs` table every 5 minutes and sends alert emails when configurable thresholds are exceeded.

## Changes

### New files
- `config/failed_jobs.php` – config keys backed by three `.env` variables
- `app/Console/Commands/MonitorFailedJobs.php` – the command
- `app/Mail/FailedJobsWarningAlert.php` – warning-level Mailable
- `app/Mail/FailedJobsCriticalAlert.php` – critical-level Mailable
- `resources/views/emails/failed-jobs/warning.blade.php` – orange HTML email
- `resources/views/emails/failed-jobs/critical.blade.php` – red HTML email with urgency banner
- `tests/Feature/Console/MonitorFailedJobsCommandTest.php` – 20 Pest tests

### Modified files
- `bootstrap/app.php` – registers `queue:monitor-failed-jobs` in the scheduler (`everyFiveMinutes()->withoutOverlapping()`)
- `.env.example` – documents the three new env variables

## Configuration (`.env`)

```env
# Leave empty to disable alerting entirely
FAILED_JOBS_ALERT_EMAIL=
# Supports comma-separated addresses: "ops@example.com,dev@example.com"
FAILED_JOBS_WARNING_THRESHOLD=5
FAILED_JOBS_CRITICAL_THRESHOLD=10
```

## Behaviour

| Condition | Action |
|---|---|
| `FAILED_JOBS_ALERT_EMAIL` empty | No-op, logs info message |
| count < warning threshold | No mail; resets cache keys |
| count >= warning and < critical | Sends `FailedJobsWarningAlert` (orange email) |
| count >= critical | Sends `FailedJobsCriticalAlert` (red email with urgency banner) |
| Alert already sent within 30 min | Throttled by cache – no duplicate mail |

Cache keys are reset when the count drops below a threshold, so the next breach re-triggers the alert.

Every run logs the current count at `info` level. Every sent alert logs at `warning` level with recipient list and count.

## Tests

20 Pest feature tests covering:
- Disabled when email is not configured
- Below-threshold: no mail sent
- Warning threshold (exact, between, multiple recipients)
- Critical threshold (exact, above, multiple recipients)
- Cache throttle for both levels
- Cache set after sending
- Cache reset when count drops
- Mailable properties (count, environment, timestamp, subject)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-824d25d1-98a7-46a6-a066-3e6f6e713e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-824d25d1-98a7-46a6-a066-3e6f6e713e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

