### PR TITLE
Hide 'Gepland' chip and schedule dates for completed activities

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -70,11 +70,11 @@
                         class="rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-error dark:bg-red-900/30 dark:text-red-400">
                         Te laat
                     </span>
-                    <span v-else-if="activity.schedule_from"
+                    <span v-else-if="!activity.is_done && activity.schedule_from"
                         class="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
                         Gepland
                     </span>
-                    <div v-if="activity.schedule_from" class="text-xs"
+                    <div v-if="!activity.is_done && activity.schedule_from" class="text-xs"
                         :class="{
                             'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
                             'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Activity cards on lead view (`/admin/leads/view/{id}#activiteiten`) showed "Gepland" label and schedule dates for completed activities, causing confusion.

## Description
When an activity is marked as done (afgerond), the "Gepland" chip and schedule dates (Vanaf/Einddatum) were still displayed. This was confusing because it suggested the activity was still planned.

**Changes in `activity-item.blade.php`:**
- Added `!activity.is_done` guard to the `v-else-if` for the "Gepland" chip (line 73)
- Added `!activity.is_done` guard to the `v-if` for the schedule dates div (line 77)

**Result:** Completed activities now only show the checkmark icon (✓), without the "Gepland" label or scheduling dates.

## How To Test This?
1. Navigate to `/admin/leads/view/{id}#activiteiten`
2. Toggle "Toon afgerond" to show completed activities
3. Verify completed activities show only the ✓ checkmark, not the "Gepland" chip or schedule dates
4. Verify open activities still show "Gepland" chip and dates as before
5. Verify overdue open activities still show "Te laat" chip and dates

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: development

## Tailwind Reordering
N/A — no Tailwind class changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf314b0a-1b8d-4cd0-a45e-fb6f6eca35c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf314b0a-1b8d-4cd0-a45e-fb6f6eca35c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

