### PR TITLE
feat: allow editing order confirmation after it has been sent (MBS-216)

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -1472,6 +1472,20 @@ class OrderController extends SimpleEntityController
         }
     }
 
+    public function getPersonConfirmationContent(int $orderId, int $personId): JsonResponse
+    {
+        Order::findOrFail($orderId);
+        Person::findOrFail($personId);
+
+        $confirmation = OrderPersonConfirmation::where('order_id', $orderId)
+            ->where('person_id', $personId)
+            ->first();
+
+        return response()->json([
+            'data' => ['content' => $confirmation?->confirmation_letter_content ?? ''],
+        ]);
+    }
+
     public function savePersonConfirmationLetter(Request $request, int $orderId, int $personId): JsonResponse
     {
         $request->validate(['content' => 'nullable|string']);
@@ -1551,10 +1565,6 @@ class OrderController extends SimpleEntityController
         $confirmation = OrderPersonConfirmation::where('order_id', $orderId)
             ->where('person_id', $personId)
             ->first();
-
-        if ($confirmation?->isEmailSent()) {
-            return response()->json(['message' => 'Deze persoon is al bevestigd.'], 422);
-        }
 
         if ($confirmation?->isLetterSaved()) {
             try {

--- a/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/orders/confirm.blade.php
@@ -109,14 +109,9 @@
                                               class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500">&ndash;</span>
                                     </td>
                                     <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
-                                        <button v-if="person.email_sent" type="button"
-                                                class="inline-flex items-center gap-1 rounded-md bg-green-50 px-3 py-1.5 text-xs font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400"
-                                                disabled>
-                                            <span>&#10003;</span> Voltooid
-                                        </button>
-                                        <button v-else type="button" @click="startPersonWizard(person)"
+                                        <button type="button" @click="startPersonWizard(person)"
                                                 class="primary-button text-xs !px-3 !py-1.5">
-                                            @{{ person.letter_saved ? 'Hervat' : 'Start' }}
+                                            @{{ person.email_sent ? 'Aanpassen' : (person.letter_saved ? 'Hervat' : 'Start') }}
                                         </button>
                                     </td>
                                 </tr>
@@ -645,7 +640,7 @@
 
                     // ---- Per-person overview ----
 
-                    startPersonWizard(person) {
+                    async startPersonWizard(person) {
                         this.selectedPerson = person;
                         this.currentStep = 0;
                         this.letterContent = '';
@@ -659,7 +654,7 @@
                         this.previewPdfBlobUrl = null;
 
                         // Load existing letter content if saved
-                        this.loadPersonLetterContent(person.id);
+                        await this.loadPersonLetterContent(person.id);
                     },
 
                     exitPersonWizard() {
@@ -671,28 +666,15 @@
 
                     async loadPersonLetterContent(personId) {
                         try {
-                            const resp = await fetch(`/admin/orders/${this.orderId}/confirmation/persons-status`, {
+                            const resp = await fetch(`/admin/orders/${this.orderId}/confirmation/person/${personId}/content`, {
                                 headers: {'Accept': 'application/json'},
                             });
-                            const data = await resp.json();
-                            const personData = (data.data || []).find(p => p.id === personId);
-                            if (personData) {
-                                // Update status in our local array
-                                const idx = this.personsStatus.findIndex(p => p.id === personId);
-                                if (idx !== -1) {
-                                    this.personsStatus.splice(idx, 1, personData);
+                            if (resp.ok) {
+                                const data = await resp.json();
+                                if (data.data?.content) {
+                                    this.letterContent = data.data.content;
+                                    this.$nextTick(() => this.setTinyMCEContent('confirmation-letter-editor', this.letterContent));
                                 }
-                            }
-                        } catch (e) { /* non-critical */
-                        }
-
-                        // Try to load saved letter from the person confirmation
-                        try {
-                            const confirmation = this.personsStatus.find(p => p.id === personId);
-                            if (confirmation && confirmation.letter_saved) {
-                                // The letter content is stored server-side; we need to fetch it
-                                // For now we'll let the user re-generate or it will be loaded
-                                // when they previously saved via the save endpoint
                             }
                         } catch (e) { /* non-critical */
                         }

--- a/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/orders-routes.php
@@ -49,6 +49,7 @@ Route::controller(OrderController::class)->prefix('orders')->group(function () {
 
     // Per-person confirmation routes (combine_order = false)
     Route::get('{orderId}/confirmation/persons-status', 'personsConfirmationStatus')->name('admin.orders.confirmation.persons-status');
+    Route::get('{orderId}/confirmation/person/{personId}/content', 'getPersonConfirmationContent')->name('admin.orders.confirmation.person.content');
     Route::get('{orderId}/confirmation/person/{personId}/template-content', 'getPersonConfirmationTemplateContent')->name('admin.orders.confirmation.person.template-content');
     Route::post('{orderId}/confirmation/person/{personId}/save', 'savePersonConfirmationLetter')->name('admin.orders.confirmation.person.save');
     Route::post('{orderId}/confirmation/person/{personId}/preview-pdf', 'previewPersonConfirmationPdf')->name('admin.orders.confirmation.person.preview-pdf');


### PR DESCRIPTION
## Summary

Fixes MBS-216: After saving an order confirmation it was no longer editable. Users can now re-open and modify the confirmation letter at any time, choose a different template and overwrite the content.

### Changes

**Per-person flow (combine_order = false):**
- Replaced the disabled "Voltooid" button with an enabled "Aanpassen" button — users can always re-enter the wizard for a person, even after confirmation was sent
- Implemented `loadPersonLetterContent` to fetch saved letter HTML from the server and pre-populate the editor when re-opening the wizard
- Added `GET /admin/orders/{orderId}/confirmation/person/{personId}/content` endpoint (`getPersonConfirmationContent`) to retrieve the saved confirmation letter content
- Removed the 422 guard in `markPersonAsSent` that blocked re-sending an already-confirmed person — re-confirming now overwrites the previous state

**Combined order flow (combine_order = true):**
- Already worked: `initialContent` is loaded from `$orders->confirmation_letter_content`, and "Genereer brief" overwrites content freely.

## Test plan

- [ ] Open an order with `combine_order = false` that has already been confirmed (email sent)
- [ ] Navigate to `/admin/orders/{id}/confirm` — persons with "Voltooid" should now show "Aanpassen"
- [ ] Click "Aanpassen" → wizard opens with saved letter content pre-loaded
- [ ] Select a different template and click "Genereer brief" → content is overwritten
- [ ] Complete the wizard and send the email again → confirmation is updated
- [ ] Open a combined order confirm page → existing content is still pre-loaded; re-generating works

🤖 Generated with [Claude Code](https://claude.com/claude-code)