### PR TITLE
Filter emails from open activity confirmations

### DIFF
--- a/app/Http/Controllers/Admin/SalesLeadController.php
+++ b/app/Http/Controllers/Admin/SalesLeadController.php
@@ -483,7 +483,7 @@ class SalesLeadController extends Controller
         $all = $salesActivities->merge($orderActivities)->unique('id')->values();
 
         return ActivityResource::collection(
-            $this->concatEmailActivitiesFor('sales', (int) $id, $all, $this->attachmentRepository)
+            $this->concatEmailActivitiesFor('sales', (int) $id, $all, $this->attachmentRepository, $isDoneFilter)
         );
     }
 

--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -487,7 +487,7 @@ class OrderController extends SimpleEntityController
         $activities = $query->with('portalPersons')->get();
 
         return ActivityResource::collection(
-            $this->concatEmailActivitiesFor('order', $id, $activities, $this->attachmentRepository)
+            $this->concatEmailActivitiesFor('order', $id, $activities, $this->attachmentRepository, $isDoneFilter)
         );
     }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
@@ -51,8 +51,13 @@ trait ConcatsEmailActivities
     /**
      * Convenience: concatenate "email activities" for an entity type into an existing activities collection.
      */
-    protected function concatEmailActivitiesFor(string $entityType, int $entityId, Collection $activities, AttachmentRepository $attachmentRepository, ?int $isDoneFilter = null): Collection
-    {
+    protected function concatEmailActivitiesFor(
+        string $entityType,
+        int $entityId,
+        Collection $activities,
+        AttachmentRepository $attachmentRepository,
+        ?int $isDoneFilter = null
+    ): Collection {
         if ($isDoneFilter === 0) {
             return $activities;
         }

--- a/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
@@ -51,8 +51,12 @@ trait ConcatsEmailActivities
     /**
      * Convenience: concatenate "email activities" for an entity type into an existing activities collection.
      */
-    protected function concatEmailActivitiesFor(string $entityType, int $entityId, Collection $activities, AttachmentRepository $attachmentRepository): Collection
+    protected function concatEmailActivitiesFor(string $entityType, int $entityId, Collection $activities, AttachmentRepository $attachmentRepository, ?int $isDoneFilter = null): Collection
     {
+        if ($isDoneFilter === 0) {
+            return $activities;
+        }
+
         $emails = $this->getEmailsForEntityThread($entityType, $entityId);
 
         return $this->concatEmails($activities, $emails, $attachmentRepository);

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -123,7 +123,7 @@ class ActivityController extends Controller
         }
 
         return ActivityResource::collection(
-            $this->concatEmailActivitiesFor('lead', (int) $leadId, $query->get(), $this->attachmentRepository)
+            $this->concatEmailActivitiesFor('lead', (int) $leadId, $query->get(), $this->attachmentRepository, $isDoneFilter)
         );
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/partials/open_activities_confirm_helper.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/partials/open_activities_confirm_helper.blade.php
@@ -12,6 +12,13 @@
             const suffixMap = { sale: ' op deze sales', order: ' op deze order' };
 
             let titlesList = '';
+            let confirmableOpenCount = Number(openCount || 0);
+
+            const isEmailActivity = (activity) => {
+                return [activity?.type, activity?.activity_type, activity?.type_label]
+                    .some(value => ['email', 'e-mail', 'e_mail'].includes(String(value || '').trim().toLowerCase()));
+            };
+
             try {
                 const config = endpointMap[type];
                 if (!config) throw new Error('Unknown entity type for fetching activities');
@@ -19,23 +26,33 @@
                 const endpoint = config.tmpl.replace('/0/', `/${entityId}/`);
                 const res = await axiosInstance.get(endpoint, { params: config.params });
                 const activities = Array.isArray(res?.data?.data) ? res.data.data : [];
+                const confirmableActivities = activities.filter(activity => !isEmailActivity(activity));
 
-                const titles = activities
+                confirmableOpenCount = confirmableActivities.length;
+                if (confirmableOpenCount <= 0) {
+                    return null;
+                }
+
+                const titles = confirmableActivities
                     .map(a => (a.title || '').trim())
                     .filter(t => t.length > 0)
                     .slice(0, 10);
                 if (titles.length > 0) {
                     titlesList = '\n\nActies:\n- ' + titles.join('\n- ');
-                    if (activities.length > titles.length) {
-                        titlesList += `\n- (+${activities.length - titles.length} meer)`;
+                    if (confirmableActivities.length > titles.length) {
+                        titlesList += `\n- (+${confirmableActivities.length - titles.length} meer)`;
                     }
                 }
             } catch (e) {
                 // Ignore fetch errors; present basic message without titles
             }
 
+            if (confirmableOpenCount <= 0) {
+                return null;
+            }
+
             const suffix = suffixMap[type] ?? ' op deze lead';
-            return `Er staan nog ${openCount} open activiteit(en)${suffix}. Wil je deze afronden en de status wijzigen?${titlesList}`;
+            return `Er staan nog ${confirmableOpenCount} open activiteit(en)${suffix}. Wil je deze afronden en de status wijzigen?${titlesList}`;
         }
     </script>
 @endPushOnce

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/stages.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/stages.blade.php
@@ -429,6 +429,11 @@
                         @endif
                         if (openCount > 0) {
                             const message = await window.buildOpenActivitiesConfirmMessage(this.$axios, entityIdForConfirm, openCount, entityType);
+                            if (!message) {
+                                await performUpdate();
+                                return;
+                            }
+
                             this.$emitter.emit('open-confirm-modal', {
                                 message,
                                 agree: () => {

--- a/resources/views/adminc/components/kanban-abstract.blade.php
+++ b/resources/views/adminc/components/kanban-abstract.blade.php
@@ -1174,6 +1174,11 @@
                                     : (this.entityType === 'order' ? 'order' : 'lead');
                                 const message = await window.buildOpenActivitiesConfirmMessage(this
                                     .$axios, lead.id, openCount, activityType);
+                                if (!message) {
+                                    await this.updateLeadStage(lead.id, stage.id);
+                                    return;
+                                }
+
                                 this.$emitter.emit('open-confirm-modal', {
                                     message,
                                     agree: () => {

--- a/tests/Feature/Activities/OpenActivityEmailFilterTest.php
+++ b/tests/Feature/Activities/OpenActivityEmailFilterTest.php
@@ -11,7 +11,8 @@ use Webkul\Lead\Models\Lead;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->actingAs(makeUser(), 'user');
+    $this->user = makeUser();
+    $this->actingAs($this->user, 'user');
 });
 
 test('lead open activities endpoint excludes email activity items', function () {
@@ -22,7 +23,7 @@ test('lead open activities endpoint excludes email activity items', function () 
         'title'         => 'Lead open task',
         'lead_id'       => $lead->id,
         'is_done'       => 0,
-        'user_id'       => auth()->id(),
+        'user_id'       => $this->user->id,
         'schedule_from' => now(),
         'schedule_to'   => now()->addHour(),
     ]);
@@ -56,7 +57,7 @@ test('sales lead open activities endpoint excludes email activity items', functi
         'title'         => 'Sales open task',
         'sales_lead_id' => $salesLead->id,
         'is_done'       => 0,
-        'user_id'       => auth()->id(),
+        'user_id'       => $this->user->id,
         'schedule_from' => now(),
         'schedule_to'   => now()->addHour(),
     ]);
@@ -70,7 +71,9 @@ test('sales lead open activities endpoint excludes email activity items', functi
         'source'        => 'system',
     ]);
 
-    $response = $this->getJson(route('admin.sales-leads.activities.index', $salesLead->id).'?is_done=0&hierarchy=false');
+    $response = $this->getJson(
+        route('admin.sales-leads.activities.index', $salesLead->id).'?is_done=0&hierarchy=false'
+    );
 
     $response->assertOk();
 
@@ -90,7 +93,7 @@ test('order open activities endpoint excludes email activity items', function ()
         'title'         => 'Order open task',
         'order_id'      => $order->id,
         'is_done'       => 0,
-        'user_id'       => auth()->id(),
+        'user_id'       => $this->user->id,
         'schedule_from' => now(),
         'schedule_to'   => now()->addHour(),
     ]);

--- a/tests/Feature/Activities/OpenActivityEmailFilterTest.php
+++ b/tests/Feature/Activities/OpenActivityEmailFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Enums\ActivityType;
+use App\Models\Order;
+use App\Models\SalesLead;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Activity\Models\Activity;
+use Webkul\Email\Models\Email;
+use Webkul\Lead\Models\Lead;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->actingAs(makeUser(), 'user');
+});
+
+test('lead open activities endpoint excludes email activity items', function () {
+    $lead = Lead::factory()->create();
+
+    Activity::create([
+        'type'          => ActivityType::TASK->value,
+        'title'         => 'Lead open task',
+        'lead_id'       => $lead->id,
+        'is_done'       => 0,
+        'user_id'       => auth()->id(),
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addHour(),
+    ]);
+
+    Email::create([
+        'subject'  => 'Lead email item',
+        'reply'    => '<p>Email inhoud</p>',
+        'from'     => json_encode(['address' => 'sender@example.com', 'name' => 'Sender']),
+        'reply_to' => json_encode(['patient@example.com']),
+        'lead_id'  => $lead->id,
+        'source'   => 'system',
+    ]);
+
+    $response = $this->getJson(route('admin.leads.activities.index', $lead->id).'?is_done=0');
+
+    $response->assertOk();
+
+    $types = collect($response->json('data'))->pluck('type');
+    $titles = collect($response->json('data'))->pluck('title');
+
+    expect($types)->not->toContain('email')
+        ->and($titles)->toContain('Lead open task')
+        ->and($titles)->not->toContain('Lead email item');
+});
+
+test('sales lead open activities endpoint excludes email activity items', function () {
+    $salesLead = SalesLead::factory()->create();
+
+    Activity::create([
+        'type'          => ActivityType::TASK->value,
+        'title'         => 'Sales open task',
+        'sales_lead_id' => $salesLead->id,
+        'is_done'       => 0,
+        'user_id'       => auth()->id(),
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addHour(),
+    ]);
+
+    Email::create([
+        'subject'       => 'Sales email item',
+        'reply'         => '<p>Email inhoud</p>',
+        'from'          => json_encode(['address' => 'sender@example.com', 'name' => 'Sender']),
+        'reply_to'      => json_encode(['patient@example.com']),
+        'sales_lead_id' => $salesLead->id,
+        'source'        => 'system',
+    ]);
+
+    $response = $this->getJson(route('admin.sales-leads.activities.index', $salesLead->id).'?is_done=0&hierarchy=false');
+
+    $response->assertOk();
+
+    $types = collect($response->json('data'))->pluck('type');
+    $titles = collect($response->json('data'))->pluck('title');
+
+    expect($types)->not->toContain('email')
+        ->and($titles)->toContain('Sales open task')
+        ->and($titles)->not->toContain('Sales email item');
+});
+
+test('order open activities endpoint excludes email activity items', function () {
+    $order = Order::factory()->create();
+
+    Activity::create([
+        'type'          => ActivityType::TASK->value,
+        'title'         => 'Order open task',
+        'order_id'      => $order->id,
+        'is_done'       => 0,
+        'user_id'       => auth()->id(),
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addHour(),
+    ]);
+
+    Email::create([
+        'subject'       => 'Order email item',
+        'reply'         => '<p>Email inhoud</p>',
+        'from'          => json_encode(['address' => 'sender@example.com', 'name' => 'Sender']),
+        'reply_to'      => json_encode(['patient@example.com']),
+        'order_id'      => $order->id,
+        'sales_lead_id' => $order->sales_lead_id,
+        'source'        => 'system',
+    ]);
+
+    $response = $this->getJson(route('admin.orders.activities.index', $order->id).'?is_done=0');
+
+    $response->assertOk();
+
+    $types = collect($response->json('data'))->pluck('type');
+    $titles = collect($response->json('data'))->pluck('title');
+
+    expect($types)->not->toContain('email')
+        ->and($titles)->toContain('Order open task')
+        ->and($titles)->not->toContain('Order email item');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference

,

## Description

- Exclude e-mail activity-like records when `is_done=0` activity endpoints are used for lead, sales, and order open-activity checks.
- Make the shared open-activities confirmation helper ignore type `email`/`e-mail` entries and skip the confirmation when no confirmable open activities remain.
- Add feature coverage for lead, sales lead, and order open activity endpoints.

## How To Test This?

- `php artisan test tests/Feature/Activities/OpenActivityEmailFilterTest.php`

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: development

## Tailwind Reordering

- [x] No Tailwind changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f950233-4698-45f7-a0f2-1355c937c78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f950233-4698-45f7-a0f2-1355c937c78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

