### PR TITLE
Use activity deadlines for action filtering

### DIFF
--- a/app/Console/Commands/SyncActivityStatuses.php
+++ b/app/Console/Commands/SyncActivityStatuses.php
@@ -16,7 +16,7 @@ class SyncActivityStatuses extends Command
     {
         Activity::query()->chunkById(500, function ($activities) {
             foreach ($activities as $activity) {
-                $computed = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, $activity->status);
+                $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
                 if ($computed->value !== ($activity->status?->value ?? null)) {
                     $activity->status = $computed;
                     $activity->save();

--- a/app/Http/Controllers/Admin/SalesLeadController.php
+++ b/app/Http/Controllers/Admin/SalesLeadController.php
@@ -494,7 +494,6 @@ class SalesLeadController extends Controller
             'title'         => 'required|string',
             'description'   => 'nullable|string',
             'user_id'       => 'nullable|exists:users,id',
-            'schedule_from' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'schedule_to'   => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
         ]);
 
@@ -504,7 +503,6 @@ class SalesLeadController extends Controller
             'comment'          => request('description'),
             'user_id'          => request('user_id') ?? auth()->id(),
             'sales_lead_id'    => $id,
-            'schedule_from'    => request('schedule_from'),
             'schedule_to'      => request('schedule_to'),
             'is_done'          => 0,
         ]);

--- a/app/Http/Controllers/Admin/Settings/Clinic/ActivityController.php
+++ b/app/Http/Controllers/Admin/Settings/Clinic/ActivityController.php
@@ -40,7 +40,6 @@ class ActivityController extends Controller
             'comment'       => 'required_if:type,note',
             'description'   => 'nullable|string',
             'user_id'       => 'nullable|exists:users,id',
-            'schedule_from' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'schedule_to'   => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'file'          => 'required_if:type,file',
         ]);
@@ -51,6 +50,7 @@ class ActivityController extends Controller
         $request->request->remove('person_id');
 
         $data = $request->all();
+        unset($data['schedule_from']);
         Activity::normalizeForeignKeys($data);
 
         // Check clinic exists

--- a/app/Http/Controllers/Api/SalesLeadController.php
+++ b/app/Http/Controllers/Api/SalesLeadController.php
@@ -79,7 +79,6 @@ class SalesLeadController extends Controller
             'description'   => 'nullable|string',
             'comment'       => 'nullable|string',
             'user_id'       => 'nullable|exists:users,id',
-            'schedule_from' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
             'schedule_to'   => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
         ]);
 
@@ -94,7 +93,6 @@ class SalesLeadController extends Controller
                 'comment'          => $validated['comment'] ?? ($validated['description'] ?? null),
                 'user_id'          => $validated['user_id'] ?? auth()->id(),
                 'sales_lead_id'    => $salesLead->id,
-                'schedule_from'    => $validated['schedule_from'] ?? null,
                 'schedule_to'      => $validated['schedule_to'] ?? null,
             ]);
 

--- a/app/Services/ActivityStatusService.php
+++ b/app/Services/ActivityStatusService.php
@@ -23,7 +23,7 @@ class ActivityStatusService
             return ActivityStatus::ACTIVE;
         }
 
-        if ($to->lt($now)) {
+        if ($to->lt(now())) {
             return ActivityStatus::EXPIRED;
         }
 

--- a/app/Services/ActivityStatusService.php
+++ b/app/Services/ActivityStatusService.php
@@ -9,8 +9,6 @@ class ActivityStatusService
 {
     public static function computeStatus(?CarbonInterface $from, ?CarbonInterface $to, ?ActivityStatus $current = null): ActivityStatus
     {
-        $now = now();
-
         // Respect explicit DONE: once done, keep done
         if ($current === ActivityStatus::DONE) {
             return ActivityStatus::DONE;
@@ -20,21 +18,13 @@ class ActivityStatusService
             return ActivityStatus::IN_PROGRESS;
         }
 
-        // If both dates missing, default active
-        if (! $from && ! $to) {
+        // schedule_from is intentionally ignored; schedule_to is the only managed deadline.
+        if (! $to) {
             return ActivityStatus::ACTIVE;
         }
 
-        // Determine window relative to now
-        $start = $from ?? $to;
-        $end = $to ?? $from;
-
-        if ($end && $end->lt($now)) {
+        if ($to->lt($now)) {
             return ActivityStatus::EXPIRED;
-        }
-
-        if ($start && $start->gt($now)) {
-            return ActivityStatus::ON_HOLD;
         }
 
         return ActivityStatus::ACTIVE;

--- a/app/Services/Importers/SugarCRM/ActivityImporter.php
+++ b/app/Services/Importers/SugarCRM/ActivityImporter.php
@@ -322,7 +322,7 @@ class ActivityImporter
                     if ($activity->is_done) {
                         $activity->status = ActivityStatus::DONE;
                     } else {
-                        $activity->status = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, ActivityStatus::ACTIVE);
+                        $activity->status = ActivityStatusService::computeStatus(null, $activity->schedule_to, ActivityStatus::ACTIVE);
                     }
                     $activity->saveQuietly();
 

--- a/packages/Webkul/Activity/src/Models/Activity.php
+++ b/packages/Webkul/Activity/src/Models/Activity.php
@@ -400,13 +400,13 @@ class Activity extends Model implements ActivityContract
     }
 
     /**
-     * Scope activity time filtering based on schedule_from.
+     * Scope activity time filtering based on the managed deadline.
      */
     public function scopeScheduleTimeFilter(Builder $query, ?AppointmentTimeFilter $filter, Carbon $now): Builder
     {
         return $query
-            ->when($filter === AppointmentTimeFilter::FUTURE, fn (Builder $q) => $q->where('schedule_from', '>=', $now))
-            ->when($filter === AppointmentTimeFilter::PAST,   fn (Builder $q) => $q->where('schedule_from', '<', $now));
+            ->when($filter === AppointmentTimeFilter::FUTURE, fn (Builder $q) => $q->where('schedule_to', '>=', $now))
+            ->when($filter === AppointmentTimeFilter::PAST,   fn (Builder $q) => $q->where('schedule_to', '<', $now));
     }
 
     /**
@@ -415,7 +415,6 @@ class Activity extends Model implements ActivityContract
     public function reOpen():Activity {
         $this->is_done = false;
         $this->status = ActivityStatus::ACTIVE;
-        $this->schedule_from = Carbon::today();
         $this->schedule_to = Carbon::today()->addWeek();
         return $this;
     }

--- a/packages/Webkul/Activity/src/Repositories/ActivityRepository.php
+++ b/packages/Webkul/Activity/src/Repositories/ActivityRepository.php
@@ -93,7 +93,7 @@ class ActivityRepository extends Repository
             'activities.id',
             'activities.created_at',
             'activities.title',
-            'activities.schedule_from as start',
+            'activities.schedule_to as start',
             'activities.schedule_to as end',
             DB::raw(DatabaseHelper::concatUserName('users.', 'user_name')),
         )
@@ -101,7 +101,7 @@ class ActivityRepository extends Repository
             ->leftJoin('users', 'activities.user_id', '=', 'users.id')
             ->leftJoin('groups', 'activities.group_id', '=', 'groups.id')
             ->whereIn('type', ['call', 'meeting', 'task', 'lunch'])
-            ->whereBetween('activities.schedule_from', $dateRange)
+            ->whereBetween('activities.schedule_to', $dateRange)
             ->where(function ($query) {
                 if ($userIds = bouncer()->getAuthorizedUserIds()) {
                     $query->whereIn('activities.user_id', $userIds)

--- a/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
@@ -157,7 +157,6 @@ class ActivityDataGrid extends DataGrid
         $this->addFilter('is_done', 'activities.is_done');
         $this->addFilter('created_by', DB::raw(DatabaseHelper::concatUserName('users.')));
         $this->addFilter('assigned_user_id', 'users.id');
-        $this->addFilter('schedule_from', 'activities.schedule_from');
         $this->addFilter('days_until_deadline', 'days_until_deadline');
         $this->addFilter('lead_pipeline_stage_id', 'leads.lead_pipeline_stage_id');
         $this->addFilter('lead_pipeline_id', 'leads.lead_pipeline_id');
@@ -335,30 +334,6 @@ class ActivityDataGrid extends DataGrid
         // Removed comment column as requested
 
         // Status column removed from UI (kept in DB/entity)
-
-        // Removed 'Oppakken vanaf' column as requested
-
-        // Begin date column (replaces created_at / "Aangemaakt op")
-        $this->addColumn([
-            'index'      => 'schedule_from',
-            'label'      => 'Begindatum',
-            'type'       => 'datetime',
-            'sortable'   => true,
-            'searchable' => true,
-            'filterable' => false,
-            'closure'    => function ($row) {
-                if (empty($row->schedule_from)) {
-                    return 'N/A';
-                }
-
-                $timestamp = strtotime($row->schedule_from);
-                if ($timestamp === false) {
-                    return 'N/A';
-                }
-
-                return date('d-m-Y H:i', $timestamp);
-            },
-        ]);
 
         $this->addColumn([
             'index'      => 'schedule_to',

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -92,7 +92,7 @@ class ActivityController extends Controller
         $activities = $this->activityRepository
             ->where('lead_id', $leadId)
             ->where('is_done', 0)
-            ->orderBy('schedule_from', 'asc')
+            ->orderBy('schedule_to', 'asc')
             ->get();
 
         return response()->json([
@@ -158,8 +158,7 @@ class ActivityController extends Controller
             'type'          => 'required',
             'group_id'      => 'nullable|exists:groups,id',
             'comment'       => 'required_if:type,note',
-            'schedule_from' => 'required_unless:type,note,file',
-            'schedule_to'   => 'required_unless:type,note,file',
+            'schedule_to'   => 'required_unless:type,note,file|date',
             'file'          => 'required_if:type,file',
         ]);
 
@@ -167,6 +166,7 @@ class ActivityController extends Controller
 
         // Auto-assign group if not specified but user has a group
         $data = request()->all();
+        unset($data['schedule_from']);
         logger()->info('Activity store data', $data);
 
         // If lead_id is set, ensure we do not also bind a person via pivot
@@ -316,12 +316,14 @@ class ActivityController extends Controller
         }
 
         $this->validate(request(), [
-            'group_id' => 'required|exists:groups,id',
+            'group_id'    => 'required|exists:groups,id',
+            'schedule_to' => 'nullable|date',
         ]);
 
         Event::dispatch('activity.update.before', $id);
 
         $data = request()->all();
+        unset($data['schedule_from']);
 
         Activity::normalizeForeignKeys($data);
 
@@ -379,7 +381,7 @@ class ActivityController extends Controller
                     $activity->is_done = 0;
                     $didChange = true;
                 }
-                $computed = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, $activity->status);
+                $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
                 if ($computed->value !== $requestedStatus) {
                     // Reject with computed suggestion
                     if (($activity->status?->value ?? null) !== $computed->value) {
@@ -410,7 +412,7 @@ class ActivityController extends Controller
             }
         } else {
             // No explicit flags, keep consistent automatically (respect IN_PROGRESS sticky and DONE sticky via service)
-            $computed = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, $activity->status);
+            $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
             if (($activity->status?->value ?? null) !== $computed->value) {
                 $activity->status = $computed;
                 $didChange = true;
@@ -537,7 +539,7 @@ class ActivityController extends Controller
         Event::dispatch('activity.update.before', $id);
 
         $activity->is_done = 0;
-        $activity->status  = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, null);
+        $activity->status  = ActivityStatusService::computeStatus(null, $activity->schedule_to, null);
         $activity->save();
 
         Event::dispatch('activity.update.after', $activity);
@@ -785,7 +787,7 @@ class ActivityController extends Controller
             }
         } else {
             // Un-done: compute status based on dates
-            $computed = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, ActivityStatus::ACTIVE);
+            $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, ActivityStatus::ACTIVE);
             if (($activity->status?->value ?? null) !== $computed->value) {
                 $activity->status = $computed;
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
@@ -56,21 +56,11 @@ class CallStatusController extends Controller
         if (!empty($validated['reschedule_days'])) {
 
                $days = (int) $validated['reschedule_days'];
-               // Update schedule_from to today plus the specified days
-               $originalFrom = $activity->schedule_from;
-               $originalTo = $activity->schedule_to;
-
-               if ($originalFrom) {
-                   $diff = $originalTo && $originalFrom ? (int) round($originalTo->diffInDays($originalFrom)) : 0;
-                   $activity->schedule_from = now()->addDays($days);
-                   if ($originalTo) {
-                       $activity->schedule_to = $activity->schedule_from->copy()->addDays($diff);
-                   }
-               }
+               $activity->schedule_to = now()->addDays($days);
                 $activity->save();
 
                 // Recompute status after reschedule
-                $computed = ActivityStatusService::computeStatus($activity->schedule_from, $activity->schedule_to, $activity->status);
+                $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
                 if ($computed->value !== ($activity->status?->value ?? null)) {
                     $activity->status = $computed;
                     $activity->save();

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/ActivityController.php
@@ -60,7 +60,6 @@ class ActivityController extends Controller
                 'comment' => 'required_if:type,note',
                 'description' => 'nullable|string',
                 'user_id' => 'nullable|exists:users,id',
-                'schedule_from' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
                 'schedule_to' => 'required_unless:type,note,file|date_format:Y-m-d H:i:s',
                 'file' => 'required_if:type,file',
             ]);
@@ -75,6 +74,7 @@ class ActivityController extends Controller
             $request->request->remove('person_id');
 
             $data = $request->all();
+            unset($data['schedule_from']);
             Activity::normalizeForeignKeys($data);
 
             // Always load the lead for department validation

--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -118,32 +118,20 @@
                         <x-admin::form.control-group.error control-name="type"/>
                     </x-admin::form.control-group>
 
-                    <!-- Schedule Date From/To -->
+                    <!-- Deadline -->
                     <x-admin::form.control-group>
                         @php
-                            $scheduleFromValue = old('schedule_from') ?? optional($activity->schedule_from)->format('Y-m-d\TH:i');
                             $scheduleToValue   = old('schedule_to') ?? optional($activity->schedule_to)->format('Y-m-d\TH:i');
                         @endphp
-                        <div class="flex gap-2 max-sm:flex-wrap">
-                            <x-adminc::components.field
-                                type="datetime"
-                                name="schedule_from"
-                                id="schedule_from"
-                                :label="trans('admin::app.components.activities.actions.activity.schedule-from')"
-                                rules="required"
-                                :value="$scheduleFromValue"
-                                class="w-full"
-                            />
-                            <x-adminc::components.field
-                                type="datetime"
-                                name="schedule_to"
-                                id="schedule_to"
-                                :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
-                                rules="required"
-                                :value="$scheduleToValue"
-                                class="w-full"
-                            />
-                        </div>
+                        <x-adminc::components.field
+                            type="datetime"
+                            name="schedule_to"
+                            id="schedule_to"
+                            :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
+                            rules="required"
+                            :value="$scheduleToValue"
+                            class="w-full"
+                        />
                     </x-admin::form.control-group>
 
                     <!-- Description -->
@@ -244,10 +232,6 @@
 
                 <!-- Footer timestamps -->
                 <div class="flex w-full flex-col gap-2 p-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-800">
-                    <div class="flex justify-between">
-                        <span>Begindatum:</span>
-                        <span>{{ $activity->schedule_from ? \Carbon\Carbon::parse($activity->schedule_from)->format('d-m-Y') : '-' }}</span>
-                    </div>
                     <div class="flex justify-between">
                         <span>Bijgewerkt op:</span>
                         <span>{{ $activity->updated_at->format('d-m-Y') }}</span>

--- a/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/view.blade.php
@@ -113,16 +113,6 @@
 
                     <div class="mb-3">
                         <div
-                            class="text-xs text-gray-400 dark:text-gray-500 mb-1">@lang('admin::app.activities.edit.schedule_from')
-                            :
-                        </div>
-                        <div class="text-sm text-gray-900 dark:text-gray-100">
-                            {{ $activity->schedule_from }}
-                        </div>
-                    </div>
-
-                    <div class="mb-3">
-                        <div
                             class="text-xs text-gray-400 dark:text-gray-500 mb-1">@lang('admin::app.activities.edit.schedule_to')
                             :
                         </div>
@@ -181,13 +171,9 @@
                 </div>
             @endif
 
-            <!-- Footer with begin date and modification date -->
+            <!-- Footer with modification date -->
             <div
                 class="flex w-full flex-col gap-2 p-4 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-800">
-                <div class="flex justify-between">
-                    <span>Begindatum:</span>
-                    <span>{{ $activity->schedule_from ? \Carbon\Carbon::parse($activity->schedule_from)->format('d-m-Y') : '-' }}</span>
-                </div>
                 <div class="flex justify-between">
                     <span>Bijgewerkt op:</span>
                     <span>{{ $activity->updated_at->format('d-m-Y') }}</span>

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/activity.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/activity.blade.php
@@ -141,28 +141,15 @@
                                     @endforeach
                                 </x-adminc::components.field>
 
-                                <!-- Schedule Date -->
-                                <div class="flex gap-4">
-                                    <!-- Started From -->
-                                    <x-adminc::components.field
-                                        type="datetime"
-                                        name="schedule_from"
-                                        :label="trans('admin::app.components.activities.actions.activity.schedule-from')"
-                                        rules="required"
-                                        :value="now()->format('Y-m-d\TH:i')"
-                                        class="w-full"
-                                    />
-
-                                    <!-- Started To -->
-                                    <x-adminc::components.field
-                                        type="datetime"
-                                        name="schedule_to"
-                                        :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
-                                        rules="required"
-                                        :value="now()->addWeeks(2)->format('Y-m-d\TH:i')"
-                                        class="w-full"
-                                    />
-                                </div>
+                                <!-- Deadline -->
+                                <x-adminc::components.field
+                                    type="datetime"
+                                    name="schedule_to"
+                                    :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
+                                    rules="required"
+                                    :value="now()->addWeeks(2)->format('Y-m-d\TH:i')"
+                                    class="w-full"
+                                />
                                 {!! view_render_event('admin.components.activities.actions.activity.form_controls.modal.content.controls.after') !!}
                                 </x-slot>
 
@@ -290,11 +277,7 @@
                         url = `/admin/sales-leads/${this.entity.id}/activities`;
                     }
 
-                    // Format dates to Y-m-d H:i:s format
-                    if (params.schedule_from) {
-                        const fromDate = new Date(params.schedule_from);
-                        params.schedule_from = this.formatDateTime(fromDate);
-                    }
+                    // Format deadline to Y-m-d H:i:s format
                     if (params.schedule_to) {
                         const toDate = new Date(params.schedule_to);
                         params.schedule_to = this.formatDateTime(toDate);

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -39,9 +39,9 @@
     <!-- Activity Details -->
     <div class="flex w-full items-start gap-3 rounded-xl border p-3 transition-all"
         :class="{
-            'border-l-4 border-l-red-500 bg-red-50/30 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from),
+            'border-l-4 border-l-red-500 bg-red-50/30 border-red-200 dark:bg-red-950/20 dark:border-red-900': !activity.is_done && isPastDay(activity.schedule_to),
             'border-l-4 border-l-green-500 bg-green-50/20 border-gray-200 dark:bg-green-950/10 dark:border-gray-800': activity.is_done,
-            'border-l-4 border-l-gray-300 bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': !activity.is_done && !isPastDay(activity.schedule_to || activity.schedule_from)
+            'border-l-4 border-l-gray-300 bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800': !activity.is_done && !isPastDay(activity.schedule_to)
         }">
 
         <!-- Check / Reopen button -->
@@ -95,8 +95,8 @@
                 <template v-if="activity.type !== 'system'">
                     <a class="min-w-0 font-medium hover:underline dark:text-white"
                         :class="{
-                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_from) && !isPastDay(activity.schedule_to || activity.schedule_from),
-                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to || activity.schedule_from)
+                            'text-orange-600 dark:text-orange-400': !activity.is_done && isToday(activity.schedule_to) && !isPastDay(activity.schedule_to),
+                            'text-status-expired-text dark:text-red-400': !activity.is_done && isPastDay(activity.schedule_to)
                         }"
                         :href="(activity.type === 'email'
                             ? {!! $mailViewPatternJs !!}.replace('__FOLDER__', activity.folder_name || 'inbox').replace('__ID__', String(activity.id))
@@ -159,20 +159,17 @@
 
                     <div class="ml-auto flex shrink-0 items-center gap-2">
                         <!-- Deadline pill -->
-                        <template v-if="!activity.is_done && (activity.schedule_from || activity.schedule_to)">
+                        <template v-if="!activity.is_done && activity.schedule_to">
                             <span
                                 class="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap"
-                                :class="isPastDay(activity.schedule_to || activity.schedule_from)
+                                :class="isPastDay(activity.schedule_to)
                                     ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400'
                                     : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'"
                             >
-                                <span v-if="isPastDay(activity.schedule_to || activity.schedule_from)" class="icon-clock text-sm"></span>
+                                <span v-if="isPastDay(activity.schedule_to)" class="icon-clock text-sm"></span>
                                 <span v-else class="icon-calendar text-sm"></span>
-                                <span v-if="activity.schedule_to">
+                                <span>
                                     @{{ $admin.formatDate(activity.schedule_to, 'd MMM yyyy', timezone) }}
-                                </span>
-                                <span v-else>
-                                    @{{ $admin.formatDate(activity.schedule_from, 'd MMM yyyy', timezone) }}
                                 </span>
                             </span>
                         </template>

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -287,7 +287,7 @@
 
                     activityTypeFilter: 'all',
 
-                    showCompleted: true,
+                    showCompleted: false,
 
                     entitySourceBadgeClasses: @json($entitySourceBadgeClasses),
 
@@ -347,8 +347,8 @@
                 countActionNeeded() {
                     return this.activities.filter(activity =>
                         !activity.is_done &&
-                        activity.schedule_from &&
-                        this.isStartedOrToday(activity.schedule_from)
+                        activity.schedule_to &&
+                        this.isDueTodayOrPastDay(activity.schedule_to)
                     ).length;
                 },
 
@@ -368,15 +368,15 @@
                     if (this.selectedType === 'action_needed') {
                         let filtered = this.activities.filter(activity =>
                             !activity.is_done &&
-                            activity.schedule_from &&
-                            this.isStartedOrToday(activity.schedule_from)
+                            activity.schedule_to &&
+                            this.isDueTodayOrPastDay(activity.schedule_to)
                         );
                         if (this.activityTypeFilter !== 'all') {
                             filtered = filtered.filter(activity => activity.type === this.activityTypeFilter);
                         }
                         return filtered.sort((a, b) => {
-                            const aTime = a.schedule_from ? new Date(a.schedule_from).getTime() : Infinity;
-                            const bTime = b.schedule_from ? new Date(b.schedule_from).getTime() : Infinity;
+                            const aTime = a.schedule_to ? new Date(a.schedule_to).getTime() : Infinity;
+                            const bTime = b.schedule_to ? new Date(b.schedule_to).getTime() : Infinity;
                             return aTime - bTime;
                         });
                     }
@@ -441,8 +441,8 @@
                     if (!a.is_done && b.is_done) return -1;
                     if (a.is_done && !b.is_done) return 1;
                     if (!a.is_done && !b.is_done) {
-                        const aDeadline = a.schedule_to || a.schedule_from;
-                        const bDeadline = b.schedule_to || b.schedule_from;
+                        const aDeadline = a.schedule_to;
+                        const bDeadline = b.schedule_to;
                         if (aDeadline && bDeadline) return new Date(aDeadline) - new Date(bDeadline);
                         if (aDeadline) return -1;
                         if (bDeadline) return 1;
@@ -638,7 +638,7 @@
                     return new Date(dateStr).getTime() < Date.now();
                 },
 
-                isStartedOrToday(dateStr) {
+                isDueTodayOrPastDay(dateStr) {
                     if (!dateStr) return false;
                     const d = new Date(dateStr);
                     const startOfDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());

--- a/packages/Webkul/Admin/src/Resources/views/dashboard/operational/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/dashboard/operational/index.blade.php
@@ -191,11 +191,6 @@
                                                 <template v-else-if="column.index === 'assigned_user_id'">
                                                     <div v-html="record.assigned_user_id"></div>
                                                 </template>
-                                                <template v-else-if="column.index === 'schedule_from'">
-                                                    <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                        @{{ record.schedule_from }}
-                                                    </p>
-                                                </template>
                                                 <template v-else>
                                                     <div
                                                         class="text-sm"

--- a/tests/Feature/ActivityStatusTest.php
+++ b/tests/Feature/ActivityStatusTest.php
@@ -12,7 +12,8 @@ test('it computes status based on dates', function () {
 
     expect(ActivityStatusService::computeStatus($now->copy()->subHour(), $now->copy()->addHour()))->toBe(ActivityStatus::ACTIVE)
         ->and(ActivityStatusService::computeStatus($now->copy()->subDays(2), $now->copy()->subDay()))->toBe(ActivityStatus::EXPIRED)
-        ->and(ActivityStatusService::computeStatus($now->copy()->addDay(), $now->copy()->addDays(2)))->toBe(ActivityStatus::ON_HOLD)
+        ->and(ActivityStatusService::computeStatus($now->copy()->addDay(), $now->copy()->addDays(2)))->toBe(ActivityStatus::ACTIVE)
+        ->and(ActivityStatusService::computeStatus($now->copy()->addDay(), null))->toBe(ActivityStatus::ACTIVE)
         ->and(ActivityStatusService::computeStatus($now->copy()->subDay(), $now->copy()->addDay(), ActivityStatus::IN_PROGRESS))->toBe(ActivityStatus::IN_PROGRESS);
 });
 

--- a/tests/Feature/ActivityStoreTest.php
+++ b/tests/Feature/ActivityStoreTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Enums\Departments;
 use App\Models\Department;
 use Database\Seeders\TestSeeder;
+use Webkul\Activity\Models\Activity;
 use Webkul\Lead\Models\Lead;
 use Webkul\User\Models\Group;
 use Webkul\User\Models\User;
@@ -31,7 +32,6 @@ test('test fields with storing activities', function () {
         'title'         => 'Test activity',
         'description'   => 'This is a test activity description.',
         'type'          => 'task',
-        'schedule_from' => now()->format('Y-m-d H:i:s'),
         'schedule_to'   => now()->addHour()->format('Y-m-d H:i:s'),
         // Don't provide group_id - should be auto-determined from lead's department
     ];
@@ -44,10 +44,11 @@ test('test fields with storing activities', function () {
 
     // Assert
     $this->assertDatabaseHas('activities', [
-        'title'    => 'Test activity',
-        'comment'  => 'This is a test activity description.',
-        'group_id' => $expectedGroup->id, // Should be auto-determined from lead's department
-        'lead_id'  => $lead->id,
+        'title'         => 'Test activity',
+        'comment'       => 'This is a test activity description.',
+        'group_id'      => $expectedGroup->id, // Should be auto-determined from lead's department
+        'lead_id'       => $lead->id,
+        'schedule_from' => null,
     ]);
 });
 
@@ -117,8 +118,49 @@ test('accept activity when provided group_id matches lead department', function 
     // Assert
     $response->assertStatus(200);
     $this->assertDatabaseHas('activities', [
-        'title'    => 'Matching Group Activity',
-        'group_id' => $matchingGroup->id,
-        'lead_id'  => $lead->id,
+        'title'         => 'Matching Group Activity',
+        'group_id'      => $matchingGroup->id,
+        'lead_id'       => $lead->id,
+        'schedule_from' => null,
     ]);
+});
+
+test('edit form and update only expose managed deadline', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $group = Group::query()->firstOrFail();
+    $originalScheduleFrom = now()->subDays(5)->startOfMinute();
+    $newScheduleTo = now()->addDays(3)->startOfMinute();
+
+    $activity = Activity::create([
+        'title'         => 'Deadline only activity',
+        'type'          => 'task',
+        'schedule_from' => $originalScheduleFrom,
+        'schedule_to'   => now()->addDay()->startOfMinute(),
+        'group_id'      => $group->id,
+        'user_id'       => $user->id,
+        'is_done'       => 0,
+    ]);
+
+    $this->get(route('admin.activities.edit', $activity->id))
+        ->assertOk()
+        ->assertDontSee('name="schedule_from"', false)
+        ->assertSee('name="schedule_to"', false);
+
+    $response = $this->put(route('admin.activities.update', $activity->id), [
+        'title'         => $activity->title,
+        'type'          => 'task',
+        'schedule_from' => now()->addYear()->format('Y-m-d H:i:s'),
+        'schedule_to'   => $newScheduleTo->format('Y-m-d H:i:s'),
+        'group_id'      => $group->id,
+        'user_id'       => $user->id,
+    ]);
+
+    $response->assertRedirect(route('admin.activities.index'));
+
+    $activity->refresh();
+
+    expect($activity->schedule_from->equalTo($originalScheduleFrom))->toBeTrue()
+        ->and($activity->schedule_to->equalTo($newScheduleTo))->toBeTrue();
 });

--- a/tests/Feature/CallStatusControllerTest.php
+++ b/tests/Feature/CallStatusControllerTest.php
@@ -50,7 +50,7 @@ test('spoken does not reschedule activity', function () {
 
     $response->assertOk();
     $activity->refresh();
-    $this->assertTrue($activity->schedule_from->isToday());
+    $this->assertTrue($activity->schedule_to->isTomorrow());
 });
 
 test('not spoken defaults to 7 days when empty', function () {
@@ -92,7 +92,8 @@ test('not spoken defaults to 7 days when empty', function () {
 
     $response->assertOk();
     $activity->refresh();
-    $this->assertTrue($activity->schedule_from->isSameDay(now()->addDays(7)));
+    $this->assertTrue($activity->schedule_to->isSameDay(now()->addDays(7)));
+    $this->assertTrue($activity->schedule_from->isToday());
 });
 
 test('call status with send_email returns email data', function () {

--- a/tests/Feature/Import/ImportLeadsFromSugarCRMTest.php
+++ b/tests/Feature/Import/ImportLeadsFromSugarCRMTest.php
@@ -853,7 +853,7 @@ test('imports call activities from sugarcrm', function () {
         ->and($activity2->type)->toBe(ActivityType::CALL)
         ->and($activity2->comment)->toBe('Follow-up gesprek')
         ->and($activity2->is_done)->toBe(false) // 'planned' status should map to not done
-        ->and($activity2->status)->toBe(ActivityStatusService::computeStatus($activity2->schedule_from, $activity2->schedule_to, ActivityStatus::ACTIVE))
+        ->and($activity2->status)->toBe(ActivityStatusService::computeStatus(null, $activity2->schedule_to, ActivityStatus::ACTIVE))
         ->and($activity2->additional['direction'])->toBe('outbound')
         ->and($activity2->additional['status'])->toBe('planned')
         ->and($activity2->additional['belgroep'])->toBe('follow-up');

--- a/tests/Feature/SalesLeadActivityStoreTest.php
+++ b/tests/Feature/SalesLeadActivityStoreTest.php
@@ -37,7 +37,6 @@ test('creating activity on sales lead stores sales_lead_id and appears as planne
         'type'          => 'task',
         'title'         => 'My Planned Task',
         'description'   => 'Test',
-        'schedule_from' => $now->format('Y-m-d H:i:s'),
         'schedule_to'   => $now->copy()->addHour()->format('Y-m-d H:i:s'),
     ];
 
@@ -49,6 +48,7 @@ test('creating activity on sales lead stores sales_lead_id and appears as planne
         'title'         => 'My Planned Task',
         'sales_lead_id' => $salesLead->id,
         'is_done'       => 0,
+        'schedule_from' => null,
     ]);
 
     // Fetch activities endpoint and ensure the item is returned


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
,

## Description
- Use `schedule_to` as the managed activity deadline for status computation, action-needed filtering, sorting, highlighting, and deadline display.
- Remove `schedule_from` from activity create/edit UI and ignore submitted `schedule_from` values in admin/API create/update handlers while keeping the column/resource field available.
- Update activity store/status/call-status tests for deadline-only behavior.

## How To Test This?
- `vendor/bin/duster fix --dirty`
- `php -l` on changed PHP files
- `npm ci && npm run build` in `packages/Webkul/Admin`
- `vendor/bin/pest tests/Feature/ActivityStatusTest.php tests/Feature/ActivityStoreTest.php tests/Feature/CallStatusControllerTest.php tests/Feature/SalesLeadActivityStoreTest.php --filter='status|activity|spoken|sales'` currently fails before app code because this Cloud image only provides PHP 8.3 while the installed dependencies use PHP 8.4 syntax (`vendor/symfony/var-dumper/Cloner/VarCloner.php`).

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master
- Target branch for this PR: `feat_activity`

## Tailwind Reordering
- Duster was run successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-165af169-ed6c-4c78-bc49-f276faf9a1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-165af169-ed6c-4c78-bc49-f276faf9a1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

