### PR TITLE
fix: move email to Verwerkt when linking via AI suggestion (MBS-232)

### DIFF
--- a/app/Http/Controllers/Admin/MailEmailLlmController.php
+++ b/app/Http/Controllers/Admin/MailEmailLlmController.php
@@ -58,6 +58,8 @@ class MailEmailLlmController extends Controller
 
         $this->emailRepository->update($validated['links'], $email->id);
 
+        $this->emailRepository->moveToProcessedIfInbox($email->id);
+
         $email = $this->emailRepository
             ->with(['person', 'lead', 'salesLead', 'clinic', 'order'])
             ->findOrFail($id);

--- a/tests/Feature/Mail/MailEmailLlmControllerTest.php
+++ b/tests/Feature/Mail/MailEmailLlmControllerTest.php
@@ -5,7 +5,9 @@ use App\Models\SalesLead;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Webkul\Contact\Models\Person;
+use Webkul\Email\Enums\EmailFolderEnum;
 use Webkul\Email\Models\Email;
+use Webkul\Email\Models\Folder;
 use Webkul\Lead\Models\Pipeline;
 use Webkul\Lead\Models\Stage;
 use Webkul\User\Models\Role;
@@ -167,4 +169,83 @@ test('manual llm extraction returns metadata when no match found', function () {
     $response->assertOk()
         ->assertJsonPath('result.status', 'no_match')
         ->assertJsonPath('result.senders.0.email', 'unknown@example.com');
+});
+
+test('apply suggestion moves email from inbox to Verwerkt folder', function () {
+    $inboxFolder = Folder::create([
+        'name'         => EmailFolderEnum::INBOX->value,
+        'parent_id'    => null,
+        'order'        => 1,
+        'is_deletable' => false,
+    ]);
+
+    $verwerktFolder = Folder::create([
+        'name'         => EmailFolderEnum::PROCESSED->value,
+        'parent_id'    => null,
+        'order'        => 3,
+        'is_deletable' => false,
+    ]);
+
+    $person = Person::factory()->create();
+
+    $email = Email::create([
+        'subject'   => 'Order bevestiging',
+        'from'      => ['name' => 'Patient', 'email' => 'patient@example.com'],
+        'reply'     => 'Body',
+        'folder_id' => $inboxFolder->id,
+    ]);
+
+    $response = $this->actingAs(test()->admin, 'user')
+        ->postJson(route('admin.mail.apply_suggestion', $email->id), [
+            'links' => ['person_id' => $person->id],
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('message', 'E-mail gekoppeld.');
+
+    expect($email->fresh()->folder_id)->toBe($verwerktFolder->id)
+        ->and($email->fresh()->person_id)->toBe($person->id);
+});
+
+test('apply suggestion with order link moves email from inbox to Verwerkt folder', function () {
+    $inboxFolder = Folder::create([
+        'name'         => EmailFolderEnum::INBOX->value,
+        'parent_id'    => null,
+        'order'        => 1,
+        'is_deletable' => false,
+    ]);
+
+    $verwerktFolder = Folder::create([
+        'name'         => EmailFolderEnum::PROCESSED->value,
+        'parent_id'    => null,
+        'order'        => 3,
+        'is_deletable' => false,
+    ]);
+
+    $pipeline = Pipeline::first() ?? Pipeline::create([
+        'name'        => 'Default Pipeline',
+        'is_default'  => 1,
+        'rotten_days' => 30,
+    ]);
+    $activeStage = Stage::factory()->create(['lead_pipeline_id' => $pipeline->id]);
+
+    $order = Order::factory()->create(['pipeline_stage_id' => $activeStage->id]);
+
+    $email = Email::create([
+        'subject'   => 'Order bevestiging',
+        'from'      => ['name' => 'Patient', 'email' => 'patient@example.com'],
+        'reply'     => 'Body',
+        'folder_id' => $inboxFolder->id,
+    ]);
+
+    $response = $this->actingAs(test()->admin, 'user')
+        ->postJson(route('admin.mail.apply_suggestion', $email->id), [
+            'links' => ['order_id' => $order->id],
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('message', 'E-mail gekoppeld.');
+
+    expect($email->fresh()->folder_id)->toBe($verwerktFolder->id)
+        ->and($email->fresh()->order_id)->toBe($order->id);
 });


### PR DESCRIPTION
## Summary

- **Bug**: Clicking 'Koppelen' on an AI-suggested order/entity in the mailbox did not remove the email from the inbox — the email stayed open in the mailbox and the user had to manually re-link.
- **Root cause**: `MailEmailLlmController::applySuggestion()` called `emailRepository->update()` with the entity link but never called `moveToProcessedIfInbox()`. The regular `EmailController::update()` route *does* call this via `moveToProcessedIfLinked()`, so manual linking worked correctly.
- **Fix**: Added `$this->emailRepository->moveToProcessedIfInbox($email->id)` in `applySuggestion()` after the update, matching the behavior of the regular update endpoint.

## Files changed

- `app/Http/Controllers/Admin/MailEmailLlmController.php` — one line added
- `tests/Feature/Mail/MailEmailLlmControllerTest.php` — two new tests covering person link and order link via `applySuggestion`

## Test plan

- [ ] Verify email in inbox is moved to 'Verwerkt' when clicking 'Koppelen' on an AI suggestion
- [ ] Verify email in inbox is moved to 'Verwerkt' when linking an order via AI suggestion
- [ ] Verify manual linking (via `v-entity-linker`) still works as before
- [ ] Run `php artisan test tests/Feature/Mail/MailEmailLlmControllerTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)