### PR TITLE
feat: add inline organisation create from lookup (MBS-238)

### DIFF
--- a/resources/views/adminc/components/entity-selector.blade.php
+++ b/resources/views/adminc/components/entity-selector.blade.php
@@ -81,6 +81,7 @@
                         <div v-if="search.length >= 2 && !isSearching && suggestions.length === 0" class="p-3 border rounded bg-activity-note-bg border-activity-note-border" v-show="canAddNew">
                             <div class="text-center">
                                 <div class="text-sm text-blue-700 mb-2">Geen resultaten voor "{{ search }}"</div>
+                                <button type="button" @click="emitCreateNew" class="mt-1 text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline">+ Nieuwe aanmaken</button>
                             </div>
                         </div>
                     </div>

--- a/resources/views/adminc/components/order-org-section.blade.php
+++ b/resources/views/adminc/components/order-org-section.blade.php
@@ -28,15 +28,81 @@
                     placeholder="Zoek organisatie..."
                     :search-route="searchRoute"
                     :items="selectedOrg ? [selectedOrg] : []"
-                    :can-add-new="false"
+                    :can-add-new="true"
                     @select="selectedOrg = $event"
                     @remove="selectedOrg = null"
+                    @create-new="onCreateNew"
                 ></v-entity-selector>
-                <p v-if="isBusiness == '1' && !selectedOrg" class="text-xs text-red-500 mt-1">Organisatie is verplicht bij zakelijke order.</p>
+                <p v-if="isBusiness == '1' && !selectedOrg && !showOrgForm" class="text-xs text-red-500 mt-1">Organisatie is verplicht bij zakelijke order.</p>
+
+                <!-- Inline new organisation form -->
+                <div v-if="showOrgForm" class="mt-2 bg-gray-50 border border-gray-200 rounded-lg p-4 dark:bg-gray-800 dark:border-gray-700">
+                    <p class="text-sm font-semibold text-gray-800 dark:text-white mb-3">Nieuwe organisatie aanmaken</p>
+                    <div class="grid grid-cols-1 gap-3">
+                        <div class="flex flex-col gap-1">
+                            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Naam <span class="text-red-500">*</span></label>
+                            <input type="text" v-model="newOrgName" placeholder="Organisatienaam"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                        </div>
+                        <div class="grid grid-cols-2 gap-3">
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Postcode <span class="text-red-500">*</span></label>
+                                <input type="text" v-model="newOrgPostal" placeholder="1234 AB"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Huisnummer <span class="text-red-500">*</span></label>
+                                <input type="text" v-model="newOrgHouseNumber" placeholder="123"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-2 gap-3">
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Toevoeging</label>
+                                <input type="text" v-model="newOrgSuffix" placeholder="A"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Straat</label>
+                                <input type="text" v-model="newOrgStreet" placeholder="Straatnaam"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-2 gap-3">
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Stad</label>
+                                <input type="text" v-model="newOrgCity" placeholder="Amsterdam"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Land</label>
+                                <input type="text" v-model="newOrgCountry" placeholder="Nederland"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-2 mt-4">
+                        <button type="button" @click="cancelOrgForm"
+                                class="px-4 py-2 bg-gray-500 text-white text-sm font-medium rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500">
+                            Annuleren
+                        </button>
+                        <button type="button" @click="saveOrgForm" :disabled="isSavingOrg"
+                                class="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-60 disabled:cursor-not-allowed">
+                            <span v-if="isSavingOrg">Opslaan...</span>
+                            <span v-else>Organisatie opslaan</span>
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     </script>
+@endverbatim
 
+<script>
+window.__orderOrgSectionStoreUrl = '{{ route("admin.contacts.organizations.store") }}';
+</script>
+
+@verbatim
     <script type="module">
         (function () {
             const app = window.app;
@@ -74,6 +140,15 @@
                     return {
                         isBusiness: this.initialIsBusiness ? '1' : '0',
                         selectedOrg: this.normalizeOrgProp(this.initialOrg),
+                        showOrgForm: false,
+                        newOrgName: '',
+                        newOrgPostal: '',
+                        newOrgHouseNumber: '',
+                        newOrgSuffix: '',
+                        newOrgStreet: '',
+                        newOrgCity: '',
+                        newOrgCountry: 'Nederland',
+                        isSavingOrg: false,
                     };
                 },
                 methods: {
@@ -82,6 +157,7 @@
                         this.isBusiness = on ? '1' : '0';
                         if (! on) {
                             this.selectedOrg = null;
+                            this.cancelOrgForm();
                         } else if (! this.selectedOrg && this.hintOrg) {
                             const h = this.normalizeOrgProp(this.hintOrg);
                             if (h) {
@@ -101,6 +177,76 @@
                             id,
                             name: value.name ?? value.label ?? value.text ?? String(id),
                         };
+                    },
+                    onCreateNew({ query }) {
+                        this.newOrgName = query || '';
+                        this.showOrgForm = true;
+                    },
+                    cancelOrgForm() {
+                        this.showOrgForm = false;
+                        this.newOrgName = '';
+                        this.newOrgPostal = '';
+                        this.newOrgHouseNumber = '';
+                        this.newOrgSuffix = '';
+                        this.newOrgStreet = '';
+                        this.newOrgCity = '';
+                        this.newOrgCountry = 'Nederland';
+                        this.isSavingOrg = false;
+                    },
+                    async saveOrgForm() {
+                        if (!this.newOrgName.trim()) {
+                            alert('Vul een organisatienaam in.');
+                            return;
+                        }
+                        if (!this.newOrgPostal.trim()) {
+                            alert('Vul een postcode in.');
+                            return;
+                        }
+                        if (!this.newOrgHouseNumber.trim()) {
+                            alert('Vul een huisnummer in.');
+                            return;
+                        }
+
+                        this.isSavingOrg = true;
+                        try {
+                            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+                            const formData = new FormData();
+                            formData.append('name', this.newOrgName.trim());
+                            formData.append('address[postal_code]', this.newOrgPostal.trim());
+                            formData.append('address[house_number]', this.newOrgHouseNumber.trim());
+                            formData.append('address[house_number_suffix]', this.newOrgSuffix.trim());
+                            formData.append('address[street]', this.newOrgStreet.trim());
+                            formData.append('address[city]', this.newOrgCity.trim());
+                            formData.append('address[country]', this.newOrgCountry.trim() || 'Nederland');
+                            if (csrfToken) formData.append('_token', csrfToken);
+
+                            const response = await fetch(window.__orderOrgSectionStoreUrl, {
+                                method: 'POST',
+                                body: formData,
+                                headers: {
+                                    'X-Requested-With': 'XMLHttpRequest',
+                                    'X-CSRF-TOKEN': csrfToken,
+                                },
+                            });
+
+                            const result = await response.json();
+
+                            if (response.ok && result.data) {
+                                this.selectedOrg = { id: result.data.id, name: result.data.name };
+                                this.cancelOrgForm();
+
+                                const emitter = window.app?.config?.globalProperties?.$emitter || window.app?.$emitter;
+                                if (emitter) {
+                                    emitter.emit('add-flash', { type: 'success', message: 'Organisatie aangemaakt en geselecteerd!' });
+                                }
+                            } else {
+                                alert('Fout: ' + (result.message || 'Onbekende fout bij aanmaken organisatie.'));
+                            }
+                        } catch (err) {
+                            alert('Fout bij opslaan: ' + err.message);
+                        } finally {
+                            this.isSavingOrg = false;
+                        }
                     },
                 },
             });


### PR DESCRIPTION
## Summary

- **entity-selector**: When `canAddNew=true` and search yields no results, now shows a `+ Nieuwe aanmaken` button that emits `create-new` to the parent component
- **order-org-section**: Enabled `canAddNew=true` on the organisation selector; handles the `create-new` event by showing an inline form (naam, postcode, huisnummer, toevoeging, straat, stad, land). On save, calls the existing organisations store API and auto-selects the created organisation
- **leads**: The `organization-vue.blade.php` already had `:can-add-new="true"` and `@create-new` wired — the entity-selector button now activates this flow too

## Test plan
- [ ] Order bewerken → zakelijk aan → zoek een niet-bestaande organisatie → "Geen resultaten" block toont "+ Nieuwe aanmaken"
- [ ] Klik "+ Nieuwe aanmaken" → inline formulier verschijnt met naam prefilled van zoekterm
- [ ] Vul naam + postcode + huisnummer in → opslaan → organisatie wordt aangemaakt en direct geselecteerd
- [ ] Annuleren sluit formulier zonder aanmaken
- [ ] Validatie: naam/postcode/huisnummer zijn verplicht
- [ ] Lead bewerken → organisatie lookup → zelfde "+ Nieuwe aanmaken" knop werkt

Closes MBS-238

🤖 Generated with [Claude Code](https://claude.com/claude-code)