### PR TITLE
feat: rapportage upload - persoon selectie, portaal delen en meerdere bestanden

### DIFF
--- a/app/Http/Controllers/Admin/Settings/OrderController.php
+++ b/app/Http/Controllers/Admin/Settings/OrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin\Settings;
 
+use App\Actions\Activities\CreatePatientMessageFromActivityAction;
 use App\DataGrids\Settings\OrderDataGrid;
 use App\Enums\ActivityType;
 use App\Enums\AfbDispatchStatus;
@@ -1159,45 +1160,77 @@ class OrderController extends SimpleEntityController
     }
 
     /**
-     * Upload a report file: create a file Activity linked to order + clinic, and mark selected checks as done.
+     * Upload report file(s): create a file Activity per file linked to order + clinic, and mark selected checks as done.
      */
     public function storeReport(Request $request, int $orderId): JsonResponse
     {
         $request->validate([
-            'file'        => 'required|file|max:20480',
-            'clinic_id'   => 'required|integer|exists:clinics,id',
-            'check_ids'   => 'required|array|min:1',
-            'check_ids.*' => 'integer|exists:order_checks,id',
-            'title'       => 'nullable|string|max:255',
-            'comment'     => 'nullable|string',
+            'files'            => 'required|array|min:1',
+            'files.*'          => 'file|max:20480',
+            'clinic_id'        => 'required|integer|exists:clinics,id',
+            'check_ids'        => 'required|array|min:1',
+            'check_ids.*'      => 'integer|exists:order_checks,id',
+            'title'            => 'nullable|string|max:255',
+            'comment'          => 'nullable|string',
+            'publish_to_portal' => 'nullable|boolean',
+            'person_ids'       => 'nullable|array',
+            'person_ids.*'     => 'integer|exists:persons,id',
         ]);
 
         $order = $this->orderRepository->findOrFail($orderId);
 
         $activityRepository = app(ActivityRepository::class);
 
-        $file = $request->file('file');
-        $title = $request->input('title') ?: $file->getClientOriginalName();
+        $publishToPortal = filter_var($request->input('publish_to_portal', false), FILTER_VALIDATE_BOOLEAN);
+        $personIds = array_filter(array_map('intval', (array) $request->input('person_ids', [])));
 
-        $activity = $activityRepository->create([
-            'type'      => ActivityType::FILE,
-            'title'     => $title,
-            'comment'   => $request->input('comment'),
-            'is_done'   => true,
-            'user_id'   => auth()->id(),
-            'order_id'  => $order->id,
-            'clinic_id' => $request->input('clinic_id'),
-            'file'      => $file,
-        ]);
+        $files = $request->file('files');
+        $baseTitle = $request->input('title', '');
+        $lastActivity = null;
+
+        foreach ($files as $file) {
+            $title = count($files) > 1
+                ? ($baseTitle ? "{$baseTitle} – {$file->getClientOriginalName()}" : $file->getClientOriginalName())
+                : ($baseTitle ?: $file->getClientOriginalName());
+
+            $activity = $activityRepository->create([
+                'type'      => ActivityType::FILE,
+                'title'     => $title,
+                'comment'   => $request->input('comment'),
+                'is_done'   => true,
+                'user_id'   => auth()->id(),
+                'order_id'  => $order->id,
+                'clinic_id' => $request->input('clinic_id'),
+                'file'      => $file,
+            ]);
+
+            if ($publishToPortal) {
+                $resolvedPersonIds = ! empty($personIds)
+                    ? $personIds
+                    : $activity->getPatientsFromActivity()->pluck('id')->all();
+
+                if (! empty($resolvedPersonIds)) {
+                    $activity->syncPortalPersons($resolvedPersonIds);
+                    CreatePatientMessageFromActivityAction::notifyPortalPersons($activity);
+                }
+            }
+
+            $lastActivity = $activity;
+        }
 
         $checkIds = $request->input('check_ids', []);
         OrderCheck::where('order_id', $orderId)
             ->whereIn('id', $checkIds)
             ->update(['done' => true]);
 
+        $count = count($files);
+        $message = $count > 1
+            ? "{$count} rapportages succesvol geüpload en checks afgevinkt."
+            : 'Rapportage succesvol geüpload en checks afgevinkt.';
+
         return response()->json([
-            'data'    => new ActivityResource($activity),
-            'message' => 'Rapportage succesvol geüpload en checks afgevinkt.',
+            'data'    => new ActivityResource($lastActivity),
+            'message' => $message,
         ]);
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/report.blade.php
@@ -110,14 +110,15 @@
                                 </div>
                             </div>
 
-                            <!-- File input -->
+                            <!-- File input (multiple) -->
                             <x-adminc::components.field
                                 type="file"
                                 id="report_file"
-                                name="file"
-                                label="Bestand"
+                                name="files"
+                                label="Bestand(en)"
                                 rules="required"
                                 class="!mb-0"
+                                multiple
                             />
 
                             <!-- Comment -->
@@ -126,6 +127,44 @@
                                 name="comment"
                                 label="Opmerking (optioneel)"
                             />
+
+                            <!-- Publiceren in patiëntportaal -->
+                            <div class="mt-4">
+                                <label class="flex cursor-pointer items-center gap-2">
+                                    <input
+                                        type="checkbox"
+                                        v-model="publishToPortal"
+                                        @change="onPublishChange"
+                                        class="h-4 w-4 shrink-0 rounded border-gray-300"
+                                    />
+                                    <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Publiceren in patiëntportaal
+                                    </span>
+                                </label>
+
+                                <div v-if="publishToPortal" class="mt-3">
+                                    <div v-if="loadingPersons" class="text-sm text-gray-500">
+                                        Personen laden...
+                                    </div>
+                                    <div v-else-if="persons.length > 1">
+                                        <label class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                            Deel met persoon
+                                        </label>
+                                        <select
+                                            v-model="selectedPersonId"
+                                            class="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                                        >
+                                            <option value="" disabled>Selecteer een persoon</option>
+                                            <option v-for="person in persons" :key="person.id" :value="person.id">
+                                                @{{ person.name }}
+                                            </option>
+                                        </select>
+                                    </div>
+                                    <div v-else-if="!loadingPersons && persons.length === 1" class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                        Wordt gedeeld met: <span class="font-medium">@{{ persons[0].name }}</span>
+                                    </div>
+                                </div>
+                            </div>
                         </x-slot>
 
                         <x-slot:footer>
@@ -162,6 +201,10 @@
                     checks: [],
                     selectedClinicId: '',
                     selectedCheckIds: [],
+                    publishToPortal: false,
+                    persons: [],
+                    selectedPersonId: '',
+                    loadingPersons: false,
                 };
             },
 
@@ -171,8 +214,36 @@
                     this.selectedCheckIds = [];
                     this.clinics = [];
                     this.checks = [];
+                    this.publishToPortal = false;
+                    this.persons = [];
+                    this.selectedPersonId = '';
                     this.$refs.reportUploadModal.open();
                     this.fetchData();
+                },
+
+                onPublishChange() {
+                    this.persons = [];
+                    this.selectedPersonId = '';
+
+                    if (!this.publishToPortal) {
+                        return;
+                    }
+
+                    this.loadingPersons = true;
+
+                    this.$axios.get("{{ route('admin.activities.persons-for-entity') }}", {
+                        params: { entity_type: 'order', entity_id: this.entity.id }
+                    }).then(response => {
+                        this.persons = response.data.data ?? [];
+
+                        if (this.persons.length === 1) {
+                            this.selectedPersonId = this.persons[0].id;
+                        }
+                    }).catch(() => {
+                        this.persons = [];
+                    }).finally(() => {
+                        this.loadingPersons = false;
+                    });
                 },
 
                 fetchData() {
@@ -211,7 +282,7 @@
                         if (value === null || value === undefined) return;
                         if (key === 'clinic_id') return;
                         if (value instanceof FileList) {
-                            Array.from(value).forEach(f => formData.append(key, f));
+                            Array.from(value).forEach(f => formData.append('files[]', f));
                         } else if (value instanceof File || value instanceof Blob) {
                             formData.append(key, value);
                         } else {
@@ -224,6 +295,12 @@
                     this.selectedCheckIds.forEach(id => {
                         formData.append('check_ids[]', String(id));
                     });
+
+                    formData.set('publish_to_portal', this.publishToPortal ? '1' : '0');
+
+                    if (this.publishToPortal && this.selectedPersonId) {
+                        formData.append('person_ids[]', String(this.selectedPersonId));
+                    }
 
                     const url = '{{ route("admin.orders.report-upload.store", ":id") }}'.replace(':id', this.entity.id);
 


### PR DESCRIPTION
## Summary

Fixes MBS-249 — bij het uploaden van rapportages kon geen persoon geselecteerd worden en konden geen meerdere bestanden tegelijk worden geüpload.

**Wijzigingen:**
- Checkbox "Publiceren in patiëntportaal" toegevoegd aan het rapportage upload modal
- Persoon-selector toegevoegd (via bestaande `persons-for-entity` API) wanneer portaal delen is aangevinkt; bij 1 persoon auto-geselecteerd
- Bestandsinput ondersteunt nu meerdere bestanden tegelijk (`multiple`)
- Backend: valideert `files[]`, `publish_to_portal` en `person_ids[]`; maakt per bestand een activiteit aan; synchroniseert portaal-personen en verstuurt notificatie

Werkt vergelijkbaar met stap 2 van "Afspraak bevestigen".

## Test plan
- [ ] Open een order met meerdere personen → klik "Rapportage" → vink "Publiceren in patiëntportaal" aan → persoon-selector verschijnt
- [ ] Selecteer meerdere bestanden tegelijk → upload → activiteiten worden aangemaakt per bestand
- [ ] Bij 1 persoon wordt deze automatisch geselecteerd, geen keuzelijst nodig
- [ ] Portaal-notificatie wordt verstuurd naar geselecteerde persoon(en)
- [ ] Checks worden correct afgevinkt na upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)