### PR TITLE
Make completed activities read-only

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityActionController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityActionController.php
@@ -18,7 +18,11 @@ class ActivityActionController extends Controller
 
     public function store(Request $request, int $activityId): JsonResponse
     {
-        $this->activityRepository->findOrFail($activityId);
+        $activity = $this->activityRepository->findOrFail($activityId);
+
+        if ($activity->is_done) {
+            return $this->completedActivityResponse();
+        }
 
         $validated = $request->validate([
             'type'            => 'required|in:notitie,belstatus',
@@ -52,7 +56,6 @@ class ActivityActionController extends Controller
 
         // Apply reschedule when belstatus
         if ($rescheduleDays !== null) {
-            $activity = $this->activityRepository->findOrFail($activityId);
             $originalFrom = $activity->schedule_from;
             $originalTo   = $activity->schedule_to;
 
@@ -98,6 +101,12 @@ class ActivityActionController extends Controller
 
     public function destroy(int $activityId, int $actionId): JsonResponse
     {
+        $activity = $this->activityRepository->findOrFail($activityId);
+
+        if ($activity->is_done) {
+            return $this->completedActivityResponse();
+        }
+
         $action = ActivityAction::where('activity_id', $activityId)->findOrFail($actionId);
 
         if ($action->created_by !== auth()->guard('user')->id()) {
@@ -126,5 +135,12 @@ class ActivityActionController extends Controller
         }
 
         return $activity->lead?->findDefaultEmail();
+    }
+
+    private function completedActivityResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Deze activiteit is afgerond. Heropen de activiteit om acties te wijzigen.',
+        ], 422);
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -271,6 +271,10 @@ class ActivityController extends Controller
         // Get the current activity to check permissions
         $activity = $this->activityRepository->findOrFail($id);
 
+        if ($activity->is_done) {
+            return $this->completedActivityResponse();
+        }
+
         // Check if user_id is being changed and if user has permission
         if (request()->has('user_id') && request('user_id') != $activity->user_id) {
             $currentUser = auth()->guard('user')->user();
@@ -812,6 +816,12 @@ class ActivityController extends Controller
     {
         $activity = $this->activityRepository->findOrFail($id);
 
+        if ($activity->is_done) {
+            return response()->json([
+                'message' => 'Deze activiteit is afgerond. Heropen de activiteit om deze te wijzigen.',
+            ], 422);
+        }
+
         $allowed = ['person_id', 'lead_id', 'sales_lead_id', 'order_id', 'clinic_id'];
 
         $data = array_intersect_key(request()->all(), array_flip($allowed));
@@ -824,5 +834,18 @@ class ActivityController extends Controller
             'data'    => new ActivityResource($activity->refresh()),
             'message' => 'Koppeling bijgewerkt.',
         ]);
+    }
+
+    private function completedActivityResponse(): RedirectResponse|JsonResponse
+    {
+        $message = 'Deze activiteit is afgerond. Heropen de activiteit om deze te wijzigen.';
+
+        if (request()->expectsJson() || request()->ajax()) {
+            return response()->json(['message' => $message], 422);
+        }
+
+        session()->flash('error', $message);
+
+        return redirect()->back();
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
@@ -4,12 +4,12 @@ namespace Webkul\Admin\Http\Controllers\Activity;
 
 use App\Enums\CallStatus as CallStatusEnum;
 use App\Models\CallStatus;
+use App\Services\ActivityStatusService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Webkul\Activity\Models\Activity;
 use Webkul\Activity\Repositories\ActivityRepository;
 use Webkul\Admin\Http\Controllers\Controller;
-use App\Services\ActivityStatusService;
 
 class CallStatusController extends Controller
 {
@@ -30,6 +30,12 @@ class CallStatusController extends Controller
 
     public function store(Request $request, int $activityId): JsonResponse
     {
+        $activity = $this->activityRepository->findOrFail($activityId);
+
+        if ($activity->is_done) {
+            return $this->completedActivityResponse();
+        }
+
         $validated = $request->validate([
             'status' => 'required|in:' . implode(',', array_map(fn($c) => $c->value, CallStatusEnum::cases())),
             'omschrijving' => 'nullable|string',
@@ -51,7 +57,6 @@ class CallStatusController extends Controller
             'status' => $validated['status'],
             'omschrijving' => $validated['omschrijving'] ?? null,
         ]);
-        $activity = $this->activityRepository->findOrFail($activityId);
         // Reschedule activity if requested
         if (!empty($validated['reschedule_days'])) {
 
@@ -89,6 +94,12 @@ class CallStatusController extends Controller
 
     public function destroy(int $activityId, int $callStatusId): JsonResponse
     {
+        $activity = $this->activityRepository->findOrFail($activityId);
+
+        if ($activity->is_done) {
+            return $this->completedActivityResponse();
+        }
+
         $callStatus = CallStatus::where('activity_id', $activityId)->findOrFail($callStatusId);
 
         if ($callStatus->created_by !== auth()->guard('user')->id()) {
@@ -128,6 +139,13 @@ class CallStatusController extends Controller
         }
 
         return null;
+    }
+
+    private function completedActivityResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Deze activiteit is afgerond. Heropen de activiteit om acties te wijzigen.',
+        ], 422);
     }
 }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/CallStatusController.php
@@ -37,10 +37,10 @@ class CallStatusController extends Controller
         }
 
         $validated = $request->validate([
-            'status' => 'required|in:' . implode(',', array_map(fn($c) => $c->value, CallStatusEnum::cases())),
-            'omschrijving' => 'nullable|string',
+            'status'          => 'required|in:' . implode(',', array_map(fn ($c) => $c->value, CallStatusEnum::cases())),
+            'omschrijving'    => 'nullable|string',
             'reschedule_days' => 'nullable|integer|min:1|max:20',
-            'send_email' => 'nullable|boolean',
+            'send_email'      => 'nullable|boolean',
         ]);
 
         // Backend defaults: spoken => no move; others => 7 days if empty
@@ -58,35 +58,34 @@ class CallStatusController extends Controller
             'omschrijving' => $validated['omschrijving'] ?? null,
         ]);
         // Reschedule activity if requested
-        if (!empty($validated['reschedule_days'])) {
+        if (! empty($validated['reschedule_days'])) {
+            $days = (int) $validated['reschedule_days'];
+            $activity->schedule_to = now()->addDays($days);
+            $activity->save();
 
-               $days = (int) $validated['reschedule_days'];
-               $activity->schedule_to = now()->addDays($days);
+            // Recompute status after reschedule
+            $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
+            if ($computed->value !== ($activity->status?->value ?? null)) {
+                $activity->status = $computed;
                 $activity->save();
-
-                // Recompute status after reschedule
-                $computed = ActivityStatusService::computeStatus(null, $activity->schedule_to, $activity->status);
-                if ($computed->value !== ($activity->status?->value ?? null)) {
-                    $activity->status = $computed;
-                    $activity->save();
-                }
+            }
         }
         $this->activityRepository->unassign($activity);
 
         $response = [
-            'message' => 'Call status toegevoegd' . (!empty($validated['reschedule_days']) ? ' en taak verplaatst' : ''),
-            'data' => $callStatus,
+            'message' => 'Call status toegevoegd' . (! empty($validated['reschedule_days']) ? ' en taak verplaatst' : ''),
+            'data'    => $callStatus,
         ];
 
         // If email should be sent, return additional data for frontend to handle
-        if (!empty($validated['send_email'])) {
+        if (! empty($validated['send_email'])) {
             // Fetch activity; rely on lazy-loading with null checks in helper to avoid BelongsToMany on missing lead
             $activity = Activity::findOrFail($activityId);
             $defaultEmail = $this->getDefaultEmailForActivity($activity);
 
-            $response['send_email'] = true;
+            $response['send_email']   = true;
             $response['default_email'] = $defaultEmail;
-            $response['activity_id'] = $activityId;
+            $response['activity_id']   = $activityId;
         }
 
         return response()->json($response);

--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -1,4 +1,9 @@
-@php use App\Enums\ActivityType; use App\Enums\LostReason; @endphp
+@php
+    use App\Enums\ActivityType;
+    use App\Enums\LostReason;
+
+    $isReadOnly = (bool) $activity->is_done;
+@endphp
 <x-admin::layouts>
     <x-slot:title>
         {{ $activity->title ?: __('admin::app.activities.edit.title') }}
@@ -61,13 +66,21 @@
                     Annuleren
                 </button>
 
-                <button type="submit" class="primary-button">
-                    @lang('admin::app.activities.edit.save-btn')
-                </button>
+                @if(! $isReadOnly)
+                    <button type="submit" class="primary-button" data-activity-save-button>
+                        @lang('admin::app.activities.edit.save-btn')
+                    </button>
+                @endif
 
                 {!! view_render_event('admin.activities.edit.save_button.after') !!}
             </div>
         </div>
+
+        @if($isReadOnly)
+            <div class="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-800 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                Deze activiteit is afgerond en daarom alleen-lezen. Heropen de activiteit om gegevens of acties te wijzigen.
+            </div>
+        @endif
 
         <!-- Three Column Layout -->
         <div class="relative flex gap-4 max-lg:flex-wrap mt-4">
@@ -76,7 +89,7 @@
             <div class="max-lg:min-w-full max-lg:max-w-full [&>div:last-child]:border-b-0 lg:sticky lg:top-[73px] flex min-w-[394px] max-w-[394px] flex-col self-start rounded-lg border bg-white dark:border-gray-800 dark:bg-gray-900">
 
                 <!-- Koppeling -->
-                @if(bouncer()->hasPermission('activities.edit'))
+                @if(bouncer()->hasPermission('activities.edit') && ! $isReadOnly)
                     @include('admin::activities.partials.link-panel')
                     <div class="p-4 border-b border-gray-200 dark:border-gray-800">
                         <v-activity-link-panel></v-activity-link-panel>
@@ -89,151 +102,153 @@
 
                 <!-- Form Fields -->
                 <div class="p-4 flex flex-col gap-0">
-                    {!! view_render_event('admin.activities.edit.form_controls.before') !!}
+                    <fieldset class="contents" @if($isReadOnly) disabled @endif>
+                        {!! view_render_event('admin.activities.edit.form_controls.before') !!}
 
-                    <!-- Title -->
-                    <x-adminc::components.field
-                        type="text"
-                        name="title"
-                        id="title"
-                        :label="trans('admin::app.activities.edit.title')"
-                        value="{{ old('title') ?? $activity->title }}"
-                        rules="required"
-                        :placeholder="trans('admin::app.activities.edit.title')"
-                    />
-
-                    <!-- Type (read-only) -->
-                    <x-admin::form.control-group>
-                        @php
-                            $currentTypeValue = old('type') ?? ($activity->type?->value ?? $activity->type);
-                            $currentTypeLabel = $activity->type->label();
-                        @endphp
-                        <div class="flex items-center justify-between rounded-md border px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:text-gray-200">
-                            <span>{{ $currentTypeLabel }}</span>
-                        </div>
-                        <input type="hidden" name="type" value="{{ $currentTypeValue }}"/>
-                        <x-admin::form.control-group.label class="required">
-                            @lang('admin::app.activities.edit.type')
-                        </x-admin::form.control-group.label>
-                        <x-admin::form.control-group.error control-name="type"/>
-                    </x-admin::form.control-group>
-
-                    <!-- Deadline -->
-                    @if($activity->type->hasDeadline())
-                    <x-admin::form.control-group>
-                        @php
-                            $scheduleToValue   = old('schedule_to') ?? optional($activity->schedule_to)->format('Y-m-d\TH:i');
-                        @endphp
+                        <!-- Title -->
                         <x-adminc::components.field
-                            type="datetime"
-                            name="schedule_to"
-                            id="schedule_to"
-                            :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
+                            type="text"
+                            name="title"
+                            id="title"
+                            :label="trans('admin::app.activities.edit.title')"
+                            value="{{ old('title') ?? $activity->title }}"
                             rules="required"
-                            :value="$scheduleToValue"
-                            class="w-full"
+                            :placeholder="trans('admin::app.activities.edit.title')"
                         />
-                    </x-admin::form.control-group>
-                    @endif
 
-                    <!-- Description -->
-                    @php
-                        $commentRestrictedTypes = [ActivityType::CALL, ActivityType::TASK];
-                        $isCommentReadOnly = in_array($activity->type, $commentRestrictedTypes)
-                            && ! auth()->guard('user')->user()?->isGlobalAdmin();
-                    @endphp
-                    @if($isCommentReadOnly)
+                        <!-- Type (read-only) -->
                         <x-admin::form.control-group>
-                            <x-admin::form.control-group.label>
-                                {{ trans('admin::app.components.activities.actions.activity.description') }}
+                            @php
+                                $currentTypeValue = old('type') ?? ($activity->type?->value ?? $activity->type);
+                                $currentTypeLabel = $activity->type->label();
+                            @endphp
+                            <div class="flex items-center justify-between rounded-md border px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:text-gray-200">
+                                <span>{{ $currentTypeLabel }}</span>
+                            </div>
+                            <input type="hidden" name="type" value="{{ $currentTypeValue }}"/>
+                            <x-admin::form.control-group.label class="required">
+                                @lang('admin::app.activities.edit.type')
                             </x-admin::form.control-group.label>
-                            <textarea
-                                class="w-full rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
-                                rows="3"
-                                disabled
-                            >{{ $activity->comment }}</textarea>
-                            <input type="hidden" name="comment" value="{{ $activity->comment }}">
+                            <x-admin::form.control-group.error control-name="type"/>
                         </x-admin::form.control-group>
-                    @else
-                        <x-adminc::components.field
-                            type="textarea"
-                            name="comment"
-                            id="comment"
-                            :label="trans('admin::app.components.activities.actions.activity.description')"
-                            value="{{ old('comment') ?? $activity->comment }}"
-                            :placeholder="trans('admin::app.components.activities.actions.activity.description')"
-                        />
-                    @endif
 
-                    <!-- Toegewezen aan -->
-                    <x-admin::form.control-group>
-                        <div class="flex items-center gap-2">
-                            <x-admin::form.control-group.control
-                                type="select"
-                                name="user_id"
-                                id="user_id_select"
-                                :value="old('user_id', $activity->user_id)"
-                                class="flex-1"
-                                :disabled="$activity->user_id && $activity->user_id != auth()->guard('user')->id() && !$canTakeover"
-                            >
-                                <option value="">{{ __('admin::app.activities.select-user') }}</option>
-                                @foreach (app(Webkul\User\Repositories\UserRepository::class)->allActiveUsers() as $user)
-                                    <option value="{{ $user->id }}" {{ $activity->user_id == $user->id ? 'selected' : '' }}>
-                                        {{ $user->name }}
-                                    </option>
-                                @endforeach
-                            </x-admin::form.control-group.control>
+                        <!-- Deadline -->
+                        @if($activity->type->hasDeadline())
+                        <x-admin::form.control-group>
+                            @php
+                                $scheduleToValue   = old('schedule_to') ?? optional($activity->schedule_to)->format('Y-m-d\TH:i');
+                            @endphp
+                            <x-adminc::components.field
+                                type="datetime"
+                                name="schedule_to"
+                                id="schedule_to"
+                                :label="trans('admin::app.components.activities.actions.activity.schedule-to')"
+                                rules="required"
+                                :value="$scheduleToValue"
+                                class="w-full"
+                            />
+                        </x-admin::form.control-group>
+                        @endif
 
-                            @if($activity->user_id && $activity->user_id != auth()->guard('user')->id() && !$canTakeover)
-                                <input type="hidden" name="user_id" id="user_id_hidden" value="{{ $activity->user_id }}" />
-                            @endif
+                        <!-- Description -->
+                        @php
+                            $commentRestrictedTypes = [ActivityType::CALL, ActivityType::TASK];
+                            $isCommentReadOnly = in_array($activity->type, $commentRestrictedTypes)
+                                && ! auth()->guard('user')->user()?->isGlobalAdmin();
+                        @endphp
+                        @if($isCommentReadOnly)
+                            <x-admin::form.control-group>
+                                <x-admin::form.control-group.label>
+                                    {{ trans('admin::app.components.activities.actions.activity.description') }}
+                                </x-admin::form.control-group.label>
+                                <textarea
+                                    class="w-full rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                                    rows="3"
+                                    disabled
+                                >{{ $activity->comment }}</textarea>
+                                <input type="hidden" name="comment" value="{{ $activity->comment }}">
+                            </x-admin::form.control-group>
+                        @else
+                            <x-adminc::components.field
+                                type="textarea"
+                                name="comment"
+                                id="comment"
+                                :label="trans('admin::app.components.activities.actions.activity.description')"
+                                value="{{ old('comment') ?? $activity->comment }}"
+                                :placeholder="trans('admin::app.components.activities.actions.activity.description')"
+                            />
+                        @endif
 
-                            @if($activity->user_id && $activity->user_id != auth()->guard('user')->id() && $canTakeover)
-                                <button
-                                    type="button"
-                                    class="secondary-button bg-orange-500 hover:bg-orange-600 text-white whitespace-nowrap"
-                                    onclick="takeoverActivity({{ $activity->id }})"
-                                    title="Overnemen van {{ $activity->user ? $activity->user->name : 'onbekend' }}"
+                        <!-- Toegewezen aan -->
+                        <x-admin::form.control-group>
+                            <div class="flex items-center gap-2">
+                                <x-admin::form.control-group.control
+                                    type="select"
+                                    name="user_id"
+                                    id="user_id_select"
+                                    :value="old('user_id', $activity->user_id)"
+                                    class="flex-1"
+                                    :disabled="$isReadOnly || ($activity->user_id && $activity->user_id != auth()->guard('user')->id() && !$canTakeover)"
                                 >
-                                    Overnemen
-                                </button>
-                            @endif
-                        </div>
-                        <x-admin::form.control-group.label>
-                            @lang('admin::app.activities.assign-to')
-                        </x-admin::form.control-group.label>
-                        <x-admin::form.control-group.error control-name="user_id"/>
-                    </x-admin::form.control-group>
+                                    <option value="">{{ __('admin::app.activities.select-user') }}</option>
+                                    @foreach (app(Webkul\User\Repositories\UserRepository::class)->allActiveUsers() as $user)
+                                        <option value="{{ $user->id }}" {{ $activity->user_id == $user->id ? 'selected' : '' }}>
+                                            {{ $user->name }}
+                                        </option>
+                                    @endforeach
+                                </x-admin::form.control-group.control>
 
-                    <!-- Group -->
-                    <x-adminc::components.field
-                        type="select"
-                        name="group_id"
-                        :label="__('admin::app.activities.group')"
-                        :value="old('group_id', $activity->group_id)"
-                        rules="required"
-                    >
-                        <option value="">{{ __('admin::app.activities.select-group') }}</option>
-                        @foreach ($groups as $group)
-                            <option value="{{ $group->id }}" {{ $activity->group_id == $group->id ? 'selected' : '' }}>
-                                {{ $group->name }}
-                            </option>
-                        @endforeach
-                    </x-adminc::components.field>
+                                @if(! $isReadOnly && $activity->user_id && $activity->user_id != auth()->guard('user')->id() && !$canTakeover)
+                                    <input type="hidden" name="user_id" id="user_id_hidden" value="{{ $activity->user_id }}" />
+                                @endif
 
-                    <!-- Portal publishing (only for FILE/PATIENT_MESSAGE) -->
-                    @if(in_array($activity->type, [ActivityType::FILE, ActivityType::PATIENT_MESSAGE]))
-                        <input type="hidden" name="publish_to_portal" value="0" />
+                                @if(! $isReadOnly && $activity->user_id && $activity->user_id != auth()->guard('user')->id() && $canTakeover)
+                                    <button
+                                        type="button"
+                                        class="secondary-button bg-orange-500 hover:bg-orange-600 text-white whitespace-nowrap"
+                                        onclick="takeoverActivity({{ $activity->id }})"
+                                        title="Overnemen van {{ $activity->user ? $activity->user->name : 'onbekend' }}"
+                                    >
+                                        Overnemen
+                                    </button>
+                                @endif
+                            </div>
+                            <x-admin::form.control-group.label>
+                                @lang('admin::app.activities.assign-to')
+                            </x-admin::form.control-group.label>
+                            <x-admin::form.control-group.error control-name="user_id"/>
+                        </x-admin::form.control-group>
+
+                        <!-- Group -->
                         <x-adminc::components.field
-                            type="checkbox"
-                            name="publish_to_portal"
-                            label="Publiceren in patiëntportaal"
-                            value="1"
-                            :checked="old('publish_to_portal', $activity->portalPersons->isNotEmpty())"
-                        />
-                    @endif
+                            type="select"
+                            name="group_id"
+                            :label="__('admin::app.activities.group')"
+                            :value="old('group_id', $activity->group_id)"
+                            rules="required"
+                        >
+                            <option value="">{{ __('admin::app.activities.select-group') }}</option>
+                            @foreach ($groups as $group)
+                                <option value="{{ $group->id }}" {{ $activity->group_id == $group->id ? 'selected' : '' }}>
+                                    {{ $group->name }}
+                                </option>
+                            @endforeach
+                        </x-adminc::components.field>
 
-                    {!! view_render_event('admin.activities.edit.form_controls.after') !!}
+                        <!-- Portal publishing (only for FILE/PATIENT_MESSAGE) -->
+                        @if(in_array($activity->type, [ActivityType::FILE, ActivityType::PATIENT_MESSAGE]))
+                            <input type="hidden" name="publish_to_portal" value="0" />
+                            <x-adminc::components.field
+                                type="checkbox"
+                                name="publish_to_portal"
+                                label="Publiceren in patiëntportaal"
+                                value="1"
+                                :checked="old('publish_to_portal', $activity->portalPersons->isNotEmpty())"
+                            />
+                        @endif
+
+                        {!! view_render_event('admin.activities.edit.form_controls.after') !!}
+                    </fieldset>
                 </div>
 
 <!-- Additional data (hidden for SYSTEM activities — handled by the center panel) -->
@@ -307,7 +322,7 @@
         $mailEntity = $relatedEntity ?? $activity->lead ?? null;
         $mailEntityControlName = $relatedEntityType?->getForeignKey() ?? 'lead_id';
     @endphp
-    @if($mailEntity)
+    @if($mailEntity && ! $isReadOnly)
         <!-- Mail dialog (listens for open-email-dialog event from actions panel) -->
         <x-admin::activities.actions.mail
             :entity="$mailEntity"

--- a/packages/Webkul/Admin/src/Resources/views/activities/partials/actions.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/partials/actions.blade.php
@@ -5,6 +5,7 @@ use App\Enums\CallStatus;
 $isCall = $activity->type === ActivityType::CALL;
 $defaultTab = $isCall ? 'belstatus' : 'notitie';
 $currentUserId = auth()->guard('user')->id();
+$isActivityDone = (bool) $activity->is_done;
 
 $statusConfig = [
     CallStatus::SPOKEN->value           => ['label' => CallStatus::SPOKEN->label(),           'color' => '#1f8a5b', 'bg' => '#dcf3e6', 'border' => '#a3d9b8', 'icon' => CallStatus::SPOKEN->icon()],
@@ -24,7 +25,7 @@ foreach (($actions ?? collect()) as $action) {
         'body'        => $action->body,
         'call_status' => $action->call_status,
         'by'          => $action->creator?->name ?? '-',
-        'can_delete'  => $action->created_by === $currentUserId,
+        'can_delete'  => ! $isActivityDone && $action->created_by === $currentUserId,
     ]);
 }
 
@@ -46,6 +47,11 @@ $totalCount    = $timelineItems->count();
 {{-- ═══════════════════════════════════════════════════════════
      KAART 1: Actie toevoegen
      ═══════════════════════════════════════════════════════════ --}}
+@if($isActivityDone)
+    <div class="box-shadow rounded-lg border border-amber-200 bg-amber-50 px-5 py-4 text-sm font-medium text-amber-800 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+        Deze activiteit is afgerond. Heropen de activiteit om acties toe te voegen.
+    </div>
+@else
 <div class="box-shadow rounded-lg border bg-white dark:bg-gray-900 dark:border-gray-800 overflow-hidden">
 
     {{-- ── Type selector ───────────────────────────────────────── --}}
@@ -150,6 +156,7 @@ $totalCount    = $timelineItems->count();
         </button>
     </div>
 </div>
+@endif
 
 {{-- ═══════════════════════════════════════════════════════════
      KAART 2: Geschiedenis

--- a/tests/Feature/Activities/ActivityActionReadonlyTest.php
+++ b/tests/Feature/Activities/ActivityActionReadonlyTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use App\Enums\ActivityStatus;
+use App\Enums\ActivityType;
+use App\Models\ActivityAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Activity\Models\Activity;
+use Webkul\User\Models\Group;
+use Webkul\User\Models\User;
+
+uses(RefreshDatabase::class);
+
+function createReadonlyActivityTestActivity(array $attributes = []): Activity
+{
+    $group = Group::create([
+        'name'        => 'Readonly activity test group',
+        'description' => 'Readonly activity test group',
+    ]);
+
+    return Activity::create(array_merge([
+        'title'       => 'Readonly activity test',
+        'type'        => ActivityType::TASK->value,
+        'schedule_to' => now()->addDay(),
+        'group_id'    => $group->id,
+        'is_done'     => false,
+        'status'      => ActivityStatus::ACTIVE,
+    ], $attributes));
+}
+
+test('actions can be added to open activities', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = createReadonlyActivityTestActivity(['user_id' => $user->id]);
+
+    $response = $this->postJson(route('admin.activities.actions.store', $activity->id), [
+        'type' => 'notitie',
+        'body' => 'Nieuwe actie op open activiteit',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('message', 'Notitie toegevoegd');
+
+    $this->assertDatabaseHas('activity_actions', [
+        'activity_id' => $activity->id,
+        'type'        => 'notitie',
+        'body'        => 'Nieuwe actie op open activiteit',
+    ]);
+});
+
+test('actions cannot be added to completed activities', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = createReadonlyActivityTestActivity([
+        'user_id' => $user->id,
+        'is_done' => true,
+        'status'  => ActivityStatus::DONE,
+    ]);
+
+    $response = $this->postJson(route('admin.activities.actions.store', $activity->id), [
+        'type' => 'notitie',
+        'body' => 'Mag niet worden toegevoegd',
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonPath('message', 'Deze activiteit is afgerond. Heropen de activiteit om acties te wijzigen.');
+
+    $this->assertDatabaseMissing('activity_actions', [
+        'activity_id' => $activity->id,
+        'body'        => 'Mag niet worden toegevoegd',
+    ]);
+});
+
+test('completed activity edit page is read only for actions and save controls', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = createReadonlyActivityTestActivity([
+        'user_id' => $user->id,
+        'is_done' => true,
+        'status'  => ActivityStatus::DONE,
+    ]);
+
+    ActivityAction::create([
+        'activity_id' => $activity->id,
+        'type'        => 'notitie',
+        'body'        => 'Bestaande historie',
+        'created_by'  => $user->id,
+    ]);
+
+    $this->get(route('admin.activities.edit', $activity->id))
+        ->assertOk()
+        ->assertSee('Deze activiteit is afgerond en daarom alleen-lezen')
+        ->assertSee('Heropen de activiteit om acties toe te voegen')
+        ->assertDontSee('data-activity-save-button', false)
+        ->assertDontSee('Notitie toevoegen')
+        ->assertDontSee('Belstatus toevoegen')
+        ->assertDontSee('title="Verwijderen"', false);
+});
+
+test('completed activities cannot be updated until reopened', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = createReadonlyActivityTestActivity([
+        'user_id' => $user->id,
+        'is_done' => true,
+        'status'  => ActivityStatus::DONE,
+    ]);
+
+    $response = $this->putJson(route('admin.activities.update', $activity->id), [
+        'title'       => 'Gewijzigde titel',
+        'type'        => ActivityType::TASK->value,
+        'schedule_to' => now()->addDays(2)->format('Y-m-d H:i:s'),
+        'group_id'    => $activity->group_id,
+        'user_id'     => $user->id,
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonPath('message', 'Deze activiteit is afgerond. Heropen de activiteit om deze te wijzigen.');
+
+    expect($activity->refresh()->title)->toBe('Readonly activity test');
+});
+
+test('reopened activities accept actions again', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = createReadonlyActivityTestActivity([
+        'user_id' => $user->id,
+        'is_done' => true,
+        'status'  => ActivityStatus::DONE,
+    ]);
+
+    $this->post(route('admin.activities.reopen', $activity->id))
+        ->assertRedirect(route('admin.activities.edit', $activity->id));
+
+    expect($activity->refresh()->is_done)->toBeFalse();
+
+    $this->postJson(route('admin.activities.actions.store', $activity->id), [
+        'type' => 'notitie',
+        'body' => 'Actie na heropenen',
+    ])->assertOk();
+
+    $this->assertDatabaseHas('activity_actions', [
+        'activity_id' => $activity->id,
+        'body'        => 'Actie na heropenen',
+    ]);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
CRM | Activity | Geen acties kunnen toevoegen als activiteit afgerond is.

## Description
- Blocks activity action creation/deletion when an activity is completed.
- Makes the activity edit page read-only while completed, keeping only reopen available.
- Blocks backend activity updates and relation changes until reopen.
- Adds focused Pest coverage for completed/read-only and reopened activity behavior.

## How To Test This?
- `git diff --check` passed after implementation and cleanup.
- `vendor/bin/duster fix --dirty` could not run because `vendor/bin/duster` is missing.
- `php -l ...` could not run because `php` is missing.
- `docker compose ps` and `docker-compose ps` could not run because Docker/Compose are missing.
- `composer --version` could not run because Composer is missing.
- `./vendor/bin/sail artisan test --filter=ActivityActionReadonlyTest` could not run because `vendor/bin/sail` is missing.
- `./m.sh artisan test --filter=ActivityActionReadonlyTest` could not start Laravel; the helper failed with a jq syntax error and then curl connection reset.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master

## Tailwind Reordering
- [ ] Tailwind classes checked where touched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cf309aa-ba3e-44f5-bf16-d03fe4cd5816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cf309aa-ba3e-44f5-bf16-d03fe4cd5816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

