### PR TITLE
Improve activity overview details and ordering

### DIFF
--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -32,6 +32,16 @@ class ActivityObserver
     }
 
     /**
+     * Prepare Activity changes before they are persisted.
+     */
+    public function updating(Activity $activity): void
+    {
+        if ($activity->isDirty('is_done')) {
+            $activity->completed_at = $activity->is_done ? now() : null;
+        }
+    }
+
+    /**
      * Handle the Activity "updated" event.
      */
     public function updated(Activity $activity): void

--- a/database/migrations/2026_06_23_083500_add_completed_at_to_activities_table.php
+++ b/database/migrations/2026_06_23_083500_add_completed_at_to_activities_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->timestamp('completed_at')->nullable()->after('is_done');
+        });
+
+        DB::table('activities')
+            ->where('is_done', true)
+            ->whereNull('completed_at')
+            ->update([
+                'completed_at' => DB::raw('updated_at'),
+            ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropColumn('completed_at');
+        });
+    }
+};

--- a/packages/Webkul/Activity/src/Models/Activity.php
+++ b/packages/Webkul/Activity/src/Models/Activity.php
@@ -51,6 +51,7 @@ class Activity extends Model implements ActivityContract
     protected $casts = [
         'schedule_from' => 'datetime',
         'schedule_to'   => 'datetime',
+        'completed_at'  => 'datetime',
         'assigned_at'   => 'datetime',
         'additional'    => 'array',
         'is_done'              => 'boolean',
@@ -71,6 +72,7 @@ class Activity extends Model implements ActivityContract
         'additional',
         'schedule_from',
         'schedule_to',
+        'completed_at',
         'is_done',
         'status',
         'user_id',

--- a/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php
@@ -187,7 +187,7 @@ trait ConcatsEmailActivities
             ];
         });
 
-        return $activities->concat($mapped)->sortByDesc('id')->sortByDesc('created_at');
+        return $this->sortActivitiesForOverview($activities->concat($mapped));
     }
 
     private function toArray($value): ?array
@@ -195,5 +195,59 @@ trait ConcatsEmailActivities
         return is_array($value)
             ? $value
             : json_decode($value, true);
+    }
+
+    private function sortActivitiesForOverview(Collection $activities): Collection
+    {
+        return $activities
+            ->sort(function ($a, $b) {
+                $aDone = (bool) data_get($a, 'is_done', false);
+                $bDone = (bool) data_get($b, 'is_done', false);
+
+                if ($aDone !== $bDone) {
+                    return $aDone ? 1 : -1;
+                }
+
+                if (! $aDone) {
+                    $aSchedule = $this->timestampFor(data_get($a, 'schedule_to'));
+                    $bSchedule = $this->timestampFor(data_get($b, 'schedule_to'));
+
+                    if ($aSchedule !== $bSchedule) {
+                        return ($aSchedule ?? PHP_INT_MAX) <=> ($bSchedule ?? PHP_INT_MAX);
+                    }
+                }
+
+                $aDate = $this->overviewSortTimestamp($a);
+                $bDate = $this->overviewSortTimestamp($b);
+
+                if ($aDate !== $bDate) {
+                    return ($bDate ?? 0) <=> ($aDate ?? 0);
+                }
+
+                return ((int) data_get($b, 'id', 0)) <=> ((int) data_get($a, 'id', 0));
+            })
+            ->values();
+    }
+
+    private function overviewSortTimestamp(object $activity): ?int
+    {
+        return $this->timestampFor(data_get($activity, 'completed_at'))
+            ?? $this->timestampFor(data_get($activity, 'updated_at'))
+            ?? $this->timestampFor(data_get($activity, 'created_at'));
+    }
+
+    private function timestampFor($value): ?int
+    {
+        if (! $value) {
+            return null;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        $timestamp = strtotime((string) $value);
+
+        return $timestamp === false ? null : $timestamp;
     }
 }

--- a/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/ActivityResource.php
@@ -52,6 +52,7 @@ class ActivityResource extends JsonResource
                 ? $this->resource->portalPersons->map(fn ($p) => ['id' => $p->id, 'name' => $p->name])->values()
                 : [],
             'entity_source'      => data_get($this->resource, 'entity_source', null),
+            'completed_at'       => data_get($this->resource, 'completed_at', null),
             'created_at'         => $this->created_at,
             'updated_at'         => $this->updated_at,
         ];
@@ -101,8 +102,8 @@ class ActivityResource extends JsonResource
                     'type'        => $typeValue,
                     'call_status' => $callStatusKey ?: null,
                     'label'       => $typeValue === 'belstatus'
-                        ? ($statusLabel . ($body !== '' ? ' — ' . mb_strimwidth($body, 0, 60, '…') : ''))
-                        : mb_strimwidth($body, 0, 80, '…'),
+                        ? ($statusLabel . ($body !== '' ? ' — ' . $body : ''))
+                        : $body,
                     'creator'     => $a->creator?->name ?? '',
                     'date'        => $a->created_at->locale('nl')->isoFormat('D MMM HH:mm'),
                     'date_full'   => $a->created_at->toIso8601String(),

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/activity-item.blade.php
@@ -286,11 +286,12 @@
             {!! view_render_event('admin.components.activities.content.activity.item.description.before') !!}
 
             <!-- Activity Description -->
-            <p class="dark:text-white" v-if="activity.comment">
-                <span v-if="activity.type === 'email'">
-                    @{{ truncateHtmlASSummary(activity.comment, 350) }}
-                </span>
-{{--                <span v-else v-safe-html="activity.comment"></span>--}}
+            <p
+                class="truncate text-sm leading-5 text-gray-600 dark:text-gray-300"
+                v-if="activity.comment"
+                :title="activitySummaryText(activity.comment)"
+            >
+                @{{ activitySummaryText(activity.comment) }}
             </p>
 
             <!-- Actions timeline (task + call) -->
@@ -300,7 +301,7 @@
                          class="flex items-start gap-1.5 text-xs text-gray-400 dark:text-gray-500">
                         <span class="shrink-0 mt-px text-sm"
                               :class="getActionIconClass(a)"></span>
-                        <span class="truncate min-w-0">
+                        <span class="min-w-0 truncate" :title="a.label">
                             @{{ $admin.formatDate(a.date_full, 'd MMM HH:mm', timezone) }} ·
                             <strong class="font-semibold text-gray-600 dark:text-gray-300">@{{ a.creator }}</strong>:
                             @{{ a.label }}

--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -482,7 +482,17 @@
                         if (aDeadline) return -1;
                         if (bDeadline) return 1;
                     }
-                    return new Date(b.created_at) - new Date(a.created_at);
+                    return this.sortDateFor(b) - this.sortDateFor(a);
+                },
+
+                sortDateFor(activity) {
+                    const value = activity.completed_at || activity.updated_at || activity.created_at;
+
+                    if (!value) return 0;
+
+                    const time = new Date(value).getTime();
+
+                    return Number.isNaN(time) ? 0 : time;
                 },
 
                 get() {
@@ -521,7 +531,7 @@
                                 .then((response) => {
                                     this.isUpdating[activity.id] = false;
 
-                                    activity.is_done = 1;
+                                    Object.assign(activity, response.data.data);
 
                                     this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
                                 })
@@ -543,7 +553,7 @@
                                 .then((response) => {
                                     this.isUpdating[activity.id] = false;
 
-                                    activity.is_done = 0;
+                                    Object.assign(activity, response.data.data);
 
                                     this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
                                 })
@@ -649,7 +659,7 @@
                 //     return textContent.substring(0, maxLength) + '...';
                 // },
 
-                truncateHtmlASSummary(html, maxLength = 150) {
+                activitySummaryText(html) {
                     if (!html) return '';
 
                     const tempDiv = document.createElement('div');
@@ -659,11 +669,7 @@
 
                     const textContent = (tempDiv.textContent || tempDiv.innerText || '').replace(/\s+/g, ' ').trim();
 
-                    if (textContent.length <= maxLength) {
-                        return textContent;
-                    }
-
-                    return textContent.substring(0, maxLength) + '...';
+                    return textContent;
                 },
 
                 truncate(value, maxLength = 60) {

--- a/tests/Feature/Activities/ActivityHierarchyTest.php
+++ b/tests/Feature/Activities/ActivityHierarchyTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Enums\ActivityType;
+use App\Enums\ActivityActionType;
+use App\Models\ActivityAction;
 use App\Models\Order;
 use App\Models\SalesLead;
 use Database\Seeders\TestSeeder;
@@ -115,6 +117,57 @@ test('saleslead child order activity has entity_source with type order and url',
     expect($item['entity_source']['type'])->toBe('order')
         ->and($item['entity_source']['label'])->toStartWith('Order:')
         ->and($item['entity_source']['url'])->toContain((string) $order->id);
+});
+
+test('saleslead completed activities are ordered by completed date', function () {
+    $salesLead = SalesLead::factory()->create();
+
+    makeActivity([
+        'sales_lead_id' => $salesLead->id,
+        'title'         => 'Older completed activity',
+        'is_done'       => 1,
+        'completed_at'  => now()->subDays(3),
+    ]);
+
+    makeActivity([
+        'sales_lead_id' => $salesLead->id,
+        'title'         => 'Newest completed activity',
+        'is_done'       => 1,
+        'completed_at'  => now()->subHour(),
+    ]);
+
+    $response = $this->getJson(route('admin.sales-leads.activities.index', $salesLead->id));
+    $response->assertOk();
+
+    expect(collect($response->json('data'))->pluck('title')->take(2)->all())
+        ->toBe([
+            'Newest completed activity',
+            'Older completed activity',
+        ]);
+});
+
+test('activity resource keeps full action labels for browser truncation', function () {
+    $salesLead = SalesLead::factory()->create();
+    $activity = makeActivity([
+        'sales_lead_id' => $salesLead->id,
+        'type'          => ActivityType::TASK->value,
+        'title'         => 'Task with long action',
+    ]);
+
+    $body = 'Wij gaan de operatie inplannen voor 9 juli en publiceren daarna alle praktische informatie voor de patient.';
+    ActivityAction::create([
+        'activity_id' => $activity->id,
+        'type'        => ActivityActionType::Notitie->value,
+        'body'        => $body,
+        'created_by'  => getDefaultAdmin()->id,
+    ]);
+
+    $response = $this->getJson(route('admin.sales-leads.activities.index', $salesLead->id));
+    $response->assertOk();
+
+    $item = collect($response->json('data'))->firstWhere('title', 'Task with long action');
+
+    expect($item['actions'][0]['label'])->toBe($body);
 });
 
 // ── Lead ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference

Activity overview feedback for lead/order/person/sales entity views.

## Description

- Show activity descriptions directly in overview cards as a one-line summary.
- Let long activity action labels truncate in the browser instead of being shortened by the API.
- Add `completed_at` for activities and sort completed items by completion date with fallback for existing data.
- Update inline complete/reopen responses so the visible list re-sorts immediately.

## How To Test This?

- `php -l database/migrations/2026_06_23_083500_add_completed_at_to_activities_table.php && php -l packages/Webkul/Activity/src/Models/Activity.php && php -l app/Observers/ActivityObserver.php && php -l packages/Webkul/Admin/src/Http/Resources/ActivityResource.php && php -l packages/Webkul/Admin/src/Http/Controllers/Concerns/ConcatsEmailActivities.php && php -l tests/Feature/Activities/ActivityHierarchyTest.php`
- `git diff --check`
- Intended Pest command is currently blocked in this Cloud Agent because `vendor/bin/pest` is absent and the environment has no Docker/PHP 8.4 runtime: `vendor/bin/pest tests/Feature/Activities/ActivityHierarchyTest.php tests/Feature/Activities/OpenActivityEmailFilterTest.php tests/Feature/SalesLeadActivityStoreTest.php`

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [ ] Target Branch: master

## Tailwind Reordering
Tailwind classes changed only in Blade markup for the activity overview card.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0e8ddd2-2caa-4b82-8a08-58ff4ce71716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0e8ddd2-2caa-4b82-8a08-58ff4ce71716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

