### PR TITLE
test: add HTTP integration tests for lead address clear (MBS-22)

### DIFF
--- a/tests/Feature/Leads/LeadAddressHttpTest.php
+++ b/tests/Feature/Leads/LeadAddressHttpTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Address;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Lead\Models\Lead;
+use Webkul\User\Models\User;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+    $this->user = User::factory()->active()->create();
+});
+
+test('submitting empty address fields via HTTP clears the address', function () {
+    $lead = Lead::factory()->withAddress()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $originalAddressId = $lead->address_id;
+    $this->assertNotNull($originalAddressId);
+
+    $response = $this->actingAs($this->user, 'user')
+        ->put(route('admin.leads.update', $lead->id), [
+            'first_name'    => $lead->first_name ?? 'Test',
+            'last_name'     => $lead->last_name ?? 'Lead',
+            'department_id' => $lead->department_id,
+            'emails'        => [['value' => 'test@example.com', 'label' => 'eigen']],
+            'address'       => [
+                '_clear'              => '0',
+                'street'              => '',
+                'house_number'        => '',
+                'house_number_suffix' => '',
+                'postal_code'         => '',
+                'city'                => '',
+                'state'               => '',
+                'country'             => '',
+            ],
+        ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+
+    $lead->refresh();
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});
+
+test('submitting _clear=1 via HTTP deletes the address', function () {
+    $lead = Lead::factory()->withAddress()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $originalAddressId = $lead->address_id;
+    $this->assertNotNull($originalAddressId);
+
+    $response = $this->actingAs($this->user, 'user')
+        ->put(route('admin.leads.update', $lead->id), [
+            'first_name'    => $lead->first_name ?? 'Test',
+            'last_name'     => $lead->last_name ?? 'Lead',
+            'department_id' => $lead->department_id,
+            'emails'        => [['value' => 'test@example.com', 'label' => 'eigen']],
+            'address'       => [
+                '_clear' => '1',
+            ],
+        ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+
+    $lead->refresh();
+    $this->assertNull($lead->address_id);
+    $this->assertDatabaseMissing('addresses', ['id' => $originalAddressId]);
+});


### PR DESCRIPTION
## Summary

Adds HTTP integration tests for the lead address clear functionality (MBS-22).

These tests were written previously in the `daan/mbs-22-lead-adres-leegmaken` branch but were never merged because that branch targeted a feature branch that was later deleted. The underlying fix (`AddressRepository._clear` key stripping) is already in `development`.

**Tests added:**
- `submitting empty address fields via HTTP clears the address` — verifies that sending empty address fields via `PUT admin.leads.update` removes the address record
- `submitting _clear=1 via HTTP deletes the address` — verifies the explicit clear flag removes the address via the HTTP route

These complement the existing unit-level tests in `LeadAddressClearTest.php`.

## Test plan
- [x] `LeadAddressHttpTest.php` added to `tests/Feature/Leads/`
- [ ] CI passes (PHP 8.3 test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)