### PR TITLE
fix: set Monday as first day of week in datepicker (MBS-269)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js
+++ b/packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js
@@ -28,6 +28,8 @@ export default {
 
         setLocaleFromLang();
 
+        Flatpickr.l10ns.default.firstDayOfWeek = 1;
+
         const changeTheme = (theme) => {
             document.getElementById('flatpickr')?.remove();
 


### PR DESCRIPTION
## Summary

- Set `firstDayOfWeek: 1` (Monday) on Flatpickr's default locale in the global plugin configuration
- Applies app-wide to all datepickers, regardless of language/locale setting
- Fixes report from Linda Meijer via Marker.io: calendar was showing Sunday as first day

## Change

`packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js` — one line added after locale initialization:
```js
Flatpickr.l10ns.default.firstDayOfWeek = 1;
```

Setting this on `l10ns.default` ensures it takes effect after any locale override (Spanish, Arabic, Persian, Turkish) and applies to all datepickers globally.

## Test plan
- [ ] Open any date/datetime picker in the CRM (e.g. activity edit form)
- [ ] Verify the calendar week starts on Monday, not Sunday

Closes MBS-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)