### PR TITLE
fix: include order-level anamnesis in AFB document (MBS-268)

### DIFF
--- a/app/Services/Afb/AfbDocumentGenerator.php
+++ b/app/Services/Afb/AfbDocumentGenerator.php
@@ -340,6 +340,17 @@ class AfbDocumentGenerator
             return null;
         }
 
+        // Inheritance: order-level overrides sales-level overrides lead-level.
+        $orderAnamnesis = Anamnesis::query()
+            ->where('person_id', $person->id)
+            ->where('order_id', $order->id)
+            ->latest('updated_at')
+            ->first();
+
+        if ($orderAnamnesis) {
+            return $orderAnamnesis;
+        }
+
         $leadId = $order->salesLead?->lead_id;
 
         return Anamnesis::query()

--- a/tests/Feature/Afb/AfbDispatchFlowTest.php
+++ b/tests/Feature/Afb/AfbDispatchFlowTest.php
@@ -1137,6 +1137,47 @@ test('send afb endpoint returns already sent message when all departments dispat
     Bus::assertNotDispatched(SendAfbDispatchJob::class);
 });
 
+test('order-specific anamnesis overrides sales-level anamnesis on afb (MBS-268)', function () {
+    $context = createOrderForClinic(Carbon::parse('2026-03-31 09:30:00'));
+    $order = $context['order'];
+    $person = $context['person'];
+
+    // Verify sales-level anamnesis is present (created by createOrderForClinic)
+    $salesAnamnesis = Anamnesis::where('sales_id', $order->salesLead->id)
+        ->where('person_id', $person->id)
+        ->first();
+    expect($salesAnamnesis)->not->toBeNull();
+    expect($salesAnamnesis->metals_notes)->toBe('Schroef in knie');
+
+    // Create order-specific anamnesis with different values
+    Anamnesis::create([
+        'id'             => (string) Str::uuid(),
+        'order_id'       => $order->id,
+        'person_id'      => $person->id,
+        'claustrophobia' => false,
+        'metals'         => true,
+        'metals_notes'   => 'Titanium pen in heup',
+        'heart_surgery'  => false,
+        'implant'        => false,
+        'allergies'      => false,
+        'glaucoma'       => false,
+        'diabetes'       => false,
+        'comment_clinic' => 'Orderspecifieke opmerking voor kliniek',
+        'remarks'        => 'Orderspecifieke opmerking',
+    ]);
+
+    $generator = app(AfbDocumentGenerator::class);
+    $html = $generator->renderHtmlForOrderAndDepartment($order->fresh(), $context['department'])['html'];
+
+    // Order-level values must appear
+    expect($html)
+        ->toContain('Titanium pen in heup')
+        ->toContain('Orderspecifieke opmerking voor kliniek')
+        // Sales-level value must NOT appear
+        ->not->toContain('Schroef in knie')
+        ->not->toContain('Nekpijn links, voorzichtig positioneren.');
+});
+
 test('gvl pdf attachment filename includes slugified person name', function () {
     Mail::fake();
 


### PR DESCRIPTION
## Samenvatting

Orderspecifieke anamnese gegevens kwamen niet terecht op de AFB (Aanvraagformulier Behandeling).

**Root cause:** `AfbDocumentGenerator::resolveAnamnesis()` doorzocht alleen anamnese records op `sales_id` of `lead_id`, maar negeerde `order_id`. Het Anamnesis-model documenteert de overerving als Order → Sales → Lead, maar het genereerproces implementeerde dit niet.

**Fix:** De methode controleert nu eerst of er een order-specifieke anamnese bestaat (`order_id = $order->id`). Pas als die niet bestaat, valt het terug op sales- en lead-niveau — in lijn met de gedocumenteerde inheritance-keten.

## Wijzigingen

- `app/Services/Afb/AfbDocumentGenerator.php` — `resolveAnamnesis()` geeft nu prioriteit aan order-niveau anamnese
- `tests/Feature/Afb/AfbDispatchFlowTest.php` — test die verifieert dat order-specifieke anamnese de sales-niveau waarden overschrijft op de AFB

## Test plan

- [ ] `php artisan test --filter="order-specific anamnesis overrides"` slaagt
- [ ] Controleer het case van Linda: Herniapoli Lead → Sales Herniapoli → Sales Privatescan → Order Privatescan met orderspecifieke anamnese → AFB toont de orderspecifieke waarden

Fixes MBS-268

🤖 Generated with [Claude Code](https://claude.com/claude-code)