### PR TITLE
fix: use contact person's default email in lead email compose (MBS-267)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/actions/mail.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/actions/mail.blade.php
@@ -868,10 +868,10 @@
 
                     tryExtract(this.entity);
 
-                    // Some entities may have nested person
+                    // Some entities may have nested person; prefer contactPerson (single) over person (collection)
                     if (this.entity && this.entity.contactPerson) {
-                        tryExtract(this.entity.person);
-                    } else if (this.entity && this.entity.person) {
+                        tryExtract(this.entity.contactPerson);
+                    } else if (this.entity && this.entity.person && !Array.isArray(this.entity.person)) {
                         tryExtract(this.entity.person);
                     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
@@ -84,8 +84,13 @@
                         {!! view_render_event('admin.leads.view.actions.before', ['lead' => $lead]) !!}
 
                         @if (bouncer()->hasPermission('mail.create'))
-                            <!-- Mail Activity Action -->
-                            <x-admin::activities.actions.mail :entity="$lead" entity-control-name="lead_id"/>
+                            <!-- Mail Activity Action: use contact person's emails when available, fall back to lead's own emails -->
+                            @php
+                                $mailEmails = !empty($lead->contactPerson?->emails)
+                                    ? $lead->contactPerson->emails
+                                    : ($lead->emails ?? []);
+                            @endphp
+                            <x-admin::activities.actions.mail :entity="$lead" entity-control-name="lead_id" :emails="$mailEmails"/>
                         @endif
 
                         @if (bouncer()->hasPermission('activities.create'))


### PR DESCRIPTION
## Summary

Fixes the bug where the email compose modal in the lead view pre-filled an old (non-default) email address instead of the contact person's current default email.

**Root cause (two issues):**
1. **JS bug** in `collectEntityEmails()` (`mail.blade.php`): the code checked `entity.contactPerson` but then extracted emails from `entity.person` (which is the many-to-many collection/array). `tryExtract()` doesn't handle arrays, so the contact person's emails were silently skipped and only the lead's own (potentially stale) emails were collected.
2. The contact person's emails were never passed server-side, so client-side fallback logic had to guess — and guessed wrong.

**Fix:**
- Pass the contact person's emails (or lead's own emails as fallback) explicitly from PHP in `view.blade.php`. This bypasses the fragile client-side extraction entirely when a contact person is available.
- Fix the JS guard in `collectEntityEmails()` to use `entity.contactPerson` (single object) instead of `entity.person` (array/collection) when extracting emails.

## Test plan
- [ ] Open a lead that has a contact person with multiple emails, where the default is not the first/oldest
- [ ] Click "Email opstellen" — the To field should show the person's current default email
- [ ] Verify the email dropdown shows all person emails with the default marked

🤖 Generated with [Claude Code](https://claude.com/claude-code)