### PR TITLE
fix: configure keycloak admin_password in tests and add email to person (MBS-270)

### DIFF
--- a/tests/Feature/Api/patient/PatientPasswordTest.php
+++ b/tests/Feature/Api/patient/PatientPasswordTest.php
@@ -14,6 +14,7 @@ uses(RefreshDatabase::class);
 beforeEach(function () {
     Config::set('api.keys', ['valid-api-key-123']);
     Config::set('services.keycloak.client_id', 'crm-app');
+    Config::set('services.keycloak.admin_password', 'test-admin-password');
 
     // Prevent real Keycloak HTTP calls; allow assertions in specific tests.
     Http::fake(function (HttpRequest $request) {
@@ -81,6 +82,7 @@ it('syncs the password change to keycloak', function () {
         'keycloak_user_id' => $keycloakUserId,
         'is_active'        => true,
         'password'         => 'OudWachtwoord1!',
+        'emails'           => [['value' => 'patient@example.com', 'label' => 'home', 'is_default' => true]],
     ]);
 
     $response = $this

--- a/tests/Feature/Auth/PatientForgotPasswordTest.php
+++ b/tests/Feature/Auth/PatientForgotPasswordTest.php
@@ -12,6 +12,7 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Config::set('services.keycloak.client_id', 'crm-app');
+    Config::set('services.keycloak.admin_password', 'test-admin-password');
     Config::set('services.portal.patient.web_url', 'https://patient-portal.test');
 
     Http::fake(function (HttpRequest $request) {


### PR DESCRIPTION
## Summary

Fixes 2 failing tests (`PatientPasswordTest` and `PatientForgotPasswordTest`) that are blocking CI on all open PRs.

**Root causes:**

1. `services.keycloak.admin_password` not set in `beforeEach` → `KeycloakService::getAdminToken()` early-returns `null` without making any HTTP request → `Http::assertSent()` fails with "An expected request was not recorded"
2. `PatientPasswordTest` person created without email → `PersonObserver::shouldManagePortal()` requires `findDefaultEmail()` to be non-empty → returns `false` → Keycloak sync is skipped

**Fix:**
- Add `Config::set('services.keycloak.admin_password', 'test-admin-password')` to `beforeEach` in both test files
- Add email to person factory in `it('syncs the password change to keycloak')`

## Test plan

- [ ] CI passes on this PR
- [ ] `PatientPasswordTest - syncs the password change to keycloak` passes
- [ ] `PatientForgotPasswordTest - synct het nieuwe wachtwoord naar keycloak na een forgot-password reset` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)