### PR TITLE
fix: task department based on order pipeline, not lead origin (MBS-271)

### DIFF
--- a/app/Actions/Activities/CreateActivityForOrderAction.php
+++ b/app/Actions/Activities/CreateActivityForOrderAction.php
@@ -21,10 +21,11 @@ class CreateActivityForOrderAction extends AbstractCreateActivityAction
     public function execute(Order $order, bool $isDone, array $activityData): Activity
     {
         $activityData['order_id'] = $order->id;
-        $department = $order->salesLead?->getDepartment();
-        $groupId = $department
-            ? Department::getGroupIdForDepartmentId($department->id)
-            : Department::getGroupIdForLead($order->salesLead->lead);
+        // Use the order's pipeline department so that tasks are always assigned to the
+        // correct group, even when the lead was originally from a different department
+        // (e.g. Herniapoli lead converted to Privatescan).
+        $department = $order->getPipelineDepartment();
+        $groupId = Department::getGroupIdForDepartmentId($department->id);
 
         return $this->createActivity('order_id', $order->id, $groupId, $isDone, $activityData);
     }

--- a/tests/Feature/Actions/CreateActivityForOrderActionTest.php
+++ b/tests/Feature/Actions/CreateActivityForOrderActionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Actions\Activities\CreateActivityForOrderAction;
+use App\Enums\PipelineStage;
+use App\Models\Department;
+use App\Models\Order;
+use App\Models\SalesLead;
+use Database\Seeders\TestSeeder;
+use Webkul\Activity\Models\Activity;
+use Webkul\Lead\Models\Lead;
+use Webkul\User\Models\Group;
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+});
+
+test('task is assigned to privatescan group when order is in privatescan pipeline, even if saleslead department is hernia', function () {
+    // Scenario: lead was originally from Herniapoli but converted to Privatescan.
+    // The SalesLead.department_id may still hold the Hernia ID, but the order's
+    // pipeline stage belongs to the Privatescan order pipeline.
+    $herniaDepartment = Department::where('name', 'hernia')->firstOrFail();
+    $privateScanDepartment = Department::where('name', 'privatescan')->firstOrFail();
+
+    $privateScanGroup = Group::where('department_id', $privateScanDepartment->id)->firstOrFail();
+
+    $lead = Lead::factory()->create(['department_id' => $privateScanDepartment->id]);
+
+    // SalesLead with Hernia department (as if created before conversion)
+    $salesLead = SalesLead::factory()->create([
+        'lead_id'       => $lead->id,
+        'department_id' => $herniaDepartment->id,
+    ]);
+
+    // Order in the Privatescan order pipeline (stage 30 = ORDER_CONFIRM)
+    $order = Order::factory()->create([
+        'sales_lead_id'     => $salesLead->id,
+        'pipeline_stage_id' => PipelineStage::ORDER_CONFIRM->id(),
+    ]);
+
+    $action = app(CreateActivityForOrderAction::class);
+    $activity = $action->execute($order, false, [
+        'title'         => 'Test taak',
+        'type'          => 'task',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addWeek(),
+    ]);
+
+    expect($activity)->toBeInstanceOf(Activity::class);
+    expect($activity->group_id)->toBe($privateScanGroup->id);
+});
+
+test('task is assigned to hernia group when order is in hernia pipeline', function () {
+    $herniaDepartment = Department::where('name', 'hernia')->firstOrFail();
+    $herniaGroup = Group::where('department_id', $herniaDepartment->id)->firstOrFail();
+
+    $lead = Lead::factory()->create(['department_id' => $herniaDepartment->id]);
+
+    $salesLead = SalesLead::factory()->create([
+        'lead_id'       => $lead->id,
+        'department_id' => $herniaDepartment->id,
+    ]);
+
+    // Order in the Hernia order pipeline (stage 39 = ORDER_VOORBEREIDEN_HERNIA)
+    $order = Order::factory()->create([
+        'sales_lead_id'     => $salesLead->id,
+        'pipeline_stage_id' => PipelineStage::ORDER_VOORBEREIDEN_HERNIA->id(),
+    ]);
+
+    $action = app(CreateActivityForOrderAction::class);
+    $activity = $action->execute($order, false, [
+        'title'         => 'Hernia taak',
+        'type'          => 'task',
+        'schedule_from' => now(),
+        'schedule_to'   => now()->addWeek(),
+    ]);
+
+    expect($activity)->toBeInstanceOf(Activity::class);
+    expect($activity->group_id)->toBe($herniaGroup->id);
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `CreateActivityForOrderAction` was determining the task group (department) via `$order->salesLead->getDepartment()`, which reads `SalesLead.department_id`. When a lead was originally from Herniapoli and later converted to Privatescan, the `SalesLead.department_id` still held the Hernia department ID — causing tasks created on order status changes to be assigned to the Hernia group instead of Privatescan.
- **Fix**: Replace the SalesLead-based department lookup with `$order->getPipelineDepartment()`, which derives the department from the order's actual pipeline stage (`lead_pipeline_id`). Orders in the Privatescan order pipeline always get Privatescan tasks; Hernia pipeline orders always get Hernia tasks — regardless of the lead's history.
- **Test**: Added `CreateActivityForOrderActionTest` with two cases: converted Hernia→Privatescan lead (verifies Privatescan group) and a native Hernia lead (verifies Hernia group).

## Test plan

- [ ] Run `php artisan test tests/Feature/Actions/CreateActivityForOrderActionTest.php`
- [ ] Reproduce scenario: create a lead under Herniapoli, convert it to Privatescan, create an order, advance status → verify created tasks show Privatescan department
- [ ] Verify Hernia orders still create tasks in Hernia group

Fixes: MBS-271

🤖 Generated with [Claude Code](https://claude.com/claude-code)