### PR TITLE
fix: exclude clinic uploads from patient uploads queue (MBS-272)

### DIFF
--- a/app/Services/ActivityQueueRegistry.php
+++ b/app/Services/ActivityQueueRegistry.php
@@ -117,6 +117,7 @@ class ActivityQueueRegistry
             ],
 
             // Upload bestanden door klanten – monitor file uploads from portal.
+            // Exclude clinic uploads (inkoop facturen) which have a clinic_id set.
             'uploads' => [
                 'key'   => 'uploads',
                 'label' => 'Upload bestanden door patiënten',
@@ -127,7 +128,8 @@ class ActivityQueueRegistry
                 'apply' => static function (Builder $query): void {
                     $query
                         ->where('activities.type', ActivityType::FILE->value)
-                        ->where('activities.is_done', false);
+                        ->where('activities.is_done', false)
+                        ->whereNull('activities.clinic_id');
                 },
             ],
 

--- a/tests/Feature/Activities/UploadsQueueFilterTest.php
+++ b/tests/Feature/Activities/UploadsQueueFilterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Enums\ActivityType;
+use App\Models\Clinic;
+use App\Services\ActivityQueueRepository;
+use Database\Seeders\TestSeeder;
+use Webkul\Activity\Models\Activity;
+use Webkul\User\Models\Role;
+use Webkul\User\Models\User;
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+});
+
+it('excludes clinic uploads (rekening/inkoop factuur) from the uploads queue', function () {
+    $adminRole = Role::factory()->create([
+        'permission_type' => 'all',
+        'permissions'     => null,
+    ]);
+
+    $admin = User::factory()->create([
+        'role_id'         => $adminRole->id,
+        'view_permission' => 'global',
+        'status'          => 1,
+    ]);
+
+    $clinic = Clinic::factory()->create();
+
+    // Patient upload – no clinic_id, should appear in queue
+    $patientUpload = Activity::create([
+        'type'    => ActivityType::FILE->value,
+        'title'   => 'Patient upload',
+        'is_done' => false,
+        'user_id' => $admin->id,
+    ]);
+
+    // Clinic invoice upload – has clinic_id, should NOT appear in queue
+    $clinicUpload = Activity::create([
+        'type'      => ActivityType::FILE->value,
+        'title'     => 'Inkoop factuur clinic',
+        'is_done'   => false,
+        'user_id'   => $admin->id,
+        'clinic_id' => $clinic->id,
+    ]);
+
+    $this->actingAs($admin, 'user');
+
+    /** @var ActivityQueueRepository $repo */
+    $repo = app(ActivityQueueRepository::class);
+
+    $counts = $repo->counts('uploads');
+
+    expect($counts['open'])->toBe(1);
+});


### PR DESCRIPTION
## Summary

- The _Uploads_ queue (`queue=uploads`) on the operational dashboard was showing clinic invoice uploads (inkoop facturen / rekeningen) alongside patient file uploads
- Clinic-linked FILE activities are created with a `clinic_id` column set; patient uploads have `clinic_id = null`
- Added `->whereNull('activities.clinic_id')` to the `uploads` queue filter in `ActivityQueueRegistry`

## Root cause

`InkoopController::store` creates a `FILE` activity with `clinic_id` set when a staff member uploads an inkoop factuur for a clinic. The uploads queue filter only checked `type = file` and `is_done = false`, so those clinic invoices were also returned.

## Test

Added `tests/Feature/Activities/UploadsQueueFilterTest.php` that verifies:
- A patient FILE activity (no `clinic_id`) is counted in the uploads queue
- A clinic FILE activity (with `clinic_id`) is **not** counted in the uploads queue

## Test plan
- [ ] Deploy and open `/admin/operational-dashboard?queue=uploads&department=Privatescan`
- [ ] Confirm rekeningen/inkoop facturen are no longer listed
- [ ] Confirm patient uploads still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)