### PR TITLE
feat: add geboortedatum filter on persons datagrid (MBS-274)

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Contact/PersonDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Contact/PersonDataGrid.php
@@ -94,6 +94,7 @@ class PersonDataGrid extends DataGrid
         )"));
         $this->addFilter('organization', 'organizations.name');
         $this->addFilter('is_active', 'persons.is_active');
+        $this->addFilter('date_of_birth', 'persons.date_of_birth');
 
         return $queryBuilder;
     }
@@ -175,21 +176,22 @@ class PersonDataGrid extends DataGrid
         ]);
 
         $this->addColumn([
-            'index'      => 'date_of_birth',
-            'label'      => 'Leeftijd',
-            'type'       => 'string',
-            'sortable'   => true,
-            'filterable' => false,
-            'searchable' => false,
-            'closure'    => function ($row) {
-                if (!$row->date_of_birth) {
+            'index'           => 'date_of_birth',
+            'label'           => 'Geboortedatum',
+            'type'            => 'date',
+            'sortable'        => true,
+            'filterable'      => true,
+            'filterable_type' => 'date_range',
+            'searchable'      => false,
+            'closure'         => function ($row) {
+                if (! $row->date_of_birth) {
                     return '-';
                 }
 
                 $birthDate = Carbon::parse($row->date_of_birth);
                 $age = $birthDate->age;
 
-                return $age . ' jaar';
+                return $row->date_of_birth . ' (' . $age . ' jaar)';
             },
         ]);
 


### PR DESCRIPTION
## Summary

Sluit aan op MBS-274: gebruiker kan nu filteren op geboortedatum in de contactpersonenlijst.

- `date_of_birth` kolom in `PersonDataGrid` is nu filterbaar via een datumbereik (`date_range`)
- Kolomlabel gewijzigd van "Leeftijd" naar "Geboortedatum"
- Weergave toont nu zowel de geboortedatum als de leeftijd (bijv. `1985-03-12 (39 jaar)`)
- `addFilter('date_of_birth', 'persons.date_of_birth')` toegevoegd zodat de DataGrid-engine de juiste kolom filtert

## Test plan
- [ ] Open `/admin/contacts/persons`
- [ ] Klik op het filter-icoon → filter "Geboortedatum" is beschikbaar
- [ ] Selecteer een datumbereik en controleer of enkel personen binnen dat bereik worden getoond
- [ ] Verifieer dat de kolom de geboortedatum én leeftijd toont

🤖 Generated with [Claude Code](https://claude.com/claude-code)