### PR TITLE
feat: multi-mailbox support (PrivateScan + HerniaPoli) (MBS-276)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,8 @@ IMAP_PASSWORD=test1234
 GRAPH_CLIENT_ID=7657ba5b-b033-409b-a03d-1259a387bbcf
 GRAPH_TENANT_ID=dd126d7e-0693-4344-86b8-548e33182661
 GRAPH_CLIENT_SECRET=bZb8Q~6ymirceVRGyuzZ6zb3~l6x9QNHLmmB4cbw
-GRAPH_MAILBOX=crm@privatescan.nl
+GRAPH_MAILBOX=service@privatescan.nl
+GRAPH_MAILBOX_HP=service@herniapoli.nl
 MAIL_RECEIVER_DRIVER=microsoft-graph
 GRAPH_SENDER_DOMAIN=crm.private-scan.nl
 

--- a/app/Console/Commands/SyncGraphEmails.php
+++ b/app/Console/Commands/SyncGraphEmails.php
@@ -16,14 +16,14 @@ class SyncGraphEmails extends Command
      *
      * @var string
      */
-    protected $signature = 'emails:sync-graph';
+    protected $signature = 'emails:sync-graph {--mailbox= : Sync only the mailbox with this key (e.g. privatescan or herniapoli)}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Sync emails from Microsoft Graph API';
+    protected $description = 'Sync emails from Microsoft Graph API (all configured mailboxes)';
 
     /**
      * Create a new command instance.
@@ -45,19 +45,44 @@ class SyncGraphEmails extends Command
      */
     public function handle(GraphMailService $graphService)
     {
-        $this->info('Starting Microsoft Graph email sync...');
+        $mailboxes = config('mail.mailboxes', []);
 
-        try {
-            $graphService->processMessagesFromAllFolders();
-
-            $this->info('Microsoft Graph email sync completed successfully.');
-
-            return Command::SUCCESS;
-
-        } catch (Exception $e) {
-            $this->error('Microsoft Graph email sync failed: '.$e->getMessage());
+        if (empty($mailboxes)) {
+            $this->error('No mailboxes configured in config/mail.php under mail.mailboxes');
 
             return Command::FAILURE;
         }
+
+        $filterKey = $this->option('mailbox');
+
+        $errors = 0;
+
+        foreach ($mailboxes as $key => $mailboxConfig) {
+            if ($filterKey && $filterKey !== $key) {
+                continue;
+            }
+
+            $address = $mailboxConfig['address'] ?? null;
+            $folderName = $mailboxConfig['folder_name'] ?? 'inbox';
+
+            if (empty($address)) {
+                $this->warn("Mailbox '{$key}' has no address configured, skipping.");
+                continue;
+            }
+
+            $this->info("Syncing mailbox [{$key}] {$address} ...");
+
+            try {
+                $graphService->configureMailbox($address, $key, $folderName);
+                $graphService->processMessagesFromAllFolders();
+
+                $this->info("  -> Done.");
+            } catch (Exception $e) {
+                $this->error("  -> Failed: {$e->getMessage()}");
+                $errors++;
+            }
+        }
+
+        return $errors > 0 ? Command::FAILURE : Command::SUCCESS;
     }
 }

--- a/app/Services/Mail/GraphMailService.php
+++ b/app/Services/Mail/GraphMailService.php
@@ -18,6 +18,8 @@ use Webkul\Email\Repositories\EmailRepository;
  * normalises them into the application's Email model, stores attachments, and
  * marks each message as read once processed.
  *
+ * Supports multiple mailboxes via {@see configureMailbox()}.
+ *
  * Bound to the {@see InboundEmailProcessor} contract when the
  * `mail-receiver.default` config value is `'microsoft-graph'`.
  *
@@ -30,6 +32,10 @@ class GraphMailService extends AbstractEmailProcessor
 
     protected string $mailbox;
 
+    protected string $mailboxKey = 'privatescan';
+
+    protected string $inboxFolderName = 'inbox';
+
     public function __construct(
         EmailRepository $emailRepository,
         AttachmentRepository $attachmentRepository,
@@ -38,6 +44,20 @@ class GraphMailService extends AbstractEmailProcessor
     ) {
         parent::__construct($emailRepository, $attachmentRepository, $emailEntityLinker);
         $this->mailbox = config('mail.graph.mailbox');
+    }
+
+    /**
+     * Configure the service to operate on a specific mailbox.
+     *
+     * @param  string  $mailboxAddress  The Exchange mailbox address (e.g. service@herniapoli.nl)
+     * @param  string  $mailboxKey      Identifier stored on Email records (e.g. 'herniapoli')
+     * @param  string  $folderName      Inbox folder name in the local folders table
+     */
+    public function configureMailbox(string $mailboxAddress, string $mailboxKey, string $folderName): void
+    {
+        $this->mailbox = $mailboxAddress;
+        $this->mailboxKey = $mailboxKey;
+        $this->inboxFolderName = $folderName;
     }
 
     // Abstract method implementations
@@ -87,7 +107,7 @@ class GraphMailService extends AbstractEmailProcessor
 
     protected function getFolderName($message): string
     {
-        return SupportedFolderEnum::INBOX->value;
+        return $this->inboxFolderName;
     }
 
     protected function extractEmailData($message, string $folderName, ?Email $parentEmail): array
@@ -109,6 +129,7 @@ class GraphMailService extends AbstractEmailProcessor
             'reply'         => $body,
             'is_read'       => (int) ($message['isRead'] ?? false),
             'folder_id'     => $this->getFolderId($folderName),
+            'mailbox_key'   => $this->mailboxKey,
             'reply_to'      => $this->extractEmailAddresses($replyTo),
             'cc'            => $this->extractEmailAddresses($ccRecipients),
             'bcc'           => $this->extractEmailAddresses($bccRecipients),
@@ -196,7 +217,8 @@ class GraphMailService extends AbstractEmailProcessor
     protected function getSyncMetadata(): array
     {
         return [
-            'mailbox' => $this->mailbox,
+            'mailbox'     => $this->mailbox,
+            'mailbox_key' => $this->mailboxKey,
         ];
     }
 

--- a/app/Services/Mail/MicrosoftGraphMailTransport.php
+++ b/app/Services/Mail/MicrosoftGraphMailTransport.php
@@ -44,6 +44,28 @@ class MicrosoftGraphMailTransport implements TransportInterface
     }
 
     /**
+     * Resolve the sending mailbox address from a candidate From address.
+     *
+     * If the $candidate matches one of the configured mailboxes, that mailbox
+     * address is used as the sending identity (and API endpoint user). Otherwise
+     * falls back to the default configured mailbox.
+     */
+    protected function resolveMailbox(string $candidate): string
+    {
+        $mailboxes = config('mail.mailboxes', []);
+
+        foreach ($mailboxes as $config) {
+            $address = $config['address'] ?? null;
+            if ($address && strtolower($address) === strtolower($candidate)) {
+                return $address;
+            }
+        }
+
+        // Fall back to the default mailbox
+        return config('mail.graph.mailbox');
+    }
+
+    /**
      * Check if an email address matches any of the allowed patterns
      */
     public static function matchesAnyPattern(string $emailAddress, array $patterns): bool
@@ -88,10 +110,14 @@ class MicrosoftGraphMailTransport implements TransportInterface
         try {
             $email = MessageConverter::toEmail($message);
 
-            // Get the sender information
-            // Always use the service account mailbox as from address to avoid SendAs permission issues
-            // Always use the authenticated user's name for the from name (not from database)
-            $fromAddress = $this->getDefaultFromAddress(); // Always use service account
+            // Get the sender information.
+            // Derive the From address from the message's From header when it matches a configured
+            // mailbox, so users can choose which mailbox to send from. Fall back to the default
+            // mailbox when the From address is not a known mailbox.
+            $messageFrom = $email->getFrom()[0] ?? null;
+            $fromAddress = $messageFrom
+                ? $this->resolveMailbox($messageFrom->getAddress())
+                : $this->getDefaultFromAddress();
             $fromName = $this->getDefaultFromName(); // Always use current user's name
 
             // Build recipients
@@ -181,9 +207,9 @@ class MicrosoftGraphMailTransport implements TransportInterface
             // isInline: true and referenced via cid: in the HTML.
             $this->processInlineImages($payload);
 
-            // Send via Graph API
+            // Send via Graph API using the resolved mailbox as the sending identity
             $accessToken = $this->tokenService->getAccessToken();
-            $url = "{$this->baseUrl}/users/{$this->mailbox}/sendMail";
+            $url = "{$this->baseUrl}/users/{$fromAddress}/sendMail";
 
             logger()->info('Sending email via Microsoft Graph', [
                 'to'      => collect($toRecipients)->pluck('emailAddress.address')->toArray(),

--- a/config/mail.php
+++ b/config/mail.php
@@ -137,8 +137,37 @@ return [
         'client_id'     => env('GRAPH_CLIENT_ID'),
         'tenant_id'     => env('GRAPH_TENANT_ID'),
         'client_secret' => env('GRAPH_CLIENT_SECRET'),
-        'mailbox'       => env('GRAPH_MAILBOX', 'crm@privatescan.nl'),
+        'mailbox'       => env('GRAPH_MAILBOX', 'service@privatescan.nl'),
         'sender_domain' => env('GRAPH_SENDER_DOMAIN', 'crm.private-scan.nl'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Multiple Mailbox Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure all mailboxes that should be synced and available for sending.
+    | Each entry has:
+    |   key          – unique identifier used as mailbox_key on Email records
+    |   address      – the actual mailbox address on Exchange Online
+    |   display_name – human-readable name shown in the UI
+    |   folder_name  – inbox folder name in the local folders table
+    |
+    | The first entry is the default mailbox used when no mailbox_key is set.
+    |
+    */
+
+    'mailboxes' => [
+        'privatescan' => [
+            'address'      => env('GRAPH_MAILBOX', 'service@privatescan.nl'),
+            'display_name' => 'PrivateScan',
+            'folder_name'  => 'inbox',
+        ],
+        'herniapoli' => [
+            'address'      => env('GRAPH_MAILBOX_HP', 'service@herniapoli.nl'),
+            'display_name' => 'HerniaPoli',
+            'folder_name'  => 'inbox_herniapoli',
+        ],
     ],
 
     /*

--- a/database/migrations/2026_06_26_000001_add_mailbox_key_to_emails_table.php
+++ b/database/migrations/2026_06_26_000001_add_mailbox_key_to_emails_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('emails', function (Blueprint $table) {
+            $table->string('mailbox_key')->nullable()->after('folder_id')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('emails', function (Blueprint $table) {
+            $table->dropIndex(['mailbox_key']);
+            $table->dropColumn('mailbox_key');
+        });
+    }
+};

--- a/database/migrations/2026_06_26_000002_add_herniapoli_inbox_folder.php
+++ b/database/migrations/2026_06_26_000002_add_herniapoli_inbox_folder.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Only insert if it does not already exist
+        $exists = DB::table('folders')
+            ->where('name', 'inbox_herniapoli')
+            ->whereNull('parent_id')
+            ->exists();
+
+        if (! $exists) {
+            // Determine next order value
+            $maxOrder = DB::table('folders')->max('order') ?? 0;
+
+            DB::table('folders')->insert([
+                'name'         => 'inbox_herniapoli',
+                'parent_id'    => null,
+                'order'        => $maxOrder + 1,
+                'is_deletable' => false,
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('folders')
+            ->where('name', 'inbox_herniapoli')
+            ->whereNull('parent_id')
+            ->delete();
+    }
+};

--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -486,6 +486,24 @@ class EmailController extends Controller
     // Removed: searchByEmail. Reuse existing search endpoints (leads/persons/sales-leads) from respective controllers.
 
     /**
+     * Get list of configured mailboxes available for sending.
+     */
+    public function getMailboxes(): JsonResponse
+    {
+        $mailboxes = config('mail.mailboxes', []);
+
+        $data = collect($mailboxes)->map(function ($config, $key) {
+            return [
+                'key'          => $key,
+                'address'      => $config['address'],
+                'display_name' => $config['display_name'],
+            ];
+        })->values()->toArray();
+
+        return response()->json(['data' => $data]);
+    }
+
+    /**
      * Get list of available email templates with filtering support.
      *
      * Query Parameters:

--- a/packages/Webkul/Admin/src/Resources/views/mail/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/index.blade.php
@@ -472,6 +472,33 @@
                                     v-model="draft.id"
                                 />
 
+                                <!-- From (sender mailbox) -->
+                                <x-admin::form.control-group v-if="mailboxes.length > 1">
+                                    <x-admin::form.control-group.label>
+                                        Van
+                                    </x-admin::form.control-group.label>
+                                    <select
+                                        name="from"
+                                        v-model="draft.from"
+                                        class="flex w-full rounded-md border px-3 py-2 text-sm leading-6 text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
+                                    >
+                                        <option
+                                            v-for="mb in mailboxes"
+                                            :key="mb.key"
+                                            :value="mb.address"
+                                        >
+                                            @{{ mb.display_name }} (@{{ mb.address }})
+                                        </option>
+                                    </select>
+                                </x-admin::form.control-group>
+
+                                <x-admin::form.control-group.control
+                                    v-else
+                                    type="hidden"
+                                    name="from"
+                                    v-model="draft.from"
+                                />
+
                                 <!-- To -->
                                 <x-admin::form.control-group>
                                     <div class="relative">
@@ -663,8 +690,11 @@
 
                         emailTemplates: [],
 
+                        mailboxes: @json(array_values(array_map(fn($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']], array_keys(config('mail.mailboxes', [])), config('mail.mailboxes', [])))),
+
                         draft: {
                             id: null,
+                            from: '{{ config('mail.mailboxes.' . array_key_first(config('mail.mailboxes', [])) . '.address', config('mail.graph.mailbox')) }}',
                             reply_to: [],
                             cc: [],
                             bcc: [],
@@ -805,6 +835,7 @@
                     },
 
                     toggleModal() {
+                        this.draft.from = this.mailboxes.length ? this.mailboxes[0].address : '';
                         this.draft.reply_to = [];
                         this.draft.subject = '';
                         this.draft.reply = '';

--- a/packages/Webkul/Admin/src/Resources/views/mail/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/index.blade.php
@@ -670,6 +670,17 @@
             {!! view_render_event('admin.mail.create.form.after') !!}
         </script>
 
+        @php
+            $mailboxList = array_values(array_map(
+                fn ($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']],
+                array_keys(config('mail.mailboxes', [])),
+                config('mail.mailboxes', [])
+            ));
+            $defaultMailboxAddress = count($mailboxList) > 0
+                ? $mailboxList[0]['address']
+                : config('mail.graph.mailbox', '');
+        @endphp
+
         <script type="module">
             app.component('v-mail', {
                 template: '#v-mail-template',
@@ -690,11 +701,11 @@
 
                         emailTemplates: [],
 
-                        mailboxes: @json(array_values(array_map(fn($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']], array_keys(config('mail.mailboxes', [])), config('mail.mailboxes', [])))),
+                        mailboxes: @json($mailboxList),
 
                         draft: {
                             id: null,
-                            from: '{{ config('mail.mailboxes.' . array_key_first(config('mail.mailboxes', [])) . '.address', config('mail.graph.mailbox')) }}',
+                            from: '{{ $defaultMailboxAddress }}',
                             reply_to: [],
                             cc: [],
                             bcc: [],

--- a/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
@@ -183,6 +183,27 @@
                                         value="1"
                                     />
 
+                                    <!-- From (sender mailbox) -->
+                                    <x-admin::form.control-group v-if="mailboxes.length > 1">
+                                        <x-admin::form.control-group.label>
+                                            Van
+                                        </x-admin::form.control-group.label>
+                                        <select
+                                            name="from"
+                                            v-model="selectedFrom"
+                                            class="flex w-full rounded-md border px-3 py-2 text-sm leading-6 text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
+                                        >
+                                            <option
+                                                v-for="mb in mailboxes"
+                                                :key="mb.key"
+                                                :value="mb.address"
+                                            >
+                                                @{{ mb.display_name }} (@{{ mb.address }})
+                                            </option>
+                                        </select>
+                                    </x-admin::form.control-group>
+                                    <input v-else type="hidden" name="from" :value="selectedFrom" />
+
                                     <!-- To -->
                                     <x-admin::form.control-group>
                                         <div class="relative">
@@ -1139,6 +1160,10 @@
                         subject: '',
 
                         userSignature: {!! json_encode($userSig, JSON_HEX_TAG) !!},
+
+                        mailboxes: @json(array_values(array_map(fn($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']], array_keys(config('mail.mailboxes', [])), config('mail.mailboxes', [])))),
+
+                        selectedFrom: '{{ config('mail.mailboxes.' . array_key_first(config('mail.mailboxes', [])) . '.address', config('mail.graph.mailbox')) }}',
                     };
                 },
 

--- a/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
@@ -1142,7 +1142,17 @@
 
         <!-- Email Form Vue Component -->
         <script type="module">
-            @php $userSig = auth()->guard('user')->user()?->signature ?? ''; @endphp
+            @php
+                $userSig = auth()->guard('user')->user()?->signature ?? '';
+                $mailboxList = array_values(array_map(
+                    fn ($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']],
+                    array_keys(config('mail.mailboxes', [])),
+                    config('mail.mailboxes', [])
+                ));
+                $defaultMailboxAddress = count($mailboxList) > 0
+                    ? $mailboxList[0]['address']
+                    : config('mail.graph.mailbox', '');
+            @endphp
 
             app.component('v-email-form', {
                 template: '#v-email-form-template',
@@ -1161,9 +1171,9 @@
 
                         userSignature: {!! json_encode($userSig, JSON_HEX_TAG) !!},
 
-                        mailboxes: @json(array_values(array_map(fn($k, $v) => ['key' => $k, 'address' => $v['address'], 'display_name' => $v['display_name']], array_keys(config('mail.mailboxes', [])), config('mail.mailboxes', [])))),
+                        mailboxes: @json($mailboxList),
 
-                        selectedFrom: '{{ config('mail.mailboxes.' . array_key_first(config('mail.mailboxes', [])) . '.address', config('mail.graph.mailbox')) }}',
+                        selectedFrom: '{{ $defaultMailboxAddress }}',
                     };
                 },
 

--- a/packages/Webkul/Admin/src/Routes/Admin/mail-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/mail-routes.php
@@ -15,6 +15,8 @@ Route::prefix('mail')->group(function () {
 
     Route::controller(EmailController::class)->group(function () {
         // Specific routes must come FIRST, before any catch-all routes
+        Route::get('mailboxes', 'getMailboxes')->name('admin.mail.mailboxes');
+
         Route::get('templates', 'get')->name('admin.mail.templates');
 
         Route::get('template-content', 'getTemplateContent')->name('admin.mail.template_content');

--- a/packages/Webkul/Email/src/Models/Email.php
+++ b/packages/Webkul/Email/src/Models/Email.php
@@ -66,6 +66,7 @@ class Email extends Model implements EmailContract
         'user_type',
         'is_read',
         'folder_id',
+        'mailbox_key',
         'from',
         'sender',
         'reply_to',


### PR DESCRIPTION
## MBS-276 — Mogelijkheid voor 2 mailboxen

Voegt ondersteuning toe voor meerdere mailboxen (PrivateScan + HerniaPoli) via Microsoft Graph. Gebouwd met uitbreidbaarheid voor een eventuele 3e mailbox.

## Wat is er veranderd

### Configuratie
- `config/mail.php`: nieuw `mail.mailboxes` array met per-mailbox config (`address`, `display_name`, `folder_name`)
- `.env.example`: nieuw `GRAPH_MAILBOX_HP` env-var voor de herniapoli-mailbox

### Database
- Migratie: `mailbox_key` kolom op `emails` tabel (nullable, geïndexeerd) — slaat op welke mailbox een e-mail verwerkte
- Migratie: voegt `inbox_herniapoli` folder toe aan de `folders` tabel

### Backend
- `GraphMailService::configureMailbox()` — maakt de inbound-sync per mailbox configureerbaar
- `SyncGraphEmails` command — loopt over alle geconfigureerde mailboxen; optionele `--mailbox=key` vlag voor selectief synchroniseren
- `MicrosoftGraphMailTransport` — leest het `From`-adres uit het Symfony-bericht en matcht dit op een geconfigureerde mailbox voor verzending; fallback naar de default mailbox
- `EmailController::getMailboxes()` — nieuw `GET /admin/mail/mailboxes` endpoint voor de UI
- `Email` model — `mailbox_key` toegevoegd aan `$fillable`

### UI
- Compose-formulier en reply-formulier tonen een "Van:" dropdown als er meer dan één mailbox geconfigureerd is
- Geselecteerd adres wordt meegestuurd als `from` veld → gebruikt door de transport voor verzending

## Extensibiliteit
Een 3e (of meer) mailboxen toevoegen vereist alleen een extra entry in het `mail.mailboxes` config-array. Geen codewijziging nodig.

## Hoe te deployen
1. Stel `GRAPH_MAILBOX_HP=service@herniapoli.nl` in op de server
2. Voer migraties uit: `php artisan migrate`
3. Controleer dat de app-registratie in Azure AD `Mail.ReadWrite` en `Mail.Send` rechten heeft op de herniapoli-mailbox

## Test plan
- [ ] Compose e-mail: "Van:" dropdown toont beide mailboxen
- [ ] E-mail verzenden via HerniaPoli: Graph API call gaat naar `users/service@herniapoli.nl/sendMail`
- [ ] `php artisan emails:sync-graph` synchroniseert beide mailboxen
- [ ] `php artisan emails:sync-graph --mailbox=herniapoli` synchroniseert alleen HerniaPoli
- [ ] Inkomende HP-mails landen in de `inbox_herniapoli` folder en krijgen `mailbox_key = herniapoli`
- [ ] Bestaande PS-functionaliteit ongewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)