### PR TITLE
fix: resolve PHPStan nullCoalesce and collection warnings, update baseline

### DIFF
--- a/app/Console/Commands/ImportOrdersFromSugarCRM.php
+++ b/app/Console/Commands/ImportOrdersFromSugarCRM.php
@@ -946,7 +946,7 @@ class ImportOrdersFromSugarCRM extends AbstractSugarCRMImport
                     $salesName = $this->stripOrderNumberFromName($record->name ?? '', $record->order_num ?? null);
                     // Same path as createFromWonLead (copyFromLead → persons + anamnesis), without auto-created order
                     $salesLead = $this->salesLeadRepository->createFromLeadForOrderImport($crmLead, [
-                        'name'              => $salesName ?? "Order {$record->order_num}",
+                        'name'              => $salesName,
                         'pipeline_stage_id' => $salesStage->id(),
                         'lost_reason'       => $lostReason,
                         'closed_at'         => $closedAt,

--- a/app/Services/Inkoop/InkoopPdfParser.php
+++ b/app/Services/Inkoop/InkoopPdfParser.php
@@ -78,7 +78,7 @@ class InkoopPdfParser
             return $result;
         } catch (Exception $e) {
             Log::error('Error parsing PDF', [
-                'file_path'  => $pdfPath ?? 'unknown',
+                'file_path'  => $pdfPath,
                 'invoice_id' => $invoice->id,
                 'error'      => $e->getMessage(),
                 'trace'      => $e->getTraceAsString(),

--- a/app/Services/UserDefaultValueService.php
+++ b/app/Services/UserDefaultValueService.php
@@ -14,7 +14,6 @@ class UserDefaultValueService
     {
         return UserDefaultValue::where('user_id', $userId)
             ->where('key', 'like', $keyPattern)
-            ->get()
             ->pluck('value', 'key');
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: app/Console/Commands/ImportOrdersFromSugarCRM.php
 
 		-
-			message: '#^Variable \$salesName on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.variable
-			count: 1
-			path: app/Console/Commands/ImportOrdersFromSugarCRM.php
-
-		-
 			message: '#^Variable \$value on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.variable
 			count: 1
@@ -64,13 +58,7 @@ parameters:
 			message: '#^Variable \$shiftBlocks in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
-			path: app/Http/Controllers/Admin/Planning/OrderItemPlanningController.php
-
-		-
-			message: '#^Variable \$shiftBlocks in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: app/Http/Controllers/Admin/Planning/ResourcePlanningMonitorController.php
+			path: app/Http/Controllers/Admin/Planning/Concerns/ResourceAvailabilityTrait.php
 
 		-
 			message: '#^Variable \$events in empty\(\) always exists and is not falsy\.$#'
@@ -91,25 +79,13 @@ parameters:
 			path: app/Models/PurchasePrice.php
 
 		-
-			message: '#^Call to an undefined method class@anonymous/Providers/AuditTrailServiceProvider\.php\:73\:\:belongsTo\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Providers/AuditTrailServiceProvider.php
-
-		-
 			message: '#^Variable \$pdf in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
 			path: app/Services/Inkoop/InkoopPdfParser.php
 
 		-
-			message: '#^Variable \$pdfPath on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.variable
-			count: 1
-			path: app/Services/Inkoop/InkoopPdfParser.php
-
-		-
-			message: '#^Called ''pluck'' on Laravel collection, but could have been retrieved as a query\.$#'
-			identifier: larastan.noUnnecessaryCollectionCall
-			count: 1
-			path: app/Services/UserDefaultValueService.php
+			message: '#^Call to an undefined method class@anonymous/Providers/AuditTrailServiceProvider\.php\:73\:\:belongsTo\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: app/Providers/AuditTrailServiceProvider.php


### PR DESCRIPTION
## Summary

Idle task sweep (MBS-288) found 3 fixable PHPStan warnings still in the baseline:

- **`UserDefaultValueService`**: `->get()->pluck()` → `->pluck()` (move pluck to query level, avoids loading full collection into memory)
- **`InkoopPdfParser`**: removed redundant `$pdfPath ?? 'unknown'` — `$pdfPath` is always initialized before the catch block
- **`ImportOrdersFromSugarCRM`**: removed `$salesName ?? "Order {$record->order_num}"` — `stripOrderNumberFromName()` returns `string` so `??` fallback was dead code

Also corrected stale baseline paths: `$shiftBlocks in empty()` was listed under two deleted controller files; code lives in `ResourceAvailabilityTrait.php` since the trait extraction refactor.

## Changes
- `phpstan-baseline.neon`: -3 resolved entries, corrected 2 stale paths → 1 correct path
- 3 source files: removed dead null-coalescing and unnecessary collection hydration

## Test plan
- [ ] CI PHPStan passes (level 1, baseline updated)
- [ ] No functional changes — purely dead-code removal and query optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)