### PR TITLE
fix: resolve 4 PHPStan baseline warnings (MBS-290)

### DIFF
--- a/app/Enums/Currency.php
+++ b/app/Enums/Currency.php
@@ -85,7 +85,7 @@ enum Currency: string
         }
 
         $value = (string) $value;
-        $value = preg_replace('/\s+/', '', $value ?? '');
+        $value = preg_replace('/\s+/', '', $value);
 
         if ($value === '') {
             return null;

--- a/app/Http/Controllers/Admin/Settings/ResourceController.php
+++ b/app/Http/Controllers/Admin/Settings/ResourceController.php
@@ -195,10 +195,6 @@ class ResourceController extends SimpleEntityController
             }
         }
 
-        if (empty($events)) {
-            return [];
-        }
-
         usort($events, function ($a, $b) {
             if ($a['date']->eq($b['date'])) {
                 return $a['type'] === 'end' ? -1 : 1; // end before start on same day

--- a/app/Http/Resources/PatientPaginatedCollection.php
+++ b/app/Http/Resources/PatientPaginatedCollection.php
@@ -38,6 +38,7 @@ abstract class PatientPaginatedCollection extends ResourceCollection
      */
     public static function fromPaginator(LengthAwarePaginator $paginator, $resource): static
     {
+        // @phpstan-ignore-next-line new.static
         return new static($resource, [
             'current_page' => $paginator->currentPage(),
             'per_page'     => $paginator->perPage(),
@@ -47,6 +48,7 @@ abstract class PatientPaginatedCollection extends ResourceCollection
 
     public static function empty(int $perPage = 15): static
     {
+        // @phpstan-ignore-next-line new.static
         return new static(collect(), [
             'current_page' => 1,
             'per_page'     => $perPage,

--- a/app/Models/PurchasePrice.php
+++ b/app/Models/PurchasePrice.php
@@ -46,7 +46,7 @@ class PurchasePrice extends Model
     {
         $prefix = 'purchase_price_';
 
-        return collect((new static)->getFillable())
+        return collect((new self)->getFillable())
             ->filter(fn (string $field) => str_starts_with($field, $prefix))
             ->map(fn (string $field) => substr($field, strlen($prefix)))
             ->values()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,30 +49,6 @@ parameters:
 			path: app/Console/Commands/ImportOrdersFromSugarCRM.php
 
 		-
-			message: '#^Variable \$value on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.variable
-			count: 1
-			path: app/Enums/Currency.php
-
-		-
-			message: '#^Variable \$events in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: app/Http/Controllers/Admin/Settings/ResourceController.php
-
-		-
-			message: '#^Unsafe usage of new static\(\)\.$#'
-			identifier: new.static
-			count: 2
-			path: app/Http/Resources/PatientPaginatedCollection.php
-
-		-
-			message: '#^Unsafe usage of new static\(\)\.$#'
-			identifier: new.static
-			count: 1
-			path: app/Models/PurchasePrice.php
-
-		-
 			message: '#^Variable \$pdf in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1


### PR DESCRIPTION
## Summary

Idle task sweep (MBS-290) found 4 more fixable PHPStan warnings still in the baseline.
Baseline shrinks from 15 → 11 entries.

- **`Currency::normalizePrice`**: removed dead `?? ''` — `$value` is already cast to `string` on the line before
- **`ResourceController::buildPeriodAwareWeeklySummaries`**: removed unreachable `empty($events)` guard — the `empty($shifts)` early-return above guarantees `$events` always has at least one entry after the loop
- **`PatientPaginatedCollection`**: moved `new.static` suppression from baseline to inline `@phpstan-ignore-next-line` — pattern is intentional (abstract class factory methods for subclass instantiation)
- **`PurchasePrice::priceSuffixes`**: `new static()` → `new self()` — class has no subclasses, so `new self()` is correct and removes the warning without suppression

## Remaining baseline (11 entries)
- 8× `ImportOrdersFromSugarCRM` — architectural issue (`RepairSugarOrderPurchasePrices` extends it but overrides signature; complex refactor needed)
- 1× `ResourceAvailabilityTrait` — `empty($shiftBlocks)` — cast array type nuance; leave suppressed
- 1× `InkoopPdfParser` — `empty($pdf)` — PDF parser object always truthy; leave suppressed
- 1× `AuditTrailServiceProvider` — anonymous class `belongsTo()` — complex to fix

## Test plan
- [ ] CI PHPStan passes (level 1, updated baseline)
- [ ] No functional behavior changed (all removed code was unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)