### PR TITLE
feat: allow changing activity type between task and call note (MBS-291)

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php
@@ -325,6 +325,15 @@ class ActivityController extends Controller
         $data = request()->all();
         unset($data['schedule_from']);
 
+        // Only allow type changes between user-selectable types (CALL, TASK).
+        // For non-user-selectable types (FILE, NOTE, SYSTEM, PATIENT_MESSAGE), ignore the submitted type.
+        if (isset($data['type'])) {
+            $newType = ActivityType::tryFrom($data['type']);
+            if (! $newType || ! $newType->isUserSelectable() || ! $activity->type?->isUserSelectable()) {
+                $data['type'] = $activity->type?->value;
+            }
+        }
+
         // Non-admins cannot change the description of CALL or TASK activities.
         $restrictedTypes = [ActivityType::CALL->value, ActivityType::TASK->value];
         if (in_array($activity->type?->value, $restrictedTypes, true)

--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -116,16 +116,32 @@
                             :placeholder="trans('admin::app.activities.edit.title')"
                         />
 
-                        <!-- Type (read-only) -->
+                        <!-- Type -->
                         <x-admin::form.control-group>
                             @php
                                 $currentTypeValue = old('type') ?? ($activity->type?->value ?? $activity->type);
                                 $currentTypeLabel = $activity->type->label();
+                                $typeIsEditable = ! $isReadOnly && $activity->type->isUserSelectable();
                             @endphp
-                            <div class="flex items-center justify-between rounded-md border px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:text-gray-200">
-                                <span>{{ $currentTypeLabel }}</span>
-                            </div>
-                            <input type="hidden" name="type" value="{{ $currentTypeValue }}"/>
+                            @if($typeIsEditable)
+                                <x-admin::form.control-group.control
+                                    type="select"
+                                    name="type"
+                                    id="type"
+                                    :value="$currentTypeValue"
+                                >
+                                    @foreach(array_filter(\App\Enums\ActivityType::cases(), fn($t) => $t->isUserSelectable()) as $activityType)
+                                        <option value="{{ $activityType->value }}" {{ $currentTypeValue === $activityType->value ? 'selected' : '' }}>
+                                            {{ $activityType->label() }}
+                                        </option>
+                                    @endforeach
+                                </x-admin::form.control-group.control>
+                            @else
+                                <div class="flex items-center justify-between rounded-md border px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:text-gray-200">
+                                    <span>{{ $currentTypeLabel }}</span>
+                                </div>
+                                <input type="hidden" name="type" value="{{ $currentTypeValue }}"/>
+                            @endif
                             <x-admin::form.control-group.label class="required">
                                 @lang('admin::app.activities.edit.type')
                             </x-admin::form.control-group.label>

--- a/tests/Feature/Activities/ActivityTypeChangeTest.php
+++ b/tests/Feature/Activities/ActivityTypeChangeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Enums\ActivityStatus;
+use App\Enums\ActivityType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Activity\Models\Activity;
+use Webkul\User\Models\Group;
+use Webkul\User\Models\User;
+
+uses(RefreshDatabase::class);
+
+function makeTypeChangeActivity(array $attributes = []): Activity
+{
+    $group = Group::create([
+        'name'        => 'Type change test group',
+        'description' => 'Type change test group',
+    ]);
+
+    return Activity::create(array_merge([
+        'title'       => 'Type change test',
+        'type'        => ActivityType::TASK->value,
+        'schedule_to' => now()->addDay(),
+        'group_id'    => $group->id,
+        'is_done'     => false,
+        'status'      => ActivityStatus::ACTIVE,
+    ], $attributes));
+}
+
+test('can change activity type from task to call', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = makeTypeChangeActivity(['user_id' => $user->id]);
+
+    $response = $this->put(route('admin.activities.update', $activity->id), [
+        'title'       => $activity->title,
+        'type'        => ActivityType::CALL->value,
+        'schedule_to' => now()->addDay()->format('Y-m-d\TH:i'),
+        'group_id'    => $activity->group_id,
+    ]);
+
+    $response->assertRedirect();
+
+    $this->assertDatabaseHas('activities', [
+        'id'   => $activity->id,
+        'type' => ActivityType::CALL->value,
+    ]);
+});
+
+test('can change activity type from call to task', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = makeTypeChangeActivity([
+        'user_id' => $user->id,
+        'type'    => ActivityType::CALL->value,
+    ]);
+
+    $response = $this->put(route('admin.activities.update', $activity->id), [
+        'title'       => $activity->title,
+        'type'        => ActivityType::TASK->value,
+        'schedule_to' => now()->addDay()->format('Y-m-d\TH:i'),
+        'group_id'    => $activity->group_id,
+    ]);
+
+    $response->assertRedirect();
+
+    $this->assertDatabaseHas('activities', [
+        'id'   => $activity->id,
+        'type' => ActivityType::TASK->value,
+    ]);
+});
+
+test('cannot change non-user-selectable activity type', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = makeTypeChangeActivity([
+        'user_id' => $user->id,
+        'type'    => ActivityType::FILE->value,
+        'is_done' => true,
+    ]);
+
+    // FILE activities are read-only (is_done = true), so update is rejected
+    $response = $this->put(route('admin.activities.update', $activity->id), [
+        'title'    => $activity->title,
+        'type'     => ActivityType::TASK->value,
+        'group_id' => $activity->group_id,
+    ]);
+
+    // Should be rejected because activity is done
+    $this->assertDatabaseHas('activities', [
+        'id'   => $activity->id,
+        'type' => ActivityType::FILE->value,
+    ]);
+});
+
+test('cannot change task type to non-user-selectable type', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'user');
+
+    $activity = makeTypeChangeActivity(['user_id' => $user->id]);
+
+    $response = $this->put(route('admin.activities.update', $activity->id), [
+        'title'       => $activity->title,
+        'type'        => ActivityType::FILE->value,
+        'schedule_to' => now()->addDay()->format('Y-m-d\TH:i'),
+        'group_id'    => $activity->group_id,
+    ]);
+
+    $response->assertRedirect();
+
+    // Type should remain unchanged (FILE is not a valid user-selectable type)
+    $this->assertDatabaseHas('activities', [
+        'id'   => $activity->id,
+        'type' => ActivityType::TASK->value,
+    ]);
+});


### PR DESCRIPTION
## Summary

- Activiteitstype veld op de edit pagina is nu een dropdown voor CALL en TASK activiteiten (beide user-selectable types)
- Niet-bewerkbare types (FILE, PATIENT_MESSAGE, SYSTEM, NOTE) blijven read-only
- Controller beschermt tegen ongeldige type-wijzigingen: alleen user-selectable types mogen worden ingesteld, en alleen als de huidige type ook user-selectable is
- Tests toegevoegd voor de type-wijziging (task→call, call→task, en bescherming tegen ongeldige types)

## Changes

- `packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php` — Type veld toont nu een select dropdown wanneer het activiteitstype user-selectable is (CALL of TASK) en de activiteit niet read-only is
- `packages/Webkul/Admin/src/Http/Controllers/Activity/ActivityController.php` — Validatie toegevoegd in `update()`: type mag alleen gewijzigd worden tussen user-selectable types
- `tests/Feature/Activities/ActivityTypeChangeTest.php` — Feature tests voor type-wijziging

## Test plan

- [ ] Open een activiteit van type "Interne taak" → type dropdown toont "Interne taak" en "Belnotitie"
- [ ] Wijzig type naar "Belnotitie" en sla op → type is bijgewerkt
- [ ] Verifieer dat FILE/PATIENT_MESSAGE activiteiten geen dropdown tonen
- [ ] Verifieer dat CI tests slagen

Closes [MBS-291](https://github.com/privatescanbv/krayin-laravel-crm/issues/MBS-291)

🤖 Generated with [Claude Code](https://claude.com/claude-code)