### PR TITLE
fix: remove unreachable empty() check on pdf parser result

### DIFF
--- a/app/Services/Inkoop/InkoopPdfParser.php
+++ b/app/Services/Inkoop/InkoopPdfParser.php
@@ -38,9 +38,6 @@ class InkoopPdfParser
 
             $parser = new Parser;
             $pdf = $parser->parseFile($pdfPath);
-            if (empty($pdf)) {
-                throw new Exception('Empty pdf file, nothing to handle');
-            }
 
             // Extract text - try coordinate-based first, fallback to simple extraction
             $extractedText = $this->extractTextByCoordinates($pdf);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: app/Console/Commands/ImportOrdersFromSugarCRM.php
 
 		-
-			message: '#^Variable \$pdf in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: app/Services/Inkoop/InkoopPdfParser.php
-
-		-
 			message: '#^Call to an undefined method class@anonymous/Providers/AuditTrailServiceProvider\.php\:73\:\:belongsTo\(\)\.$#'
 			identifier: method.notFound
 			count: 2


### PR DESCRIPTION
## Summary

- `Parser::parseFile()` returns a `Document` object or throws an exception — it never returns null or an empty value
- The `empty($pdf)` guard was therefore always false and PHPStan correctly flagged it as `empty.variable`
- Removed the dead check and shrank the PHPStan baseline from 10 → 9 entries

## Test plan
- [ ] PHPStan baseline count drops by 1 (verify with `vendor/bin/larastan analyse`)
- [ ] Existing inkoop PDF parsing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)