### PR TITLE
fix: resolve method.notFound PHPStan warning in AuditTrailServiceProvider

### DIFF
--- a/app/Providers/AuditTrailServiceProvider.php
+++ b/app/Providers/AuditTrailServiceProvider.php
@@ -75,6 +75,7 @@ class AuditTrailServiceProvider extends ServiceProvider
             public function creator()
             {
                 return function () {
+                    /** @var \Illuminate\Database\Eloquent\Model $this */
                     return $this->belongsTo(User::class, 'created_by');
                 };
             }
@@ -82,6 +83,7 @@ class AuditTrailServiceProvider extends ServiceProvider
             public function updater()
             {
                 return function () {
+                    /** @var \Illuminate\Database\Eloquent\Model $this */
                     return $this->belongsTo(User::class, 'updated_by');
                 };
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -47,9 +47,3 @@ parameters:
 			identifier: larastan.console.undefinedOption
 			count: 2
 			path: app/Console/Commands/ImportOrdersFromSugarCRM.php
-
-		-
-			message: '#^Call to an undefined method class@anonymous/Providers/AuditTrailServiceProvider\.php\:73\:\:belongsTo\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: app/Providers/AuditTrailServiceProvider.php


### PR DESCRIPTION
## Summary

- Adds `/** @var \Illuminate\Database\Eloquent\Model $this */` annotations inside the mixin closures in `AuditTrailServiceProvider::addAuditTrailRelations()`
- PHPStan now knows `$this` inside those closures is a Model instance and can resolve `belongsTo()`
- Shrinks `phpstan-baseline.neon` from 10 → 9 entries (removes 2 `method.notFound` suppressions)

## Context

The `creator()` and `updater()` mixin methods return closures that are bound to a Model when called via `Model::mixin()`. PHPStan had no type information for `$this` inside those closures, causing false-positive `method.notFound` errors.

## Test plan
- [ ] `vendor/bin/larastan analyse` reports no new errors and baseline shrinks by 2
- [ ] Existing tests pass

Closes MBS-297 (partial — part of ongoing PHPStan baseline cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)