### PR TITLE
Add command to fix won order item statuses

### DIFF
--- a/app/Console/Commands/FixWonOrderItemStatuses.php
+++ b/app/Console/Commands/FixWonOrderItemStatuses.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\OrderItemStatus;
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class FixWonOrderItemStatuses extends Command
+{
+    private const CHUNK_SIZE = 100;
+
+    protected $signature = 'orders:fix-won-item-statuses
+                            {--dry-run : Toon voorgestelde wijzigingen zonder ze op te slaan}
+                            {--order-id=* : Beperk tot specifieke order IDs}';
+
+    protected $description = 'Zet orderregels van gewonnen orders die nog niet won/lost zijn op won';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $this->components->info(sprintf(
+            'Zoeken naar gewonnen orders met orderregels die nog niet won of lost zijn%s...',
+            $dryRun ? ' (dry-run)' : ''
+        ));
+
+        $query = $this->wonOrdersWithIncorrectItemsQuery();
+        $orderCount = (clone $query)->count();
+
+        if ($orderCount === 0) {
+            $this->info('Geen gewonnen orders gevonden met te corrigeren orderregels.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Gevonden {$orderCount} gewonnen order(s) met te corrigeren orderregels.");
+
+        $tableRows = [];
+        $updatedItemCount = 0;
+
+        $query->with(['orderItems' => function ($q) {
+            $q->whereNotIn('status', [
+                OrderItemStatus::WON->value,
+                OrderItemStatus::LOST->value,
+            ]);
+        }])->chunkById(self::CHUNK_SIZE, function (Collection $orders) use (&$tableRows, &$updatedItemCount, $dryRun) {
+            foreach ($orders as $order) {
+                /** @var Order $order */
+                $items = $order->orderItems;
+
+                if ($items->isEmpty()) {
+                    continue;
+                }
+
+                foreach ($items as $item) {
+                    /** @var OrderItem $item */
+                    $tableRows[] = [
+                        $order->id,
+                        $order->order_number ?? '—',
+                        $item->id,
+                        $item->status?->value ?? 'null',
+                        OrderItemStatus::WON->value,
+                    ];
+                }
+
+                $itemIds = $items->pluck('id');
+
+                if (! $dryRun) {
+                    OrderItem::query()
+                        ->whereIn('id', $itemIds)
+                        ->update(['status' => OrderItemStatus::WON->value]);
+                }
+
+                $updatedItemCount += $itemIds->count();
+            }
+        });
+
+        if ($tableRows === []) {
+            $this->info('Geen orderregels gevonden om te corrigeren.');
+
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->table(
+            ['Order ID', 'Ordernummer', 'Order item ID', 'Huidige status', 'Nieuwe status'],
+            $tableRows,
+        );
+
+        if ($dryRun) {
+            $this->warn("Dry-run: {$updatedItemCount} orderregel(s) zouden naar won worden gezet.");
+            $this->info('Voer uit zonder --dry-run om deze wijzigingen door te voeren.');
+        } else {
+            $this->info("✓ {$updatedItemCount} orderregel(s) bijgewerkt naar won.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Won orders that still have order items whose status is neither won nor lost.
+     *
+     * @return Builder<Order>
+     */
+    private function wonOrdersWithIncorrectItemsQuery(): Builder
+    {
+        $query = Order::query()
+            ->whereHas('stage', fn (Builder $stage) => $stage->where('is_won', true))
+            ->whereHas('orderItems', function (Builder $items) {
+                $items->whereNotIn('status', [
+                    OrderItemStatus::WON->value,
+                    OrderItemStatus::LOST->value,
+                ]);
+            })
+            ->orderBy('id');
+
+        $orderIds = array_values(array_filter(
+            array_map('intval', (array) $this->option('order-id')),
+            fn (int $id) => $id > 0,
+        ));
+
+        if ($orderIds !== []) {
+            $query->whereIn('id', $orderIds);
+        }
+
+        return $query;
+    }
+}

--- a/app/Console/Commands/FixWonOrderItemStatuses.php
+++ b/app/Console/Commands/FixWonOrderItemStatuses.php
@@ -92,10 +92,10 @@ class FixWonOrderItemStatuses extends Command
         );
 
         if ($dryRun) {
-            $this->warn("Dry-run: {$updatedItemCount} orderregel(s) zouden naar won worden gezet.");
+            $this->info("Dry-run: {$updatedItemCount} orderregel(s) zouden naar won worden gezet.");
             $this->info('Voer uit zonder --dry-run om deze wijzigingen door te voeren.');
         } else {
-            $this->info("✓ {$updatedItemCount} orderregel(s) bijgewerkt naar won.");
+            $this->info("{$updatedItemCount} orderregel(s) bijgewerkt naar won.");
         }
 
         return self::SUCCESS;

--- a/tests/Feature/Console/FixWonOrderItemStatusesCommandTest.php
+++ b/tests/Feature/Console/FixWonOrderItemStatusesCommandTest.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\OrderItem;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 
 uses(RefreshDatabase::class);
 
@@ -36,13 +37,16 @@ test('dry run lists incorrect items on won orders without persisting changes', f
         'status'   => OrderItemStatus::LOST->value,
     ]);
 
-    $this->artisan(FixWonOrderItemStatuses::class, ['--dry-run' => true])
-        ->expectsOutputToContain((string) $newItem->id)
-        ->expectsOutputToContain((string) $plannedItem->id)
-        ->expectsOutputToContain('Dry-run')
-        ->assertSuccessful();
+    $exitCode = Artisan::call(FixWonOrderItemStatuses::class, ['--dry-run' => true]);
+    $output = Artisan::output();
 
-    expect($newItem->fresh()->status)->toBe(OrderItemStatus::NEW)
+    expect($exitCode)->toBe(0)
+        ->and($output)->toContain('Order item ID')
+        ->and($output)->toContain((string) $newItem->id)
+        ->and($output)->toContain((string) $plannedItem->id)
+        ->and($output)->toContain('zouden naar won worden gezet')
+        ->and($output)->toContain('zonder --dry-run')
+        ->and($newItem->fresh()->status)->toBe(OrderItemStatus::NEW)
         ->and($plannedItem->fresh()->status)->toBe(OrderItemStatus::PLANNED)
         ->and($wonItem->fresh()->status)->toBe(OrderItemStatus::WON)
         ->and($lostItem->fresh()->status)->toBe(OrderItemStatus::LOST);

--- a/tests/Feature/Console/FixWonOrderItemStatusesCommandTest.php
+++ b/tests/Feature/Console/FixWonOrderItemStatusesCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Console\Commands\FixWonOrderItemStatuses;
+use App\Enums\OrderItemStatus;
+use App\Enums\PipelineStage;
+use App\Models\Order;
+use App\Models\OrderItem;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+});
+
+test('dry run lists incorrect items on won orders without persisting changes', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_GEWONNEN->id(),
+    ]);
+
+    $newItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+    $plannedItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::PLANNED->value,
+    ]);
+    $wonItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::WON->value,
+    ]);
+    $lostItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::LOST->value,
+    ]);
+
+    $this->artisan(FixWonOrderItemStatuses::class, ['--dry-run' => true])
+        ->expectsOutputToContain((string) $newItem->id)
+        ->expectsOutputToContain((string) $plannedItem->id)
+        ->expectsOutputToContain('Dry-run')
+        ->assertSuccessful();
+
+    expect($newItem->fresh()->status)->toBe(OrderItemStatus::NEW)
+        ->and($plannedItem->fresh()->status)->toBe(OrderItemStatus::PLANNED)
+        ->and($wonItem->fresh()->status)->toBe(OrderItemStatus::WON)
+        ->and($lostItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('command updates non won and non lost items on won orders to won', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_GEWONNEN->id(),
+    ]);
+
+    $newItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+    $plannedItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::PLANNED->value,
+    ]);
+    $wonItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::WON->value,
+    ]);
+    $lostItem = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::LOST->value,
+    ]);
+
+    $this->artisan(FixWonOrderItemStatuses::class)
+        ->expectsOutputToContain('bijgewerkt naar won')
+        ->assertSuccessful();
+
+    expect($newItem->fresh()->status)->toBe(OrderItemStatus::WON)
+        ->and($plannedItem->fresh()->status)->toBe(OrderItemStatus::WON)
+        ->and($wonItem->fresh()->status)->toBe(OrderItemStatus::WON)
+        ->and($lostItem->fresh()->status)->toBe(OrderItemStatus::LOST);
+});
+
+test('command also fixes hernia won orders', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_GEWONNEN_HERNIA->id(),
+    ]);
+
+    $item = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+
+    $this->artisan(FixWonOrderItemStatuses::class)->assertSuccessful();
+
+    expect($item->fresh()->status)->toBe(OrderItemStatus::WON);
+});
+
+test('command ignores orders that are not won', function () {
+    $order = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_UITGEVOERD->id(),
+    ]);
+
+    $item = OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+
+    $this->artisan(FixWonOrderItemStatuses::class)
+        ->expectsOutputToContain('Geen gewonnen orders gevonden')
+        ->assertSuccessful();
+
+    expect($item->fresh()->status)->toBe(OrderItemStatus::NEW);
+});
+
+test('command can be limited to specific order ids', function () {
+    $target = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_GEWONNEN->id(),
+    ]);
+    $other = Order::factory()->create([
+        'pipeline_stage_id' => PipelineStage::ORDER_GEWONNEN->id(),
+    ]);
+
+    $targetItem = OrderItem::factory()->create([
+        'order_id' => $target->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+    $otherItem = OrderItem::factory()->create([
+        'order_id' => $other->id,
+        'status'   => OrderItemStatus::NEW->value,
+    ]);
+
+    $this->artisan(FixWonOrderItemStatuses::class, ['--order-id' => [$target->id]])
+        ->assertSuccessful();
+
+    expect($targetItem->fresh()->status)->toBe(OrderItemStatus::WON)
+        ->and($otherItem->fresh()->status)->toBe(OrderItemStatus::NEW);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Artisan command `orders:fix-won-item-statuses` to correct historical data where won orders still have order items that are neither `won` nor `lost`.

### Behavior
- Finds orders whose pipeline stage has `is_won = true` (Privatescan `ORDER_GEWONNEN` + Hernia `ORDER_GEWONNEN_HERNIA`)
- Finds related order items whose status is not `won` or `lost`
- Updates those remaining items to `won` (existing `lost` items are left unchanged)
- Supports `--dry-run` to preview without writing
- Supports `--order-id=*` to limit scope

### Usage
```bash
php artisan orders:fix-won-item-statuses --dry-run
php artisan orders:fix-won-item-statuses
php artisan orders:fix-won-item-statuses --order-id=123 --order-id=456
```

### Tests
Pest coverage for dry-run, apply, hernia won stages, non-won orders, and `--order-id` filtering (5 tests passing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42ae7caa-fd9a-4885-9259-4d1f8c71fb2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42ae7caa-fd9a-4885-9259-4d1f8c71fb2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

