### PR TITLE
fix: bump phpseclib to resolve Dependabot SSRF advisory

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5353,16 +5353,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
+            "version": "3.0.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305",
                 "shasum": ""
             },
             "require": {
@@ -5443,7 +5443,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.56"
             },
             "funding": [
                 {
@@ -5459,7 +5459,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-27T07:02:15+00:00"
+            "time": "2026-08-03T04:36:50+00:00"
         },
         {
             "name": "prettus/l5-repository",


### PR DESCRIPTION
## Summary
- Bumps `phpseclib/phpseclib` from 3.0.52 to 3.0.56 (patch release, no major version change) to resolve [GHSA-m557-wrgg-6rp4](https://github.com/advisories/GHSA-m557-wrgg-6rp4) — an SSRF issue in X.509 Authority Information Access certificate validation. Fixed in 3.0.54; existing `^3.0.36` composer constraint already allows this version, so `composer.json` is unchanged.
- No application code was touched.

## Out of scope (needs manual review)
The remaining 9 open Dependabot alerts (2 high, 6 medium, 1 low) all target `org.keycloak:keycloak-*` in `.docker/keycloak/http-events-custom/pom.xml`, a `provided`-scope compile dependency for a custom Keycloak SPI extension. The actual running Keycloak server is pinned to `quay.io/keycloak/keycloak:24.0` in `docker-compose.yml`. Fixing these advisories requires a **major version upgrade of the Keycloak server itself (24.x → 26.x)**, which:
- is a major version bump (out of scope per this task's "avoid major bumps unless required" constraint),
- affects the production SSO/identity service and needs its own dedicated testing/rollout,
- may involve breaking changes to the custom SPI's compile-time API surface.

Recommend tracking this as a separate, dedicated infrastructure task.

## Test plan
- [x] `composer update phpseclib/phpseclib --with-dependencies` — only `phpseclib/phpseclib` changed in `composer.lock`
- [x] Full Pest test suite: `php artisan test` — 1529 passed, 4 skipped (pre-existing skips), 0 failed
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] Verified `composer.json` constraint (`^3.0.36`) already covers the patched version, no manifest change needed