### PR TITLE
fix(mail): show status and creation date when linking a lead/sale to an email

### DIFF
--- a/packages/Webkul/Admin/src/Http/Resources/LeadLookupResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/LeadLookupResource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Resources;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class LeadLookupResource extends JsonResource
@@ -10,7 +11,7 @@ class LeadLookupResource extends JsonResource
      * Transform the resource into an array.
      * Minimal resource for lookup/search operations to avoid N+1 queries.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  Request
      * @return array
      */
     public function toArray($request)
@@ -25,25 +26,28 @@ class LeadLookupResource extends JsonResource
             'married_name_prefix'  => $this->married_name_prefix,
             'emails'               => is_array($this->emails) ? $this->emails : [],
             'phones'               => is_array($this->phones) ? $this->phones : [],
-            
+            'created_at'           => $this->created_at,
+
             // Minimal relationship data - only IDs and names, no nested relationships
             'lead_pipeline_stage_id' => $this->lead_pipeline_stage_id,
-            'stage'                => $this->when(
+            'stage'                  => $this->when(
                 $this->relationLoaded('stage'),
-                fn() => $this->stage ? [
-                    'id' => $this->stage->id,
-                    'name' => $this->stage->name,
+                fn () => $this->stage ? [
+                    'id'      => $this->stage->id,
+                    'name'    => $this->stage->name,
+                    'is_won'  => (bool) $this->stage->is_won,
+                    'is_lost' => (bool) $this->stage->is_lost,
                 ] : null
             ),
             'user_id'              => $this->user_id,
             'user'                 => $this->when(
                 $this->relationLoaded('user'),
-                fn() => $this->user ? [
-                    'id' => $this->user->id,
+                fn () => $this->user ? [
+                    'id'   => $this->user->id,
                     'name' => $this->user->name,
                 ] : null
             ),
-            
+
             // IDs only for other relationships
             'lead_source_id'       => $this->lead_source_id,
             'lead_type_id'         => $this->lead_type_id,
@@ -54,4 +58,3 @@ class LeadLookupResource extends JsonResource
         ];
     }
 }
-

--- a/packages/Webkul/Admin/src/Http/Resources/SalesLeadLookupResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/SalesLeadLookupResource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Resources;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class SalesLeadLookupResource extends JsonResource
@@ -10,7 +11,7 @@ class SalesLeadLookupResource extends JsonResource
      * Transform the resource into an array.
      * Minimal resource for lookup/search operations to avoid N+1 queries.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  Request
      * @return array
      */
     public function toArray($request)
@@ -19,20 +20,23 @@ class SalesLeadLookupResource extends JsonResource
             'id'                   => $this->id,
             'name'                 => $this->name,
             'description'          => $this->description,
+            'created_at'           => $this->created_at,
 
             // Minimal relationship data - only IDs and names, no nested relationships
             'pipeline_stage_id'    => $this->pipeline_stage_id,
             'stage'                => $this->when(
                 $this->relationLoaded('stage'),
-                fn() => $this->pipelineStage ? [
-                    'id'   => $this->pipelineStage->id,
-                    'name' => $this->pipelineStage->name,
+                fn () => $this->stage ? [
+                    'id'      => $this->stage->id,
+                    'name'    => $this->stage->name,
+                    'is_won'  => (bool) $this->stage->is_won,
+                    'is_lost' => (bool) $this->stage->is_lost,
                 ] : null
             ),
             'user_id'              => $this->user_id,
             'user'                 => $this->when(
                 $this->relationLoaded('user'),
-                fn() => $this->user ? [
+                fn () => $this->user ? [
                     'id'   => $this->user->id,
                     'name' => $this->user->name,
                 ] : null
@@ -43,4 +47,3 @@ class SalesLeadLookupResource extends JsonResource
         ];
     }
 }
-

--- a/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/mail/view.blade.php
@@ -724,14 +724,21 @@
                                     <li
                                         v-for="lead in leads"
                                         :key="lead.id"
+                                        :title="leadTooltip(lead)"
                                         class="flex cursor-pointer gap-2 px-4 py-2 text-gray-800 transition-colors hover:bg-blue-100 dark:text-white dark:hover:bg-gray-900"
                                         @click="linkLead(lead)"
                                     >
                                         <x-admin::avatar ::name="lead.name" />
 
                                         <!-- Lead Title -->
-                                        <div class="flex flex-col gap-1">
+                                        <div class="flex flex-1 items-center justify-between gap-2">
                                             <span>@{{ lead.name }}</span>
+                                            <span
+                                                v-if="lead.stage?.name"
+                                                class="shrink-0 rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                                            >
+                                                @{{ lead.stage.name }}
+                                            </span>
                                         </div>
                                     </li>
 
@@ -809,15 +816,28 @@
 
                         <ul class="max-h-40 divide-y divide-gray-100 overflow-y-auto dark:divide-gray-700">
                             <li
-                                v-for="salesLead in salesLeads"
+                                v-for="salesLead in sortedSalesLeads"
                                 :key="salesLead.id"
+                                :title="salesLeadTooltip(salesLead)"
                                 class="flex cursor-pointer gap-2 px-4 py-2 text-gray-800 transition-colors hover:bg-blue-100 dark:text-white dark:hover:bg-gray-900"
                                 @click="linkSalesLead(salesLead)"
                             >
                                 <x-admin::avatar ::name="salesLead.name" />
-                                <div class="flex flex-col gap-1">
+                                <div class="flex flex-1 items-center justify-between gap-2">
                                     <span>@{{ salesLead.name }}</span>
-                                    <span class="text-xs text-gray-500">@{{ salesLead.stage?.name }}</span>
+                                    <span
+                                        v-if="salesLead.stage?.name"
+                                        :class="[
+                                            'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
+                                            salesLead.stage?.is_won
+                                                ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                                                : salesLead.stage?.is_lost
+                                                    ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                                                    : 'bg-slate-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200'
+                                        ]"
+                                    >
+                                        @{{ salesLead.stage.name }}
+                                    </span>
                                 </div>
                             </li>
                             <li v-if="salesLeads.length === 0" class="px-4 py-2 text-gray-800 dark:text-gray-300">
@@ -1439,10 +1459,7 @@
                             ((item.name || item.title || '')).toLowerCase().includes(term)
                         );
                         // Exclude won/lost stages
-                        list = list.filter(lead => {
-                            const code = lead?.stage?.code || '';
-                            return !(code.startsWith('won') || code.startsWith('lost'));
-                        });
+                        list = list.filter(lead => !(lead?.stage?.is_won || lead?.stage?.is_lost));
                         // If email has a selected person, filter to leads containing that person
                         const pid = this.$parent?.email?.person_id || this.email?.person_id || null;
                         if (pid) {
@@ -1453,6 +1470,8 @@
                                 return arr.some(p => p.id === pid);
                             });
                         }
+                        // Most recently created (most likely relevant) lead first
+                        list = [...list].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
                         return list;
                     },
                 },
@@ -1564,6 +1583,22 @@
 
                         this.$emit('open-lead-modal');
                     },
+
+                    /**
+                     * Tooltip text with the creation date, used to help
+                     * distinguish between multiple similarly named leads.
+                     *
+                     * @param {Object} lead
+                     *
+                     * @return {string|undefined}
+                     */
+                    leadTooltip(lead) {
+                        if (! lead.created_at) {
+                            return undefined;
+                        }
+
+                        return 'Aangemaakt op ' + this.$admin.formatDate(lead.created_at, 'd MMM yyyy, HH:mm');
+                    },
                 },
             });
         </script>
@@ -1583,6 +1618,26 @@
                         salesLeads: [],
                         selectedItem: {},
                     };
+                },
+
+                computed: {
+                    /**
+                     * Active/ongoing sales leads first, most recently created first.
+                     *
+                     * @return {Array}
+                     */
+                    sortedSalesLeads() {
+                        return [...this.salesLeads].sort((a, b) => {
+                            const aClosed = a.stage?.is_won || a.stage?.is_lost ? 1 : 0;
+                            const bClosed = b.stage?.is_won || b.stage?.is_lost ? 1 : 0;
+
+                            if (aClosed !== bClosed) {
+                                return aClosed - bClosed;
+                            }
+
+                            return new Date(b.created_at) - new Date(a.created_at);
+                        });
+                    },
                 },
 
                 methods: {
@@ -1605,7 +1660,7 @@
                             }
                         })
                             .then(response => {
-                                this.salesLeads = response.data;
+                                this.salesLeads = response.data.data ?? [];
                             })
                             .catch(error => {
                                 this.$emitter.emit('add-flash', { type: 'error', message: error.response.data.message });
@@ -1619,6 +1674,22 @@
                         this.$emit('link-sales-lead', salesLead);
                         this.showPopup = false;
                         this.selectedItem = salesLead;
+                    },
+
+                    /**
+                     * Tooltip text with the creation date, used to help
+                     * distinguish between multiple similarly named sales leads.
+                     *
+                     * @param {Object} salesLead
+                     *
+                     * @return {string|undefined}
+                     */
+                    salesLeadTooltip(salesLead) {
+                        if (! salesLead.created_at) {
+                            return undefined;
+                        }
+
+                        return 'Aangemaakt op ' + this.$admin.formatDate(salesLead.created_at, 'd MMM yyyy, HH:mm');
                     },
                 },
 

--- a/tests/Feature/Leads/LeadControllerSearchTest.php
+++ b/tests/Feature/Leads/LeadControllerSearchTest.php
@@ -36,6 +36,30 @@ test('lead search returns 400 for invalid search field', function () {
         ->assertJsonStructure(['message', 'field']);
 });
 
+test('lead search returns stage and created_at so the entity-link picker can distinguish results', function () {
+    $lead = Lead::factory()->create([
+        'first_name'             => 'Stage',
+        'last_name'              => 'Info',
+        'lead_pipeline_id'       => $this->pipeline->id,
+        'lead_pipeline_stage_id' => $this->stage->id,
+        'user_id'                => $this->user->id,
+    ]);
+
+    $response = $this->getJson(route('admin.leads.search', [
+        'search'       => 'first_name:Stage;',
+        'searchFields' => 'first_name:like;',
+    ]));
+
+    $response->assertOk();
+
+    $result = collect($response->json('data'))->firstWhere('id', $lead->id);
+
+    expect($result)->not->toBeNull();
+    expect($result['created_at'])->not->toBeNull();
+    expect($result['stage']['name'])->toBe($this->stage->name);
+    expect($result['stage'])->toHaveKeys(['is_won', 'is_lost']);
+});
+
 test('lead search can find by email and phone', function () {
     // Create a lead with emails/phones arrays
     $lead = Lead::factory()->create([

--- a/tests/Feature/SalesLeadControllerSearchTest.php
+++ b/tests/Feature/SalesLeadControllerSearchTest.php
@@ -40,6 +40,28 @@ test('sales lead search by name works', function () {
     expect($ids)->toContain($salesLead->id);
 });
 
+test('sales lead search returns stage and created_at so the entity-link picker can distinguish results', function () {
+    $salesLead = SalesLead::factory()->create([
+        'name'              => 'Test Sales Lead',
+        'pipeline_stage_id' => $this->stage->id,
+        'user_id'           => $this->user->id,
+    ]);
+
+    $response = $this->getJson(route('admin.sales-leads.search', [
+        'search'       => 'name:Test;',
+        'searchFields' => 'name:like;',
+    ]));
+
+    $response->assertOk();
+
+    $result = collect($response->json('data'))->firstWhere('id', $salesLead->id);
+
+    expect($result)->not->toBeNull();
+    expect($result['created_at'])->not->toBeNull();
+    expect($result['stage']['name'])->toBe($this->stage->name);
+    expect($result['stage'])->toHaveKeys(['is_won', 'is_lost']);
+});
+
 test('sales lead search ignores email field (does not exist)', function () {
     $salesLead = SalesLead::factory()->create([
         'name'              => 'Test Sales Lead',


### PR DESCRIPTION
## Summary

Linked to MBS-335: when linking an email to a lead/sales lead, Linda often saw multiple similarly-named results with no way to tell them apart, and it took a long time to pick the right one.

- Lead and sales-lead lookup results now show the pipeline stage/status next to the title.
- Hovering a result shows the creation date in a tooltip.
- Active/ongoing leads and sales are sorted to the top (most recently created first); closed ones sink to the bottom.
- Fixed the sales-lead lookup, which was silently broken: it read a non-existent `pipelineStage` relation (always `null`) and assigned the raw `{data: [...]}` API envelope to the results array instead of unwrapping it — so status never rendered and the sort/status work would have had nothing to build on.
- `LeadLookupResource`/`SalesLeadLookupResource` now return `created_at` and `stage.is_won`/`stage.is_lost` so the frontend can distinguish and sort results. Also fixed a dead client-side filter that referenced a `stage.code` field the API never returned.

## Test plan

- [x] `vendor/bin/pest tests/Feature/SalesLeadControllerSearchTest.php tests/Feature/Leads/LeadControllerSearchTest.php` — 12 passed (46 assertions), including two new tests asserting the resources expose `created_at` and `stage.is_won`/`is_lost`.
- [x] `vendor/bin/pint` (Duster/Pint) on changed PHP files.
- [ ] Manual check in the browser: open an email, link to a lead/sales lead with multiple candidates, confirm status badge + tooltip + ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)