### PR TITLE
feat: Handmatig leads zoeken en samenvoegen vanaf View Lead

### DIFF
--- a/docs/modules/application/pages/duplicate-leads.adoc
+++ b/docs/modules/application/pages/duplicate-leads.adoc
@@ -50,7 +50,17 @@ Lead Detail Weergave
 
 * Oranje waarschuwingsbanner verschijnt bovenaan wanneer duplicaten worden gedetecteerd
 * Toont aantal mogelijke duplicaten
-* "Merge Duplicates" knop biedt directe toegang tot samenvoeg interface
+* "Duplicaten samenvoegen" knop biedt directe toegang tot samenvoeg interface
+* Actie "Lead samenvoegen" is altijd beschikbaar om handmatig een andere lead te zoeken en samen te voegen (ook buiten de detectieperiode)
+
+====== 2.1. Handmatig samenvoegen
+
+Wanneer een duplicaat niet automatisch is herkend:
+
+. Open de lead en kies *Lead samenvoegen*
+. Zoek en selecteer één andere lead
+. Via *Verder* opent het bestaande Merge leads-scherm met de huidige lead als primaire lead en de gekozen lead als duplicaat
+. Vanaf daar geldt de bestaande samenvoegfunctionaliteit
 
 ====== 3. Samenvoeg Interface
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/DuplicateController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/DuplicateController.php
@@ -27,11 +27,31 @@ class DuplicateController extends Controller
 
     /**
      * Show potential duplicates for a lead.
+     *
+     * Optional query param `with` injects a manually chosen lead into the merge screen
+     * (used by the manual "Lead samenvoegen" flow) without changing automatic detection.
      */
     public function index(int $leadId): View
     {
-        $lead = $this->leadRepository->with(['stage', 'pipeline', 'user'])->findOrFail($leadId);
+        $lead = $this->leadRepository->with(['stage', 'pipeline', 'user', 'organization', 'contactPerson'])->findOrFail($leadId);
         $duplicates = $this->leadRepository->findPotentialDuplicates($lead);
+
+        $preselectedLeadIds = [];
+        $manualLeadId = (int) request()->query('with', 0);
+
+        if ($manualLeadId > 0 && $manualLeadId !== $leadId) {
+            $manualLead = $this->leadRepository
+                ->with(['stage', 'pipeline', 'user', 'organization', 'contactPerson'])
+                ->find($manualLeadId);
+
+            if ($manualLead && ! $duplicates->contains('id', $manualLeadId)) {
+                $duplicates = $duplicates->prepend($manualLead)->values();
+            }
+
+            if ($manualLead) {
+                $preselectedLeadIds[] = $manualLeadId;
+            }
+        }
 
         // Use LeadResource for consistent data formatting
         $leadData = array_merge((new LeadResource($lead))->resolve(), $this->mergeScreenFields($lead));
@@ -62,6 +82,19 @@ class DuplicateController extends Controller
             'duplicates' => $duplicates,
             'leadData' => $leadData,
             'duplicatesData' => $duplicatesData,
+            'preselectedLeadIds' => $preselectedLeadIds,
+        ]);
+    }
+
+    /**
+     * Manual merge entry: search and select another lead to merge with the current one.
+     */
+    public function select(int $leadId): View
+    {
+        $lead = $this->leadRepository->with(['stage', 'user'])->findOrFail($leadId);
+
+        return view('admin::leads.duplicates.select', [
+            'lead' => $lead,
         ]);
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/duplicates/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/duplicates/index.blade.php
@@ -24,6 +24,7 @@
             <v-duplicates-manager
                 :primary-lead="{{ json_encode($leadData) }}"
                 :duplicates="{{ json_encode($duplicatesData) }}"
+                :preselected-lead-ids="{{ json_encode($preselectedLeadIds ?? []) }}"
                 merge-url="{{ route('admin.leads.duplicates.merge', $lead->id) }}"
                 false-positive-url="{{ route('admin.leads.duplicates.false_positive', $lead->id) }}"
                 redirect-url="{{ route('admin.leads.view', $lead->id) }}"
@@ -337,10 +338,27 @@
         <script type="module">
             app.component('v-duplicates-manager', {
                 template: '#v-duplicates-manager-template',
-                props: ['primaryLead', 'duplicates', 'mergeUrl', 'falsePositiveUrl', 'redirectUrl'],
+                props: {
+                    primaryLead: { type: Object, required: true },
+                    duplicates: { type: Array, required: true },
+                    mergeUrl: { type: String, required: true },
+                    falsePositiveUrl: { type: String, required: true },
+                    redirectUrl: { type: String, required: true },
+                    preselectedLeadIds: { type: Array, default: () => [] },
+                },
                 data() {
+                    const initialSelected = [this.primaryLead.id];
+
+                    (this.preselectedLeadIds || []).forEach((id) => {
+                        const leadId = Number(id);
+
+                        if (leadId && ! initialSelected.includes(leadId)) {
+                            initialSelected.push(leadId);
+                        }
+                    });
+
                     return {
-                        selectedLeads: [this.primaryLead.id], // Primary lead is always selected
+                        selectedLeads: initialSelected, // Primary lead is always selected
                         fieldMappings: {},
                         isLoading: false,
                         showIdenticalFields: false, // Control visibility of identical fields

--- a/packages/Webkul/Admin/src/Resources/views/leads/duplicates/select.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/duplicates/select.blade.php
@@ -1,0 +1,221 @@
+<x-admin::layouts>
+    <x-slot:title>
+        Lead samenvoegen - {{ $lead->name }}
+    </x-slot>
+
+    <v-manual-lead-merge
+        entity-name="{{ $lead->name }}"
+        :exclude-lead-id='@json($lead->id)'
+        back-url="{{ route('admin.leads.view', $lead->id) }}"
+        search-url="{{ route('admin.leads.search') }}"
+        continue-url-template="{{ route('admin.leads.duplicates.index', ['id' => $lead->id, 'with' => '__LEAD_ID__']) }}"
+    ></v-manual-lead-merge>
+
+    @pushOnce('scripts', 'manual-lead-merge-page')
+        <script type="text/x-template" id="v-manual-lead-merge-template">
+            <div class="flex flex-col gap-4 pt-3">
+                <div class="flex items-center justify-between rounded-lg border bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-900">
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs font-medium text-gray-500 dark:text-gray-400">Huidige lead</span>
+                        <h1 class="text-xl font-semibold text-gray-900 dark:text-white">@{{ entityName }}</h1>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">ID: @{{ excludeLeadId }}</p>
+                    </div>
+
+                    <a :href="backUrl" class="secondary-button flex items-center gap-1 border hover:border-neutral-text hover:text-neutral-text">
+                        <span class="icon-arrow-left text-base"></span>
+                        <span>Terug naar lead</span>
+                    </a>
+                </div>
+
+                <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr),360px]">
+                    <div class="rounded-lg border bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                        <div class="mb-4 flex flex-col gap-1">
+                            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Andere lead zoeken</h2>
+                            <p class="text-sm text-gray-500 dark:text-gray-400">
+                                Zoek op naam, e-mail of telefoonnummer. Ook leads buiten de automatische detectieperiode zijn beschikbaar.
+                            </p>
+                        </div>
+
+                        <div class="relative">
+                            <input
+                                v-model="query"
+                                type="text"
+                                class="w-full rounded border border-gray-300 px-4 py-2.5 text-sm text-gray-900 outline-none transition-all focus:border-blue-500 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                                placeholder="Zoek lead"
+                                @input="queueSearch"
+                            >
+                            <span v-if="loading" class="absolute right-3 top-2.5 text-sm text-gray-400">Zoeken...</span>
+                        </div>
+
+                        <div class="mt-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+                            <button
+                                v-for="lead in leads"
+                                :key="lead.id"
+                                type="button"
+                                class="flex w-full items-center justify-between gap-4 border-b border-gray-200 px-4 py-3 text-left last:border-b-0 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800"
+                                :class="selectedLead && selectedLead.id === lead.id ? 'bg-blue-50 dark:bg-blue-900/20' : 'bg-white dark:bg-gray-900'"
+                                @click="selectLead(lead)"
+                            >
+                                <span class="min-w-0">
+                                    <span class="block truncate text-sm font-medium text-gray-900 dark:text-white">
+                                        @{{ lead.name || [lead.first_name, lead.last_name].filter(Boolean).join(' ') || ('Lead #' + lead.id) }}
+                                    </span>
+                                    <span class="block truncate text-xs text-gray-500 dark:text-gray-400">
+                                        #@{{ lead.id }}
+                                        <template v-if="lead.stage?.name"> · @{{ lead.stage.name }}</template>
+                                        <template v-if="contactLine(lead)"> · @{{ contactLine(lead) }}</template>
+                                    </span>
+                                </span>
+
+                                <span
+                                    v-if="selectedLead && selectedLead.id === lead.id"
+                                    class="icon-check shrink-0 text-lg text-activity-note-text"
+                                ></span>
+                            </button>
+
+                            <div v-if="! loading && query.trim() && leads.length === 0" class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                                Geen leads gevonden.
+                            </div>
+
+                            <div v-if="! loading && ! query.trim()" class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                                Typ om te zoeken naar een lead om samen te voegen.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-4">
+                        <div class="rounded-lg border bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+                            <h2 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">Selectie</h2>
+
+                            <div v-if="selectedLead" class="flex flex-col gap-3">
+                                <div>
+                                    <div class="text-sm font-medium text-gray-900 dark:text-white">
+                                        @{{ selectedLead.name || [selectedLead.first_name, selectedLead.last_name].filter(Boolean).join(' ') || ('Lead #' + selectedLead.id) }}
+                                    </div>
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        #@{{ selectedLead.id }}
+                                        <template v-if="selectedLead.stage?.name"> · @{{ selectedLead.stage.name }}</template>
+                                    </div>
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">@{{ contactLine(selectedLead) || 'Geen contactgegevens' }}</div>
+                                </div>
+
+                                <a
+                                    :href="continueUrl"
+                                    class="primary-button w-full justify-center"
+                                >
+                                    Verder
+                                </a>
+                            </div>
+
+                            <div v-else class="flex flex-col gap-3">
+                                <p class="text-sm text-gray-500 dark:text-gray-400">
+                                    Selecteer één andere lead uit de zoekresultaten.
+                                </p>
+
+                                <button
+                                    type="button"
+                                    disabled
+                                    class="primary-button w-full justify-center opacity-50 cursor-not-allowed"
+                                >
+                                    Verder
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </script>
+
+        <script type="module">
+            app.component('v-manual-lead-merge', {
+                template: '#v-manual-lead-merge-template',
+
+                props: {
+                    entityName: String,
+                    excludeLeadId: Number,
+                    backUrl: String,
+                    searchUrl: String,
+                    continueUrlTemplate: String,
+                },
+
+                data() {
+                    return {
+                        query: '',
+                        leads: [],
+                        selectedLead: null,
+                        loading: false,
+                        timer: null,
+                    };
+                },
+
+                computed: {
+                    continueUrl() {
+                        if (! this.selectedLead) {
+                            return '#';
+                        }
+
+                        return this.continueUrlTemplate.replace('__LEAD_ID__', this.selectedLead.id);
+                    },
+                },
+
+                methods: {
+                    queueSearch() {
+                        clearTimeout(this.timer);
+                        this.timer = setTimeout(() => this.search(), 250);
+                    },
+
+                    async search() {
+                        const term = this.query.trim();
+
+                        if (! term) {
+                            this.leads = [];
+                            this.loading = false;
+
+                            return;
+                        }
+
+                        this.loading = true;
+
+                        try {
+                            const response = await fetch(`${this.searchUrl}?${new URLSearchParams({
+                                query: term,
+                                limit: '25',
+                            }).toString()}`, {
+                                headers: {
+                                    'Accept': 'application/json',
+                                },
+                            });
+
+                            const payload = await response.json();
+                            const result = payload?.data ?? payload ?? [];
+
+                            this.leads = (Array.isArray(result) ? result : [])
+                                .filter(lead => Number(lead.id) !== Number(this.excludeLeadId));
+                        } finally {
+                            this.loading = false;
+                        }
+                    },
+
+                    selectLead(lead) {
+                        this.selectedLead = lead;
+                    },
+
+                    contactLine(lead) {
+                        const email = this.firstValue(lead.emails);
+                        const phone = this.firstValue(lead.phones);
+
+                        return [email, phone].filter(Boolean).join(' | ');
+                    },
+
+                    firstValue(items) {
+                        if (! Array.isArray(items) || ! items.length) {
+                            return '';
+                        }
+
+                        return items[0]?.value || '';
+                    },
+                },
+            });
+        </script>
+    @endPushOnce
+</x-admin::layouts>

--- a/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
@@ -98,15 +98,13 @@
                             <x-admin::activities.actions.activity :entity="$lead" entity-control-name="lead_id"/>
                         @endif
 
-                        {!! view_render_event('admin.leads.view.actions.after', ['lead' => $lead]) !!}
-                    </div>
-
-                    <div class="mt-2">
                         <a href="{{ route('admin.leads.duplicates.select', $lead->id) }}"
-                           class="secondary-button inline-flex items-center gap-1 border hover:border-neutral-text hover:text-neutral-text">
-                            <span class="icon-setting text-base"></span>
-                            <span>Lead samenvoegen</span>
+                           class="flex h-[74px] w-[84px] flex-col items-center justify-center gap-1 rounded-lg border border-transparent bg-orange-50 font-medium text-orange-700 transition-all hover:border-orange-300 dark:bg-orange-900/20 dark:text-orange-300 dark:hover:border-orange-700">
+                            <span class="icon-setting text-2xl dark:!text-orange-300"></span>
+                            <span class="px-1 text-center text-xs leading-tight">Lead samenvoegen</span>
                         </a>
+
+                        {!! view_render_event('admin.leads.view.actions.after', ['lead' => $lead]) !!}
                     </div>
                 </div>
             </div>

--- a/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view.blade.php
@@ -100,6 +100,14 @@
 
                         {!! view_render_event('admin.leads.view.actions.after', ['lead' => $lead]) !!}
                     </div>
+
+                    <div class="mt-2">
+                        <a href="{{ route('admin.leads.duplicates.select', $lead->id) }}"
+                           class="secondary-button inline-flex items-center gap-1 border hover:border-neutral-text hover:text-neutral-text">
+                            <span class="icon-setting text-base"></span>
+                            <span>Lead samenvoegen</span>
+                        </a>
+                    </div>
                 </div>
             </div>
             @if($lead->diagnoseform_pdf_url || $lead->mri_status)

--- a/packages/Webkul/Admin/src/Routes/Admin/leads-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/leads-routes.php
@@ -80,6 +80,8 @@ Route::controller(LeadController::class)->prefix('leads')->group(function () {
     Route::controller(DuplicateController::class)->prefix('{id}/duplicates')->group(function () {
         Route::get('', 'index')->name('admin.leads.duplicates.index');
 
+        Route::get('select', 'select')->name('admin.leads.duplicates.select');
+
         Route::get('check', 'checkDuplicates')->name('admin.leads.duplicates.check');
 
         Route::get('get', 'getDuplicates')->name('admin.leads.duplicates.get');

--- a/tests/Feature/Leads/LeadManualMergeTest.php
+++ b/tests/Feature/Leads/LeadManualMergeTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Support\Carbon;
+use Webkul\Lead\Models\Lead;
+use Webkul\Lead\Repositories\LeadRepository;
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+
+    Lead::unsetEventDispatcher();
+
+    $this->actingAs(getDefaultAdmin(), 'user');
+    $this->withoutMiddleware(Authenticate::class);
+    $this->withoutVite();
+});
+
+test('view lead page shows manual merge action', function () {
+    $lead = Lead::factory()->create();
+
+    $response = $this->get(route('admin.leads.view', $lead->id));
+
+    $response->assertOk()
+        ->assertSee('Lead samenvoegen')
+        ->assertSee(route('admin.leads.duplicates.select', $lead->id), false);
+});
+
+test('manual merge select page is available from a lead', function () {
+    $lead = Lead::factory()->create([
+        'first_name' => 'Primaire',
+        'last_name'  => 'Lead',
+    ]);
+
+    $response = $this->get(route('admin.leads.duplicates.select', $lead->id));
+
+    $response->assertOk()
+        ->assertSee('Lead samenvoegen')
+        ->assertSee('Andere lead zoeken')
+        ->assertSee('Verder')
+        ->assertSee(route('admin.leads.search'), false);
+});
+
+test('merge screen accepts a manually selected lead outside the automatic detection window', function () {
+    $primary = Lead::factory()->create([
+        'first_name' => 'Jan',
+        'last_name'  => 'Jansen',
+        'created_at' => Carbon::now(),
+    ]);
+
+    $oldDuplicate = Lead::factory()->create([
+        'first_name' => 'Andere',
+        'last_name'  => 'Persoon',
+        'created_at' => Carbon::now()->subWeeks(LeadRepository::DUPLICATE_SEARCH_PERIOD_WEEKS + 2),
+    ]);
+
+    // Automatic detection should not include the old lead
+    expect(app(LeadRepository::class)->findPotentialDuplicates($primary)->pluck('id'))
+        ->not->toContain($oldDuplicate->id);
+
+    $response = $this->get(route('admin.leads.duplicates.index', [
+        'id'   => $primary->id,
+        'with' => $oldDuplicate->id,
+    ]));
+
+    $response->assertOk();
+
+    $duplicatesData = $response->viewData('duplicatesData');
+    $preselectedLeadIds = $response->viewData('preselectedLeadIds');
+
+    expect(collect($duplicatesData)->pluck('id'))->toContain($oldDuplicate->id)
+        ->and($preselectedLeadIds)->toContain($oldDuplicate->id)
+        ->and($response->viewData('duplicates')->count())->toBeGreaterThan(0);
+});
+
+test('merge screen ignores with equal to the primary lead', function () {
+    $lead = Lead::factory()->create();
+
+    $response = $this->get(route('admin.leads.duplicates.index', [
+        'id'   => $lead->id,
+        'with' => $lead->id,
+    ]));
+
+    $response->assertOk();
+
+    expect($response->viewData('preselectedLeadIds'))->toBe([])
+        ->and($response->viewData('duplicates')->pluck('id'))->not->toContain($lead->id);
+});
+
+test('manual merge still uses the existing merge endpoint', function () {
+    $primary = Lead::factory()->create([
+        'first_name' => 'Keep',
+        'last_name'  => 'Primary',
+    ]);
+
+    $duplicate = Lead::factory()->create([
+        'first_name' => 'Merge',
+        'last_name'  => 'Away',
+        'created_at' => Carbon::now()->subWeeks(LeadRepository::DUPLICATE_SEARCH_PERIOD_WEEKS + 3),
+    ]);
+
+    $response = $this->postJson(route('admin.leads.duplicates.merge', $primary->id), [
+        'primary_lead_id'     => $primary->id,
+        'duplicate_lead_ids'  => [$duplicate->id],
+        'field_mappings'      => [],
+    ]);
+
+    $response->assertOk()
+        ->assertJson(['success' => true]);
+
+    expect(Lead::find($duplicate->id))->toBeNull()
+        ->and(Lead::withTrashed()->find($duplicate->id))->not->toBeNull()
+        ->and(Lead::find($primary->id))->not->toBeNull();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Op View Lead is de actie **Lead samenvoegen** beschikbaar. Medewerkers kunnen daarmee handmatig een andere lead zoeken (niet beperkt tot de automatische 4-weken-detectie), één lead selecteren en via **Verder** het bestaande Merge leads-scherm openen.

- Huidige lead is automatisch de primaire lead
- Verder is pas beschikbaar na selectie van één andere lead
- Bestaande merge-logica (`POST .../duplicates/merge`) wordt hergebruikt
- Automatische duplicaatdetectie blijft ongewijzigd
- Actieknop is gestyled als tegel in hetzelfde actieraster als E-mail/Bestand/Notitie/Activiteit

## How To Test This?

1. Open een lead zonder automatische duplicaten
2. Controleer dat **Lead samenvoegen** als vijfde actietegel naast E-mail/Bestand/Notitie/Activiteit staat
3. Klik **Lead samenvoegen**
4. Zoek een andere lead (desnoods ouder dan 4 weken) en selecteer deze
5. Controleer dat **Verder** pas actief is na selectie
6. Na **Verder** opent het Merge leads-scherm met beide leads (huidige lead geselecteerd als primair)
7. Voer de bestaande merge uit en controleer dat de duplicaat soft-deleted is

Automatische tests: `php artisan test tests/Feature/Leads/LeadManualMergeTest.php`

## Documentation
- [x] Documentatie in-repo bijgewerkt (`docs/modules/application/pages/duplicate-leads.adoc`)

## Branch Selection
- [ ] Target Branch: master
- Target: `development`

## Tailwind Reordering
- [x] Classes volgen bestaande Admin-actietegel-patronen

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be67b8db-d9b3-418a-b604-b238f58cb625?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be67b8db-d9b3-418a-b604-b238f58cb625&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

