### PR TITLE
fix(admin): bump nanoid to 3.3.18 to resolve GHSA-2v37-7h3g-55p8

### DIFF
--- a/packages/Webkul/Admin/package-lock.json
+++ b/packages/Webkul/Admin/package-lock.json
@@ -3272,9 +3272,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Summary
- Bumps `nanoid` from 3.3.17 to 3.3.18 in `packages/Webkul/Admin/package-lock.json`, resolving Dependabot alert [#289](https://github.com/privatescanbv/krayin-laravel-crm/security/dependabot/289) (GHSA-2v37-7h3g-55p8, **HIGH**): custom generators could loop indefinitely when size is zero.
- `nanoid` is a transitive dependency of `postcss` (`^3.3.16`, satisfied by 3.3.18) — no `package.json` change needed, patch-level bump only, no major version changes.

## Dependabot alert overview
- **Resolved:** #289 nanoid < 3.3.18 (HIGH) — GHSA-2v37-7h3g-55p8
- **Remaining open alerts:** none
- **Files changed:** `packages/Webkul/Admin/package-lock.json` (3 lines: version, resolved URL, integrity hash)

## Test plan
- [x] `npm ci` in `packages/Webkul/Admin` — lockfile installs cleanly, no integrity errors
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run build` — production Vite build succeeds
- [ ] PHP/Pest test suite — **not run**: the sandboxed session's `docker-credential-osxkeychain get` hangs waiting on a macOS Keychain GUI prompt that can't be answered non-interactively, blocking any `docker-compose build` that pulls the private `ghcr.io/privatescanbv/dockerbase/php` base image. This change touches only a frontend JS lockfile (no PHP code), so no PHP-side regression is expected, but a maintainer with a working local/CI Docker environment should confirm `sail artisan test` and `vendor/bin/duster fix --dirty` / `vendor/bin/larastan analyse` stay green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)