### PR TITLE
fix(email): resolve cid: inline images in mail body

### DIFF
--- a/packages/Webkul/Email/src/Models/Email.php
+++ b/packages/Webkul/Email/src/Models/Email.php
@@ -661,10 +661,32 @@ class Email extends Model implements EmailContract
     {
         if ($this->quoteSplitCache === null) {
             $this->quoteSplitCache = app(EmailQuoteSplitter::class)
-                ->split((string) $this->reply);
+                ->split($this->resolveInlineAttachments((string) $this->reply));
         }
 
         return $this->quoteSplitCache;
+    }
+
+    /**
+     * Replace `cid:` references in the HTML body with the matching attachment's storage
+     * URL, so inline images (e.g. pasted screenshots, Outlook-embedded pictures) render
+     * instead of showing as broken images.
+     */
+    private function resolveInlineAttachments(string $html): string
+    {
+        if (stripos($html, 'cid:') === false) {
+            return $html;
+        }
+
+        foreach ($this->attachments as $attachment) {
+            if (empty($attachment->content_id)) {
+                continue;
+            }
+
+            $html = str_ireplace('cid:'.$attachment->content_id, $attachment->url, $html);
+        }
+
+        return $html;
     }
 
     /**

--- a/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
+++ b/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
@@ -47,15 +47,41 @@ class AttachmentRepository extends Repository
         foreach ($data['attachments'] as $attachment) {
             $attributes = $this->prepareData($email, $attachment);
 
-            if (
-                ! empty($attachment->contentId)
-                && $data['source'] === 'email'
-            ) {
-                $attributes['content_id'] = $attachment->contentId;
+            if ($contentId = $this->resolveContentId($attachment, $data['source'])) {
+                $attributes['content_id'] = $contentId;
             }
 
             $this->create($attributes);
         }
+    }
+
+    /**
+     * Resolve the MIME Content-ID for an inbound email attachment, so `cid:` references
+     * in the HTML body can later be matched to the stored attachment.
+     *
+     * Webklex\PHPIMAP\Attachment exposes the Content-ID header via its `id` property
+     * (not `contentId`), falling back to a content hash when no header is present —
+     * that fallback must be ignored since it never appears in a `cid:` reference.
+     */
+    private function resolveContentId($attachment, string $source): ?string
+    {
+        if ($source !== 'email') {
+            return null;
+        }
+
+        if ($attachment instanceof ImapAttachment) {
+            // Read into locals first: Webklex\PHPIMAP\Attachment resolves these via
+            // __get() with no __isset(), so empty()/isset()/?? treat them as unset
+            // and would silently discard a real Content-ID here.
+            $id = $attachment->id;
+            $hash = $attachment->hash;
+
+            return $id !== null && $id !== '' && $id !== $hash
+                ? $id
+                : null;
+        }
+
+        return $attachment->contentId ?? null;
     }
 
     /**
@@ -80,13 +106,19 @@ class AttachmentRepository extends Repository
 
         Storage::put($path, $content);
 
-        $this->create([
+        $attributes = [
             'email_id'     => $email->id,
             'name'         => $name,
             'content_type' => $graphAttachment['contentType'] ?? 'application/octet-stream',
             'size'         => strlen($content) ?: ($graphAttachment['size'] ?? 0),
             'path'         => $path,
-        ]);
+        ];
+
+        if (! empty($graphAttachment['contentId'])) {
+            $attributes['content_id'] = $graphAttachment['contentId'];
+        }
+
+        $this->create($attributes);
     }
 
     /**

--- a/tests/Unit/Email/AttachmentRepositoryContentIdTest.php
+++ b/tests/Unit/Email/AttachmentRepositoryContentIdTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Webklex\PHPIMAP\Attachment as ImapAttachment;
+use Webkul\Email\Repositories\AttachmentRepository;
+
+/**
+ * Build a Webklex attachment instance without invoking its real constructor
+ * (which needs a live Message/Part), directly seeding the protected
+ * `attributes` array it reads `id`/`hash` from via magic getters.
+ */
+function makeImapAttachment(?string $id, string $hash = 'fallback-hash'): ImapAttachment
+{
+    $attachment = (new ReflectionClass(ImapAttachment::class))->newInstanceWithoutConstructor();
+
+    $attributes = (new ReflectionClass($attachment))->getProperty('attributes');
+    $attributes->setAccessible(true);
+    $attributes->setValue($attachment, ['id' => $id, 'hash' => $hash]);
+
+    return $attachment;
+}
+
+function resolveContentId($attachment, string $source): ?string
+{
+    $method = (new ReflectionClass(AttachmentRepository::class))->getMethod('resolveContentId');
+    $method->setAccessible(true);
+
+    return $method->invoke(app(AttachmentRepository::class), $attachment, $source);
+}
+
+test('resolves the real Content-ID header from a Webklex IMAP attachment', function () {
+    $attachment = makeImapAttachment(id: 'image001@01D12345', hash: 'unrelated-hash');
+
+    expect(resolveContentId($attachment, 'email'))->toBe('image001@01D12345');
+});
+
+test('ignores Webklex hash fallback when no Content-ID header exists', function () {
+    // Webklex sets `id` to the content hash itself when no Content-ID header is present.
+    $attachment = makeImapAttachment(id: 'same-hash', hash: 'same-hash');
+
+    expect(resolveContentId($attachment, 'email'))->toBeNull();
+});
+
+test('ignores Content-ID when source is not email', function () {
+    $attachment = makeImapAttachment(id: 'image001@01D12345', hash: 'unrelated-hash');
+
+    expect(resolveContentId($attachment, 'web-form'))->toBeNull();
+});
+
+test('reads contentId property for non-IMAP attachment objects', function () {
+    $attachment = (object) ['contentId' => 'sendgrid-cid-1'];
+
+    expect(resolveContentId($attachment, 'email'))->toBe('sendgrid-cid-1');
+});
+
+test('returns null when non-IMAP attachment has no contentId', function () {
+    $attachment = (object) [];
+
+    expect(resolveContentId($attachment, 'email'))->toBeNull();
+});

--- a/tests/Unit/Email/EmailModelTest.php
+++ b/tests/Unit/Email/EmailModelTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkul\Email\Models\Attachment;
 use Webkul\Email\Models\Email;
 use Webkul\Email\Models\Folder;
 
@@ -99,4 +100,54 @@ test('email model handles edge cases for time_ago', function () {
     $email->created_at = now();
     expect($email->time_ago)->not->toBe('Unknown')
         ->and($email->time_ago)->toBeString();
+});
+
+test('quote_split resolves cid references to the matching attachment url', function () {
+    $folder = Folder::create(['name' => 'inbox']);
+
+    $email = Email::create([
+        'subject'   => 'Photo attached',
+        'from'      => ['sender@example.com'],
+        'reply'     => '<p>See attached</p><img src="cid:image001@01D12345">',
+        'folder_id' => $folder->id,
+    ]);
+
+    $attachment = Attachment::create([
+        'email_id'     => $email->id,
+        'name'         => 'photo.jpg',
+        'path'         => 'emails/'.$email->id.'/photo.jpg',
+        'content_type' => 'image/jpeg',
+        'size'         => 1234,
+        'content_id'   => 'image001@01D12345',
+    ]);
+
+    expect($email->quote_split['main'])
+        ->not->toContain('cid:image001@01D12345')
+        ->toContain($attachment->url);
+});
+
+test('quote_split leaves body untouched when it has no cid references', function () {
+    $folder = Folder::create(['name' => 'inbox']);
+
+    $email = Email::create([
+        'subject'   => 'No attachments',
+        'from'      => ['sender@example.com'],
+        'reply'     => '<p>Just text</p>',
+        'folder_id' => $folder->id,
+    ]);
+
+    expect($email->quote_split['main'])->toBe('<p>Just text</p>');
+});
+
+test('quote_split leaves unmatched cid references untouched', function () {
+    $folder = Folder::create(['name' => 'inbox']);
+
+    $email = Email::create([
+        'subject'   => 'Dangling cid',
+        'from'      => ['sender@example.com'],
+        'reply'     => '<img src="cid:unknown@01D12345">',
+        'folder_id' => $folder->id,
+    ]);
+
+    expect($email->quote_split['main'])->toContain('cid:unknown@01D12345');
 });


### PR DESCRIPTION
## Summary
- MBS-363: mail attachments/inline images (e.g. Outlook screenshots pasted into a reply) sent by customers were not visible in the CRM mail view, even though they showed fine when logging into the mailbox directly (Outlook).
- Root cause 1: `AttachmentRepository::uploadAttachments()` read `$attachment->contentId` for inbound IMAP attachments, but `Webklex\PHPIMAP\Attachment` exposes the Content-ID header via `$attachment->id` instead — so `content_id` was never stored for IMAP-synced attachments (and `empty()`/`??` silently swallow the value anyway, since that class has no `__isset()`).
- Root cause 2: even when a Content-ID was captured, nothing ever rewrote the `cid:...` references inside the stored HTML body to point at the real attachment — the `<img src="cid:...">` tag stayed broken in the browser.
- Fix: correctly resolve the Content-ID for Webklex/IMAP attachments (with a Microsoft Graph `contentId` capture added too), and rewrite `cid:` references to the attachment's storage URL when rendering `Email::quote_split` (used by the mail view).

## Test plan
- [x] `php artisan test tests/Unit/Email/EmailModelTest.php tests/Unit/Email/AttachmentRepositoryContentIdTest.php`
- [x] `php artisan test --filter=Email` (322 passed) and `--filter=Mail` (422 passed)
- [x] `vendor/bin/duster fix --dirty` — no changes needed
- [x] `vendor/bin/phpstan analyse` on changed files — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)