### PR TITLE
fix(contacts): clear stale has_duplicates flag when viewing a person's duplicates page

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/DuplicateController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/DuplicateController.php
@@ -37,6 +37,11 @@ class DuplicateController extends Controller
         $person = $this->personRepository->with(['organization', 'user', 'address'])->findOrFail($personId);
         $duplicates = $this->personRepository->findPotentialDuplicates($person);
 
+        // Viewing this page recomputes duplicates directly (bypassing the cache service), so the
+        // persisted has_duplicates flag would otherwise stay stale until the next hourly index
+        // rebuild even though this page just proved the real answer. Self-heal it here.
+        $this->personDuplicateCacheService->persistHasDuplicatesFlag($person->id, $duplicates->pluck('id'));
+
         // findPotentialDuplicates returns a Support Collection, so load per model.
         $duplicates->each(fn (Person $dup) => $dup->loadMissing(['organization', 'address']));
 

--- a/tests/Feature/Persons/PersonDuplicateViewTest.php
+++ b/tests/Feature/Persons/PersonDuplicateViewTest.php
@@ -15,6 +15,21 @@ beforeEach(function () {
     $this->withoutMiddleware(Authenticate::class);
 });
 
+test('viewing the duplicates page clears a stale has_duplicates flag left over from a merge', function () {
+    // Person C used to match B (e.g. shared phone), so both got flagged. B is then merged
+    // into A, which only clears/recomputes A and B's flags - C is left stale (MBS-366).
+    $person = Person::factory()->create([
+        'phones'         => [['value' => '+31651441908', 'label' => 'eigen']],
+        'has_duplicates' => true,
+    ]);
+
+    $response = $this->get(route('admin.contacts.persons.duplicates.index', $person->id))
+        ->assertOk();
+
+    expect($response->viewData('duplicates'))->toBeEmpty()
+        ->and($person->fresh()->has_duplicates)->toBeFalse();
+});
+
 test('person duplicates merge view loads when primary person has phone numbers', function () {
     $person = Person::factory()->create([
         'phones' => [


### PR DESCRIPTION
## Summary
- Fixes MBS-366: after merging duplicate contacts, some other contacts kept showing the "possible duplicate" warning in the persons list even though opening their duplicates page correctly reported "no known duplicates".
- Root cause: merging only invalidates/recomputes the `has_duplicates` flag for the primary and the merged-away person. A third person who previously matched the merged-away person keeps a stale `has_duplicates=true` until the hourly `duplicates:refresh-cache --index` cron catches up (or doesn't run at all in that environment).
- `DuplicateController::index()` (the page opened by clicking the duplicate warning icon) already recomputes the true, live duplicate list for that person but never persisted the result back to the `has_duplicates` column. It now does, so visiting the page self-heals the stale flag immediately instead of waiting up to an hour.

## Test plan
- [x] Added a regression test reproducing the stale-flag scenario (`PersonDuplicateViewTest`)
- [x] `php artisan test tests/Feature/Persons/` (137 passed)
- [x] `php artisan test` full suite (1657 passed, 6 skipped)
- [x] `vendor/bin/duster fix --dirty`
- [x] `vendor/bin/phpstan analyse` on the changed controller (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)