### PR TITLE
fix(contacts): allow selecting a portal-account duplicate to mark as not a duplicate

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/duplicates/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/duplicates/index.blade.php
@@ -150,8 +150,7 @@
                                             <input
                                                 type="checkbox"
                                                 :checked="selectedPersons.includes(duplicate.id)"
-                                                :disabled="duplicate.has_portal_account"
-                                                :title="duplicate.has_portal_account ? 'Heeft een patiëntportaalaccount - kan niet als duplicaat worden samengevoegd.' : ''"
+                                                :title="duplicate.has_portal_account ? 'Heeft een patiëntportaalaccount - kan alleen als geen duplicaat worden gemarkeerd, niet worden samengevoegd.' : ''"
                                                 @change="togglePersonSelection(duplicate.id)"
                                             />
                                         </td>
@@ -235,8 +234,7 @@
                                                 <input
                                                     type="checkbox"
                                                     :checked="selectedPersons.includes(duplicate.id)"
-                                                    :disabled="duplicate.has_portal_account"
-                                                    :title="duplicate.has_portal_account ? 'Heeft een patiëntportaalaccount - kan niet als duplicaat worden samengevoegd.' : ''"
+                                                    :title="duplicate.has_portal_account ? 'Heeft een patiëntportaalaccount - kan alleen als geen duplicaat worden gemarkeerd, niet worden samengevoegd.' : ''"
                                                     @change="togglePersonSelection(duplicate.id)"
                                                     class="mb-2"
                                                 />
@@ -398,7 +396,7 @@
                         <div class="mt-6 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
                             <div v-if="portalDuplicates.length > 0" class="mb-4 rounded border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
                                 <p>
-                                    Personen met een patiëntportaal kunnen niet als duplicaat worden samengevoegd. Maak die persoon primair, of trek het account eerst met de hand in.
+                                    Personen met een patiëntportaal kunnen niet als duplicaat worden samengevoegd, maar wel als geen duplicaat worden gemarkeerd. Om samen te voegen: maak die persoon primair, of trek het account eerst met de hand in.
                                 </p>
                                 <p v-if="bothSidesHavePortal" class="mt-1 font-medium">
                                     Er zijn meerdere portaalaccounts. Trek er eerst één in voordat je samenvoegt.
@@ -587,7 +585,7 @@
                     },
 
                     togglePersonSelection(personId) {
-                        if (personId === this.primaryPerson.id || this.personHasPortal(personId)) {
+                        if (personId === this.primaryPerson.id) {
                             return;
                         }
 

--- a/tests/Feature/Persons/PersonDuplicatePortalSelectionTest.php
+++ b/tests/Feature/Persons/PersonDuplicatePortalSelectionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Support\Facades\DB;
+use Webkul\Contact\Models\Person;
+
+beforeEach(function () {
+    $this->seed(TestSeeder::class);
+    Person::unsetEventDispatcher();
+
+    $this->actingAs(getDefaultAdmin(), 'user');
+    $this->withoutMiddleware(Authenticate::class);
+});
+
+test('a duplicate with a portal account is still selectable (not hard-disabled) in the duplicates view', function () {
+    $person = Person::factory()->create([
+        'keycloak_user_id' => 'kc-primary',
+    ]);
+
+    Person::factory()->create([
+        'first_name'       => $person->first_name,
+        'last_name'        => $person->last_name,
+        'keycloak_user_id' => 'kc-duplicate',
+    ]);
+
+    $this->get(route('admin.contacts.persons.duplicates.index', $person->id))
+        ->assertOk()
+        ->assertDontSee(':disabled="duplicate.has_portal_account"', false);
+});
+
+test('two persons that both have a portal account can be marked as not a duplicate', function () {
+    $person = Person::factory()->create([
+        'keycloak_user_id' => 'kc-primary',
+    ]);
+
+    $other = Person::factory()->create([
+        'first_name'       => $person->first_name,
+        'last_name'        => $person->last_name,
+        'keycloak_user_id' => 'kc-duplicate',
+    ]);
+
+    $this->postJson(route('admin.contacts.persons.duplicates.false_positive', $person->id), [
+        'entity_ids' => [$person->id, $other->id],
+    ])
+        ->assertOk()
+        ->assertJson(['success' => true]);
+
+    expect(
+        DB::table('duplicates_false_positives')
+            ->where(function ($query) use ($person, $other) {
+                $query->where('entity_id_1', $person->id)->where('entity_id_2', $other->id);
+            })
+            ->orWhere(function ($query) use ($person, $other) {
+                $query->where('entity_id_1', $other->id)->where('entity_id_2', $person->id);
+            })
+            ->exists()
+    )->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- On the person duplicates page (`/admin/contacts/persons/{id}/duplicates`), a duplicate row's checkbox was hard-disabled whenever that person had a patient portal account, making it impossible to select a second person who has a portal.
- The backend "mark as not duplicate" endpoint already had no portal restriction, and the merge button was already correctly gated separately (`canMerge`), so the only fix needed was to stop disabling the checkbox / selection for portal accounts — merging stays blocked for portal accounts, but marking as "not a duplicate" now works when both selected persons have a portal.

## Test plan
- [x] `php artisan test tests/Feature/Persons/PersonDuplicatePortalSelectionTest.php` — new regression tests: checkbox is no longer hard-disabled in the view, and marking two portal-account persons as not-duplicate succeeds via the endpoint.
- [x] `php artisan test tests/Feature/Persons/` — full persons suite still passes, including merge-side portal guard tests confirming merging two portal accounts remains blocked.
- [x] `vendor/bin/duster fix --dirty`

Fixes MBS-367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)