### PR TITLE
Unify create/edit lead person match suggestions

### DIFF
--- a/app/Http/Requests/Admin/PersonSuggestRequest.php
+++ b/app/Http/Requests/Admin/PersonSuggestRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PersonSuggestRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return (bool) $this->user('user');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'first_name'                  => ['nullable', 'string', 'max:255'],
+            'last_name'                   => ['nullable', 'string', 'max:255'],
+            'lastname_prefix'             => ['nullable', 'string', 'max:255'],
+            'married_name'                => ['nullable', 'string', 'max:255'],
+            'married_name_prefix'         => ['nullable', 'string', 'max:255'],
+            'initials'                    => ['nullable', 'string', 'max:50'],
+            'date_of_birth'               => ['nullable', 'date'],
+            'salutation'                  => ['nullable', 'string', 'max:50'],
+            'gender'                      => ['nullable', 'string', 'max:50'],
+            'emails'                      => ['nullable', 'array'],
+            'emails.*.value'              => ['nullable', 'string', 'max:255'],
+            'emails.*.label'              => ['nullable', 'string', 'max:50'],
+            'phones'                      => ['nullable', 'array'],
+            'phones.*.value'              => ['nullable', 'string', 'max:50'],
+            'phones.*.label'              => ['nullable', 'string', 'max:50'],
+            'address'                     => ['nullable', 'array'],
+            'address.street'              => ['nullable', 'string', 'max:255'],
+            'address.house_number'        => ['nullable', 'string', 'max:50'],
+            'address.house_number_suffix' => ['nullable', 'string', 'max:10'],
+            'address.postal_code'         => ['nullable', 'string', 'max:20'],
+            'address.city'                => ['nullable', 'string', 'max:255'],
+            'address.state'               => ['nullable', 'string', 'max:255'],
+            'address.country'             => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/docs/manual/leads/chapters/03-lead-aanmaken.adoc
+++ b/docs/manual/leads/chapters/03-lead-aanmaken.adoc
@@ -73,6 +73,11 @@ image::../images/leads-create-top.png[Persoonsgegevens sectie]
 Koppel een bestaande persoon uit het CRM als contactpersoon voor deze lead.
 Gebruik het zoekveld "Selecteer contactpersoon..." om te zoeken op naam.
 
+Aan de rechterkant toont het systeem automatisch *Mogelijke matches gevonden*
+op basis van de ingevulde persoonsgegevens (e-mail, telefoon, naam, geboortedatum, postcode).
+Die suggesties gebruiken dezelfde matching-logica als bij het bewerken van een lead.
+Klik *Koppelen* om een match over te nemen in het formulier.
+
 Activeer de optie *Tevens persoon aanmaken met deze lead gegevens en koppelen* om automatisch
 een nieuw persoonsprofiel aan te maken op basis van de ingevulde persoonsgegevens.
 

--- a/docs/modules/application/pages/contact-matcher.adoc
+++ b/docs/modules/application/pages/contact-matcher.adoc
@@ -109,13 +109,14 @@ Het systeem zoekt automatisch in de volgende velden wanneer je een persoon opzoe
 
 ===== Contact Zoeken vanuit Lead
 
-Wanneer je een lead bewerkt, kun je de contact matcher gebruiken om bestaande contactpersonen te vinden:
+Bij het **aanmaken** en **bewerken** van een lead toont het systeem automatische person-suggesties via dezelfde matching-logica:
 
-. **Automatische Suggesties**: Het systeem toont automatisch suggesties gebaseerd op de lead informatie
-. **Match Percentages**: Elke suggestie toont een match percentage met kleur-gecodeerde voortgangsbalk
-. **Handmatig Zoeken**: Typ in het zoekveld om aanvullende contacten te zoeken
+. **Automatische Suggesties**: Gebaseerd op lead-velden (e-mail, telefoon met format-varianten, achternaam + DOB/postcode)
+. **Match Percentages**: Elke suggestie toont een match percentage
+. **Match redenen**: Chips zoals e-mail/telefoon of achternaam; sterke hits (e-mail/telefoon) staan onder "Waarschijnlijk dezelfde persoon"
+. **Handmatig Zoeken**: Typ in het zoekveld om aanvullende contacten te zoeken (bewerken)
 . **Contact Bekijken**: Klik op het externe link icoon om contactdetails in nieuwe tab te openen
-. **Contact Selecteren**: Klik op een suggestie om deze te selecteren als gekoppelde contactpersoon
+. **Contact Selecteren / Koppelen**: Klik op een suggestie om deze te selecteren of te koppelen
 
 ===== Match Score Interpretatie
 

--- a/docs/modules/application/pages/leads.adoc
+++ b/docs/modules/application/pages/leads.adoc
@@ -57,14 +57,17 @@ Leads zijn potentiële klanten die interesse hebben getoond in je producten of d
 
 ===== Automatische Suggesties
 
-Het systeem toont automatisch mogelijke matches met bestaande contactpersonen:
+Het systeem toont automatisch mogelijke matches met bestaande contactpersonen.
+Zowel bij **lead aanmaken** als bij **lead bewerken** gebruikt dit dezelfde suggestie-engine (`PersonSuggestionService`): e-mail, telefoon (inclusief `06` ↔ `+31` varianten), achternaam plus eventueel geboortedatum of postcode.
 
 . **Match Percentage**: Toont hoe goed de lead overeenkomt
+. **Match redenen**: Labels zoals e-mail, telefoon of achternaam
 . **Contact Details**: Naam, email en telefoon van gevonden contacten
 . **Snelle Acties**:
   * 👁️ Bekijk contactdetails
-  * 🔄 Synchroniseer gegevens
+  * 🔄 Synchroniseer gegevens (alleen bij bewerken)
 
+Bij aanmaken worden suggesties bijgewerkt wanneer je velden zoals naam, e-mail, telefoon, geboortedatum of postcode invult of verlaat.
 ===== Handmatig Zoeken
 
 . Typ in het zoekveld naar naam, email of telefoon

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -289,11 +289,24 @@ class PersonController extends Controller
                 return $personResource;
             });
 
-            return PersonResource::collection(
-                $personsWithScores
-                    ->sortByDesc(fn ($personResource) => $personResource->match_score ?? 0)
-                    ->values()
-            );
+            $sorted = $personsWithScores
+                ->sort(function ($a, $b) {
+                    $reasonsA = $a->resource->match_reasons ?? [];
+                    $reasonsB = $b->resource->match_reasons ?? [];
+                    $strongA = in_array(PersonSuggestionService::REASON_EMAIL, $reasonsA, true)
+                        || in_array(PersonSuggestionService::REASON_PHONE, $reasonsA, true) ? 1 : 0;
+                    $strongB = in_array(PersonSuggestionService::REASON_EMAIL, $reasonsB, true)
+                        || in_array(PersonSuggestionService::REASON_PHONE, $reasonsB, true) ? 1 : 0;
+
+                    if ($strongA !== $strongB) {
+                        return $strongB <=> $strongA;
+                    }
+
+                    return ($b->match_score ?? 0) <=> ($a->match_score ?? 0);
+                })
+                ->values();
+
+            return PersonResource::collection($sorted);
         } catch (Exception $e) {
             logger()->warning('Could not calculate match scores for person suggestions', [
                 'lead_id' => $lead->id,
@@ -982,7 +995,7 @@ class PersonController extends Controller
     {
         // Handle array fields (emails, phones)
         if (in_array($field, ['emails', 'phones'])) {
-            return $this->arrayValuesMatch($leadValue, $personValue, $perspective);
+            return $this->arrayValuesMatch($leadValue, $personValue, $perspective, $field);
         }
 
         // Handle date fields
@@ -1002,7 +1015,7 @@ class PersonController extends Controller
     /**
      * Check if array values match (for emails/phones).
      */
-    private function arrayValuesMatch($leadArray, $personArray, string $perspective = 'generic'): bool
+    private function arrayValuesMatch($leadArray, $personArray, string $perspective = 'generic', string $field = 'emails'): bool
     {
         if (!is_array($leadArray) || !is_array($personArray)) {
             return false;
@@ -1010,6 +1023,26 @@ class PersonController extends Controller
 
         $leadValues = $this->extractArrayValues($leadArray);
         $personValues = $this->extractArrayValues($personArray);
+
+        if ($field === 'phones') {
+            $leadValues = array_values(array_filter(array_map(
+                [PhoneNormalizer::class, 'toDutchLocal'],
+                $leadValues
+            )));
+            $personValues = array_values(array_filter(array_map(
+                [PhoneNormalizer::class, 'toDutchLocal'],
+                $personValues
+            )));
+        } elseif ($field === 'emails') {
+            $leadValues = array_values(array_filter(array_map(
+                fn ($v) => EmailNormalizer::normalize($v) ?? strtolower($v),
+                $leadValues
+            )));
+            $personValues = array_values(array_filter(array_map(
+                fn ($v) => EmailNormalizer::normalize($v) ?? strtolower($v),
+                $personValues
+            )));
+        }
 
         // For sync (lead perspective): treat as match if all lead values exist in person values (subset)
         if ($perspective === 'lead') {
@@ -1019,6 +1052,7 @@ class PersonController extends Controller
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Contact/Persons/PersonController.php
@@ -13,12 +13,15 @@ use App\Enums\PortalRevocationReason;
 use App\Helpers\Comparable;
 use App\Http\Controllers\Concerns\HandlesReturnUrl;
 use App\Http\Controllers\Concerns\NormalizesContactFields;
+use App\Http\Requests\Admin\PersonSuggestRequest;
+use App\Models\Address;
 use App\Repositories\AddressRepository;
 use App\Services\DuplicateFalsePositiveService;
 use App\Services\PersonDuplicateCacheService;
 use App\Services\PersonKeycloakService;
 use App\Services\PersonSuggestionService;
 use App\Services\PersonValidationService;
+use App\Support\NameSimilarity;
 use BackedEnum;
 use Carbon\Carbon;
 use Exception;
@@ -134,6 +137,171 @@ class PersonController extends Controller
         );
 
         return PersonResource::collection($persons);
+    }
+
+    /**
+     * Auto-suggest persons from unsaved lead form fields (create lead).
+     *
+     * Uses the same PersonSuggestionService + scoring as edit-lead auto-match.
+     */
+    public function suggest(PersonSuggestRequest $request): JsonResource|JsonResponse
+    {
+        $lead = $this->makeLeadFromSuggestPayload($request->validated());
+
+        if (! $this->leadHasSuggestSignal($lead)) {
+            return PersonResource::collection(collect());
+        }
+
+        $result = $this->findPersonsBasedOnLead($lead);
+
+        return $this->attachMatchScoresToPersonResources($result, $lead);
+    }
+
+    /**
+     * Build an unsaved Lead (and optional Address) from suggest form payload.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function makeLeadFromSuggestPayload(array $data): Lead
+    {
+        $addressData = is_array($data['address'] ?? null) ? $data['address'] : null;
+        unset($data['address']);
+
+        $emails = $this->normalizeEmailsArray($data['emails'] ?? []);
+        $phones = $this->normalizePhonesArray($data['phones'] ?? []);
+
+        $attrs = [
+            'first_name'          => $this->nullableTrimmedString($data['first_name'] ?? null),
+            'last_name'           => $this->nullableTrimmedString($data['last_name'] ?? null),
+            'lastname_prefix'     => $this->nullableTrimmedString($data['lastname_prefix'] ?? null),
+            'married_name'        => $this->nullableTrimmedString($data['married_name'] ?? null),
+            'married_name_prefix' => $this->nullableTrimmedString($data['married_name_prefix'] ?? null),
+            'initials'            => $this->nullableTrimmedString($data['initials'] ?? null),
+            'date_of_birth'       => $this->nullableTrimmedString($data['date_of_birth'] ?? null),
+            'emails'              => $emails ?? [],
+            'phones'              => $phones ?? [],
+        ];
+
+        $salutation = $this->nullableTrimmedString($data['salutation'] ?? null);
+        if ($salutation !== null) {
+            $attrs['salutation'] = $salutation;
+        }
+
+        $gender = $this->nullableTrimmedString($data['gender'] ?? null);
+        if ($gender !== null) {
+            $attrs['gender'] = $gender;
+        }
+
+        $lead = Lead::make($attrs);
+
+        if ($addressData !== null && $this->addressPayloadHasValue($addressData)) {
+            $lead->setRelation('address', Address::make([
+                'street'              => $this->nullableTrimmedString($addressData['street'] ?? null),
+                'house_number'        => $this->nullableTrimmedString($addressData['house_number'] ?? null) ?? '',
+                'house_number_suffix' => $this->nullableTrimmedString($addressData['house_number_suffix'] ?? null),
+                'postal_code'         => $this->nullableTrimmedString($addressData['postal_code'] ?? null),
+                'city'                => $this->nullableTrimmedString($addressData['city'] ?? null),
+                'state'               => $this->nullableTrimmedString($addressData['state'] ?? null),
+                'country'             => $this->nullableTrimmedString($addressData['country'] ?? null),
+            ]));
+        } else {
+            $lead->setRelation('address', null);
+        }
+
+        return $lead;
+    }
+
+    /**
+     * Whether the unsaved lead has at least one signal used by PersonSuggestionService.
+     */
+    protected function leadHasSuggestSignal(Lead $lead): bool
+    {
+        if (! NameSimilarity::isBlank($lead->last_name) || ! NameSimilarity::isBlank($lead->married_name)) {
+            return true;
+        }
+
+        foreach ([$lead->emails, $lead->phones] as $contacts) {
+            if (! is_array($contacts)) {
+                continue;
+            }
+
+            foreach ($contacts as $item) {
+                $value = is_array($item) ? ($item['value'] ?? '') : $item;
+                if (is_string($value) && trim($value) !== '') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $address
+     */
+    protected function addressPayloadHasValue(array $address): bool
+    {
+        foreach (['street', 'house_number', 'house_number_suffix', 'postal_code', 'city', 'state', 'country'] as $key) {
+            if ($this->nullableTrimmedString($address[$key] ?? null) !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function nullableTrimmedString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim((string) $value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * Attach match scores to a PersonResource collection against a lead.
+     */
+    protected function attachMatchScoresToPersonResources(
+        AnonymousResourceCollection $result,
+        Lead $lead
+    ): AnonymousResourceCollection {
+        try {
+            $personsWithScores = $result->collection->map(function ($personResource) use ($lead) {
+                $person = $personResource->resource;
+                $score = $this->calculateMatchScore($lead, $person);
+
+                $personResource->match_score = $score;
+                $personResource->match_score_percentage = round($score, 1);
+
+                if ($this->enableLogging) {
+                    Log::info('Person being scored', [
+                        'person_id' => $person->id,
+                        'person_name' => $person->name,
+                        'person_first_name' => $person->first_name,
+                        'person_last_name' => $person->last_name,
+                        'calculated_score' => $score,
+                    ]);
+                }
+
+                return $personResource;
+            });
+
+            return PersonResource::collection(
+                $personsWithScores
+                    ->sortByDesc(fn ($personResource) => $personResource->match_score ?? 0)
+                    ->values()
+            );
+        } catch (Exception $e) {
+            logger()->warning('Could not calculate match scores for person suggestions', [
+                'lead_id' => $lead->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return $result;
+        }
     }
 
     /**
@@ -440,54 +608,9 @@ class PersonController extends Controller
             return $result;
         }
 
-        // Extract persons from the resource collection
-        $persons = $result->collection;
-
         // Check if we need to calculate match scores against a lead
         if ($lead) {
-            try {
-                // Calculate match scores for each person
-                // Note: $persons contains PersonResource objects, we need to get the underlying Person model
-                $personsWithScores = $persons->map(function ($personResource) use ($lead) {
-                    // Get the underlying Person model from the resource
-                    $person = $personResource->resource;
-
-                    // Calculate match score using the Person model
-                    $score = $this->calculateMatchScore($lead, $person);
-
-                    // Add score to the resource (which will be included in toArray())
-                    $personResource->match_score = $score;
-                    $personResource->match_score_percentage = round($score, 1);
-
-                    // Debug: Log which persons are being scored
-                    if ($this->enableLogging) {
-                        Log::info('Person being scored', [
-                            'person_id' => $person->id,
-                            'person_name' => $person->name,
-                            'person_first_name' => $person->first_name,
-                            'person_last_name' => $person->last_name,
-                            'calculated_score' => $score,
-                        ]);
-                    }
-
-                    return $personResource;
-                });
-
-                // Sort by match score (highest first); keep all results, even with score 0 (required for multiple persons for lead)
-                $personsWithScores = $personsWithScores
-                    ->sortByDesc(function ($personResource) {
-                        return $personResource->match_score ?? 0;
-                    })
-                    ->values();
-
-                return PersonResource::collection($personsWithScores);
-            } catch (Exception $e) {
-                // If lead not found or error in scoring, return regular results
-                logger()->warning('Could not calculate match scores for search', [
-                    'lead_id' => $leadId,
-                    'error' => $e->getMessage(),
-                ]);
-            }
+            return $this->attachMatchScoresToPersonResources($result, $lead);
         }
 
         return $result;

--- a/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/create.blade.php
@@ -617,7 +617,15 @@ $salutationToGenderMapping = [
 
                     // Attach blur/change listeners to trigger suggestions
                     this.$nextTick(() => {
-                        const blurFields = ['first_name','last_name','emails[0][value]','phones[0][value]'];
+                        const blurFields = [
+                            'first_name',
+                            'last_name',
+                            'married_name',
+                            'date_of_birth',
+                            'emails[0][value]',
+                            'phones[0][value]',
+                            'address[postal_code]',
+                        ];
                         blurFields.forEach(name => {
                             const input = this.$refs.leadForm?.querySelector(`[name="${name}"]`);
                             if (input) {
@@ -867,33 +875,48 @@ $salutationToGenderMapping = [
                     async fetchSuggestions() {
                         if (this.suggestionsDisabled || this.selectedPersonId) { this.suggestions = []; return; }
                         try {
-                            const firstName = (this.$refs.leadForm?.querySelector('[name="first_name"]').value || '').trim();
-                            const lastName = (this.$refs.leadForm?.querySelector('[name="last_name"]').value || '').trim();
-                            const email = (this.$refs.leadForm?.querySelector('input[name^="emails"][name$="[value]"]').value || '').trim();
-                            const phone = (this.$refs.leadForm?.querySelector('input[name^="phones"][name$="[value]"]').value || '').trim();
+                            const form = this.$refs.leadForm;
+                            if (!form) { this.suggestions = []; return; }
 
-                            // Build a single fielded query string
-                            let queryParts = [];
-                            if (firstName) queryParts.push(`firstname:${firstName}`);
-                            if (lastName) queryParts.push(`lastname:${lastName}`);
-                            if (email) queryParts.push(`email:${email}`);
-                            if (phone) {
-                                const onlyDigits = phone.replace(/\D+/g, '');
-                                if (onlyDigits) queryParts.push(`phone:${onlyDigits}`);
-                            }
+                            const val = (name) => (form.querySelector(`[name="${name}"]`)?.value || '').trim();
+                            const contactValues = (prefix) => {
+                                return Array.from(form.querySelectorAll(`input[name^="${prefix}"][name$="[value]"]`))
+                                    .map((input) => (input.value || '').trim())
+                                    .filter(Boolean)
+                                    .map((value) => ({ value, label: 'eigen' }));
+                            };
 
-                            const composed = queryParts.join(';') + (queryParts.length ? ';' : '');
-                            if (!composed) { this.suggestions = []; return; }
+                            const payload = {
+                                first_name: val('first_name'),
+                                last_name: val('last_name'),
+                                lastname_prefix: val('lastname_prefix'),
+                                married_name: val('married_name'),
+                                married_name_prefix: val('married_name_prefix'),
+                                initials: val('initials'),
+                                date_of_birth: val('date_of_birth'),
+                                salutation: val('salutation'),
+                                gender: val('gender'),
+                                emails: contactValues('emails'),
+                                phones: contactValues('phones'),
+                                address: {
+                                    street: val('address[street]'),
+                                    house_number: val('address[house_number]'),
+                                    house_number_suffix: val('address[house_number_suffix]'),
+                                    postal_code: val('address[postal_code]'),
+                                    city: val('address[city]'),
+                                    state: val('address[state]'),
+                                    country: val('address[country]'),
+                                },
+                            };
 
-                            const fetcher = (window.adminc && typeof window.adminc.fetchPersons === 'function') ? window.adminc.fetchPersons : null;
-                            const list = fetcher ? await fetcher(composed, {}, false) : [];
+                            const hasSignal = payload.last_name
+                                || payload.married_name
+                                || payload.emails.length
+                                || payload.phones.length;
+                            if (!hasSignal) { this.suggestions = []; return; }
 
-                            const scored = (list || []).map(p => this.calculateMatchScore(p, firstName, lastName, email, phone))
-                                .filter(p => p._client_match > 0)
-                                .sort((a,b) => (b._client_match||0) - (a._client_match||0))
-                                .slice(0, 10);
-
-                            this.suggestions = scored;
+                            const fetcher = window.adminc?.fetchPersonSuggestionsFromFields;
+                            this.suggestions = fetcher ? await fetcher(payload) : [];
                         } catch (e) {
                             this.suggestions = [];
                         }
@@ -901,20 +924,19 @@ $salutationToGenderMapping = [
 
                     clearSuggestions() { this.suggestions = []; },
 
-                    calculateMatchScore(p, firstName, lastName, email, phone) {
-                        // We can't use the server side match score, because the lead hasn't been persisted yet.
-                        let score = 0;
-                        const pEmail = (p.emails && p.emails[0] && (p.emails[0].value||'').toLowerCase()) || '';
-                        const pPhone = (p.phones && p.phones[0] && (p.phones[0].value||'')) || '';
-                        const pFirst = (p.first_name||'').toLowerCase();
-                        const pLast = (p.last_name||'').toLowerCase();
-                        if (email && pEmail && pEmail === email.toLowerCase()) score += 60;
-                        if (phone && pPhone && pPhone.replace(/\D/g,'') === phone.replace(/\D/g,'')) score += 40;
-                        if (firstName && pFirst && pFirst === firstName.toLowerCase()) score += 20;
-                        if (lastName && pLast && pLast === lastName.toLowerCase()) score += 20;
-                        if (!score && (pEmail.includes((email||'').toLowerCase()) || pPhone.includes(phone||''))) score += 20;
-                        p._client_match = Math.min(100, score);
-                        return p;
+                    isStrongSuggestion(person) {
+                        return window.adminc?.personSuggestionHelpers?.isStrongSuggestion(person) ?? false;
+                    },
+
+                    suggestionReasonLabel(reason) {
+                        return window.adminc?.personSuggestionHelpers?.suggestionReasonLabel(reason) ?? reason;
+                    },
+
+                    personSuggestionSections(suggestions) {
+                        const helpers = window.adminc?.personSuggestionHelpers;
+                        return helpers
+                            ? helpers.personSuggestionSections(suggestions)
+                            : [{ key: 'all', title: null, items: suggestions || [] }];
                     },
 
                     selectSuggestion(person) {

--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -363,9 +363,11 @@
                         try {
                             const resp = await axios.get('/admin/contacts/persons/search', { params: { lead_id: this.lead.id } });
                             const list = (resp && resp.data && (resp.data.data || resp.data)) || [];
-                            // Sort by server score if present, else by client score, then limit to 10
-                            const sorted = list.sort((a,b) => ((b.match_score_percentage||b.match_score||0) - (a.match_score_percentage||a.match_score||0)));
-                            this.suggestions = sorted.slice(0, 10);
+                            // Strong matches (email/phone) first, then by score — then limit to 10
+                            const helpers = window.adminc?.personSuggestionHelpers;
+                            this.suggestions = helpers
+                                ? helpers.rankAndLimitSuggestions(list, 10)
+                                : list.sort((a,b) => ((b.match_score_percentage||b.match_score||0) - (a.match_score_percentage||a.match_score||0))).slice(0, 10);
                         } catch (e) {
                             this.suggestions = [];
                         }

--- a/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/edit.blade.php
@@ -371,32 +371,16 @@
                         }
                     },
                     isStrongSuggestion(person) {
-                        const reasons = person.match_reasons || [];
-                        return reasons.includes('email') || reasons.includes('phone');
+                        return window.adminc?.personSuggestionHelpers?.isStrongSuggestion(person) ?? false;
                     },
                     suggestionReasonLabel(reason) {
-                        const labels = {
-                            email: 'E-mail',
-                            phone: 'Telefoon',
-                            last_name: 'Achternaam',
-                            first_name_similar: 'Voornaam lijkt',
-                            first_name_differs: 'Voornaam verschilt',
-                            dob: 'Geboortedatum',
-                            postal_code: 'Postcode',
-                        };
-                        return labels[reason] || reason;
+                        return window.adminc?.personSuggestionHelpers?.suggestionReasonLabel(reason) ?? reason;
                     },
                     personSuggestionSections(suggestions) {
-                        const items = suggestions || [];
-                        const strong = items.filter((s) => this.isStrongSuggestion(s));
-                        const possible = items.filter((s) => !this.isStrongSuggestion(s));
-                        if (strong.length && possible.length) {
-                            return [
-                                { key: 'strong', title: 'Waarschijnlijk dezelfde persoon', items: strong },
-                                { key: 'possible', title: 'Mogelijke matches', items: possible },
-                            ];
-                        }
-                        return [{ key: 'all', title: null, items }];
+                        const helpers = window.adminc?.personSuggestionHelpers;
+                        return helpers
+                            ? helpers.personSuggestionSections(suggestions)
+                            : [{ key: 'all', title: null, items: suggestions || [] }];
                     },
                     linkSuggestion(person) {
                         // Voeg toe aan de multi-contactmatcher als gekoppelde persoon

--- a/packages/Webkul/Admin/src/Routes/Admin/contacts-routes.php
+++ b/packages/Webkul/Admin/src/Routes/Admin/contacts-routes.php
@@ -29,6 +29,8 @@ Route::prefix('contacts')->group(function () {
 
         Route::get('search', 'search')->name('admin.contacts.persons.search');
 
+        Route::post('suggest', 'suggest')->name('admin.contacts.persons.suggest');
+
         Route::get('searchByLead/{lead}', 'searchByLead')->name('admin.contacts.persons.searchbylead');
         // Single-person variant, query params lead_id & person_id
         Route::get('searchByLead', 'searchByLeadSingle')->name('admin.contacts.persons.searchbylead_single');

--- a/resources/views/adminc/components/person-search-helpers.blade.php
+++ b/resources/views/adminc/components/person-search-helpers.blade.php
@@ -26,7 +26,7 @@
                     // Check if query contains colon but is not a valid fielded search pattern
                     // If it contains colon but doesn't match known patterns, treat as plain text
                     const hasColon = cleaned.includes(':');
-                    const looksLikeFieldedSearch = /^(email|emails|phone|phones|name|first_name|last_name|married_name|organization\.name|user\.name):/.test(cleaned);
+                    const looksLikeFieldedSearch = /^(email|emails|phone|phones|name|first_name|firstname|last_name|lastname|married_name|organization\.name|user\.name):/.test(cleaned);
 
                     if (hasColon && !looksLikeFieldedSearch) {
                         // Contains colon but not a valid field pattern - treat as plain text query

--- a/resources/views/adminc/components/person-search-helpers.blade.php
+++ b/resources/views/adminc/components/person-search-helpers.blade.php
@@ -44,7 +44,6 @@
 
                 const response = await axios.get('/admin/contacts/persons/search', { params });
                 const result = response?.data?.data ?? response?.data ?? [];
-                console.log('[fetchPersons] response.data:', response?.data, 'result:', result);
                 return Array.isArray(result) ? result : [];
             };
         }

--- a/resources/views/adminc/components/person-suggestion-helpers.blade.php
+++ b/resources/views/adminc/components/person-suggestion-helpers.blade.php
@@ -25,6 +25,22 @@
                     return reasonLabels[reason] || reason;
                 },
 
+                /**
+                 * Strong matches (email/phone) first, then by match_score — then cap at limit.
+                 * Prevents name-only crowding from hiding phone/email hits.
+                 */
+                rankAndLimitSuggestions(suggestions, limit = 10) {
+                    const items = Array.isArray(suggestions) ? [...suggestions] : [];
+                    items.sort((a, b) => {
+                        const strongDiff = (this.isStrongSuggestion(b) ? 1 : 0) - (this.isStrongSuggestion(a) ? 1 : 0);
+                        if (strongDiff !== 0) {
+                            return strongDiff;
+                        }
+                        return ((b.match_score_percentage || b.match_score || 0) - (a.match_score_percentage || a.match_score || 0));
+                    });
+                    return items.slice(0, limit);
+                },
+
                 personSuggestionSections(suggestions) {
                     const items = suggestions || [];
                     const strong = items.filter((s) => this.isStrongSuggestion(s));
@@ -52,9 +68,10 @@
                 const response = await axios.post('/admin/contacts/persons/suggest', payload);
                 const result = response?.data?.data ?? response?.data ?? [];
                 const list = Array.isArray(result) ? result : [];
-                return list
-                    .sort((a, b) => ((b.match_score_percentage || b.match_score || 0) - (a.match_score_percentage || a.match_score || 0)))
-                    .slice(0, 10);
+                const helpers = window.adminc.personSuggestionHelpers;
+                return helpers
+                    ? helpers.rankAndLimitSuggestions(list, 10)
+                    : list.slice(0, 10);
             };
         }
     </script>

--- a/resources/views/adminc/components/person-suggestion-helpers.blade.php
+++ b/resources/views/adminc/components/person-suggestion-helpers.blade.php
@@ -1,0 +1,62 @@
+{{-- Shared person suggestion UI helpers + create-lead suggest API --}}
+@pushOnce('scripts')
+@verbatim
+    <script type="module">
+        window.adminc = window.adminc || {};
+
+        if (!window.adminc.personSuggestionHelpers) {
+            const reasonLabels = {
+                email: 'E-mail',
+                phone: 'Telefoon',
+                last_name: 'Achternaam',
+                first_name_similar: 'Voornaam lijkt',
+                first_name_differs: 'Voornaam verschilt',
+                dob: 'Geboortedatum',
+                postal_code: 'Postcode',
+            };
+
+            window.adminc.personSuggestionHelpers = {
+                isStrongSuggestion(person) {
+                    const reasons = person?.match_reasons || [];
+                    return reasons.includes('email') || reasons.includes('phone');
+                },
+
+                suggestionReasonLabel(reason) {
+                    return reasonLabels[reason] || reason;
+                },
+
+                personSuggestionSections(suggestions) {
+                    const items = suggestions || [];
+                    const strong = items.filter((s) => this.isStrongSuggestion(s));
+                    const possible = items.filter((s) => !this.isStrongSuggestion(s));
+                    if (strong.length && possible.length) {
+                        return [
+                            { key: 'strong', title: 'Waarschijnlijk dezelfde persoon', items: strong },
+                            { key: 'possible', title: 'Mogelijke matches', items: possible },
+                        ];
+                    }
+                    return [{ key: 'all', title: null, items }];
+                },
+            };
+        }
+
+        if (!window.adminc.fetchPersonSuggestionsFromFields) {
+            /**
+             * Auto-suggest persons from unsaved lead form fields (create lead).
+             * Uses the same server-side PersonSuggestionService as edit lead.
+             *
+             * @param {object} payload Lead-like fields (first_name, emails, phones, address, ...)
+             * @returns {Promise<object[]>}
+             */
+            window.adminc.fetchPersonSuggestionsFromFields = async function(payload = {}) {
+                const response = await axios.post('/admin/contacts/persons/suggest', payload);
+                const result = response?.data?.data ?? response?.data ?? [];
+                const list = Array.isArray(result) ? result : [];
+                return list
+                    .sort((a, b) => ((b.match_score_percentage || b.match_score || 0) - (a.match_score_percentage || a.match_score || 0)))
+                    .slice(0, 10);
+            };
+        }
+    </script>
+@endverbatim
+@endPushOnce

--- a/resources/views/adminc/components/person-suggestions-panel.blade.php
+++ b/resources/views/adminc/components/person-suggestions-panel.blade.php
@@ -35,3 +35,5 @@
       </li>
     </ul>
   </template>
+
+@include('adminc.components.person-suggestion-helpers')

--- a/resources/views/adminc/components/person-suggestions-panel.blade.php
+++ b/resources/views/adminc/components/person-suggestions-panel.blade.php
@@ -28,7 +28,7 @@
           </div>
         </div>
         <div class="flex items-center gap-3">
-          <span class="px-2 py-0.5 text-xs rounded-full bg-neutral-bg dark:bg-gray-800 dark:text-gray-200">@{{ Math.round(s.match_score_percentage || s._client_match || 0) }}% match</span>
+          <span class="px-2 py-0.5 text-xs rounded-full bg-neutral-bg dark:bg-gray-800 dark:text-gray-200">@{{ Math.round(s.match_score_percentage || s.match_score || 0) }}% match</span>
           <a :href="`/admin/contacts/persons/view/${s.id}`" target="_blank" rel="noopener" class="text-xs text-blue-700 underline">Bekijken</a>
           <button type="button" class="secondary-button" @click="{{ $buttonHandler ?? 'selectSuggestion' }}(s)">{{ $buttonText ?? 'Koppelen' }}</button>
         </div>

--- a/tests/Feature/Persons/PersonSuggestionSearchTest.php
+++ b/tests/Feature/Persons/PersonSuggestionSearchTest.php
@@ -385,3 +385,128 @@ test('create suggest respects individual view permission', function () {
     test()->assertEntityFound($resp, $visible->id);
     test()->assertEntityNotFound($resp, $hidden->id);
 });
+
+/**
+ * Simulate create-lead UI: strong (email/phone) first, then match_score, keep top 10
+ * (see person-suggestion-helpers.blade.php rankAndLimitSuggestions).
+ */
+function topTenPersonSuggestionsFromFields(array $payload)
+{
+    $resp = fetchPersonSuggestionsFromFields($payload);
+    $resp->assertOk();
+
+    $topTen = collect($resp->json('data'))
+        ->sort(function ($a, $b) {
+            $strong = function ($row) {
+                $reasons = $row['match_reasons'] ?? [];
+
+                return in_array('email', $reasons, true) || in_array('phone', $reasons, true) ? 1 : 0;
+            };
+
+            $strongDiff = $strong($b) <=> $strong($a);
+            if ($strongDiff !== 0) {
+                return $strongDiff;
+            }
+
+            return ($b['match_score'] ?? $b['match_score_percentage'] ?? 0)
+                <=> ($a['match_score'] ?? $a['match_score_percentage'] ?? 0);
+        })
+        ->take(10)
+        ->values();
+
+    return [$resp, $topTen];
+}
+
+test('create suggest surfaces phone match amid many last-name candidates (Mark Bulthuis)', function () {
+    $phoneMatch = makePersonSuggestionPerson([
+        'first_name' => 'Pieter',
+        'last_name'  => 'Janssen',
+        'phones'     => [['value' => '0611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    // 15+ eligible last-name + similar-first hits outrank a format-mismatched phone
+    // in calculateMatchScore (raw string compare), then UI keeps only top 10.
+    for ($i = 0; $i < 15; $i++) {
+        makePersonSuggestionPerson([
+            'first_name' => 'Mark',
+            'last_name'  => 'Bulthuis',
+            'phones'     => [],
+            'emails'     => [],
+        ]);
+    }
+
+    [$resp, $topTen] = topTenPersonSuggestionsFromFields([
+        'first_name' => 'Mark',
+        'last_name'  => 'Bulthuis',
+        'phones'     => [['value' => '+31611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    // Full API list should include the phone match (PersonSuggestionService finds by phone).
+    test()->assertEntityFound($resp, $phoneMatch->id);
+
+    $phoneRow = collect($resp->json('data'))->firstWhere('id', $phoneMatch->id);
+    expect($phoneRow['match_reasons'])->toContain(PersonSuggestionService::REASON_PHONE);
+
+    // Phone formats differ (E.164 vs local) — scoring must still treat them as a match
+    // so the strong phone signal is not buried under name-only candidates.
+    expect($phoneRow['match_score'])->toBeGreaterThan(0);
+
+    // UI only shows top 10 by match_score — phone match must survive crowding.
+    expect($topTen->pluck('id')->all())->toContain($phoneMatch->id);
+});
+
+test('create suggest finds exact Mark Bulthuis with matching phone when all three filled', function () {
+    $match = makePersonSuggestionPerson([
+        'first_name' => 'Mark',
+        'last_name'  => 'Bulthuis',
+        'phones'     => [['value' => '+31611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    for ($i = 0; $i < 15; $i++) {
+        makePersonSuggestionPerson([
+            'first_name' => 'Mark'.$i,
+            'last_name'  => 'Bulthuis',
+            'phones'     => [],
+        ]);
+    }
+
+    [$resp, $topTen] = topTenPersonSuggestionsFromFields([
+        'first_name' => 'Mark',
+        'last_name'  => 'Bulthuis',
+        'phones'     => [['value' => '+31611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    expect($topTen->pluck('id')->all())->toContain($match->id);
+
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_PHONE)
+        ->and($row['match_reasons'])->toContain(PersonSuggestionService::REASON_LAST_NAME)
+        ->and($row['match_reasons'])->toContain(PersonSuggestionService::REASON_FIRST_NAME_SIMILAR);
+});
+
+test('create suggest finds phone-only match when last_name cleared (control)', function () {
+    $phoneMatch = makePersonSuggestionPerson([
+        'first_name' => 'Pieter',
+        'last_name'  => 'Janssen',
+        'phones'     => [['value' => '0611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    for ($i = 0; $i < 15; $i++) {
+        makePersonSuggestionPerson([
+            'first_name' => 'Crowd'.$i,
+            'last_name'  => 'Bulthuis',
+        ]);
+    }
+
+    [$resp, $topTen] = topTenPersonSuggestionsFromFields([
+        'first_name' => 'Mark',
+        'last_name'  => '',
+        'phones'     => [['value' => '+31611251149', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $phoneMatch->id);
+    expect($topTen->pluck('id')->all())->toContain($phoneMatch->id);
+    expect(collect($resp->json('data'))->firstWhere('id', $phoneMatch->id)['match_reasons'])
+        ->toContain(PersonSuggestionService::REASON_PHONE);
+});

--- a/tests/Feature/Persons/PersonSuggestionSearchTest.php
+++ b/tests/Feature/Persons/PersonSuggestionSearchTest.php
@@ -237,3 +237,151 @@ test('auto-suggest respects individual view permission', function () {
     test()->assertEntityFound($resp, $visible->id);
     test()->assertEntityNotFound($resp, $hidden->id);
 });
+
+function fetchPersonSuggestionsFromFields(array $payload)
+{
+    return test()->postJson(route('admin.contacts.persons.suggest'), $payload);
+}
+
+test('create suggest finds person when phone formats differ (06 vs +31)', function () {
+    $match = makePersonSuggestionPerson([
+        'first_name' => 'Jan',
+        'last_name'  => 'Visser',
+        'phones'     => [['value' => '+31612345678', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name' => 'Johannes',
+        'last_name'  => 'Visser',
+        'phones'     => [['value' => '0612345678', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_PHONE)
+        ->and($row['match_score'])->toBeGreaterThan(0);
+});
+
+test('create suggest finds person when phone is stored as local and payload uses e164', function () {
+    $match = makePersonSuggestionPerson([
+        'first_name' => 'Jan',
+        'last_name'  => 'De Vries',
+        'phones'     => [['value' => '0687654321', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name' => 'Johannes',
+        'last_name'  => 'De Vries',
+        'phones'     => [['value' => '+31687654321', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_PHONE);
+});
+
+test('create suggest finds person by email with different first name', function () {
+    $match = makePersonSuggestionPerson([
+        'first_name' => 'Jan',
+        'last_name'  => 'Jansen',
+        'emails'     => [['value' => 'jansen@example.com', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name' => 'Johannes',
+        'last_name'  => 'Jansen',
+        'emails'     => [['value' => 'jansen@example.com', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_EMAIL)
+        ->and($row['match_reasons'])->toContain(PersonSuggestionService::REASON_FIRST_NAME_DIFFERS);
+});
+
+test('create suggest finds last-name match with same date of birth', function () {
+    $match = makePersonSuggestionPerson([
+        'first_name'    => 'Piet',
+        'last_name'     => 'Jansen',
+        'date_of_birth' => '1984-05-17',
+    ]);
+
+    makePersonSuggestionPerson([
+        'first_name' => 'Klaas',
+        'last_name'  => 'Jansen',
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name'    => 'Linda',
+        'last_name'     => 'Jansen',
+        'date_of_birth' => '1984-05-17',
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_DOB);
+
+    test()->assertEntityNotFound($resp, Person::query()->where('first_name', 'Klaas')->first()->id);
+});
+
+test('create suggest finds last-name match with same postal code', function () {
+    $personAddress = Address::factory()->create(['postal_code' => '1234 AB', 'house_number' => '12']);
+
+    $match = makePersonSuggestionPerson([
+        'first_name' => 'Piet',
+        'last_name'  => 'Groot',
+        'address_id' => $personAddress->id,
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name' => 'Linda',
+        'last_name'  => 'Groot',
+        'address'    => ['postal_code' => '1234AB', 'house_number' => '10'],
+    ]);
+
+    test()->assertEntityFound($resp, $match->id);
+    $row = collect($resp->json('data'))->firstWhere('id', $match->id);
+    expect($row['match_reasons'])->toContain(PersonSuggestionService::REASON_POSTAL_CODE);
+});
+
+test('create suggest returns empty list for empty payload', function () {
+    makePersonSuggestionPerson([
+        'first_name' => 'Jan',
+        'last_name'  => 'Niemand',
+        'phones'     => [['value' => '0611111111', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([]);
+
+    $resp->assertOk();
+    expect($resp->json('data'))->toBe([]);
+});
+
+test('create suggest respects individual view permission', function () {
+    $otherUser = User::factory()->create(['view_permission' => 'global']);
+    $this->user->update(['view_permission' => 'individual']);
+    $this->actingAs($this->user->fresh(), 'user');
+
+    $visible = makePersonSuggestionPerson([
+        'first_name' => 'Eva',
+        'last_name'  => 'Kuijer',
+        'emails'     => [['value' => 'eva.create@example.com', 'label' => ContactLabel::Eigen->value]],
+        'user_id'    => $this->user->id,
+    ]);
+
+    $hidden = makePersonSuggestionPerson([
+        'first_name' => 'Eva',
+        'last_name'  => 'Kuijer',
+        'emails'     => [['value' => 'eva.create@example.com', 'label' => ContactLabel::Eigen->value]],
+        'user_id'    => $otherUser->id,
+    ]);
+
+    $resp = fetchPersonSuggestionsFromFields([
+        'first_name' => 'Eva',
+        'last_name'  => 'Kuijer',
+        'emails'     => [['value' => 'eva.create@example.com', 'label' => ContactLabel::Eigen->value]],
+    ]);
+
+    test()->assertEntityFound($resp, $visible->id);
+    test()->assertEntityNotFound($resp, $hidden->id);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
,

## Description
Create-lead “Mogelijke matches gevonden” used a separate, weaker path (advanced person search + client-side scoring). That missed phone matches across format variants (`06` vs `+31`) and lacked `match_reasons` / strong-vs-possible sections.

This change unifies create with edit:

- New `POST /admin/contacts/persons/suggest` builds an unsaved `Lead::make(...)` from form fields and runs the same `PersonSuggestionService` + `calculateMatchScore` as edit (`?lead_id=`).
- Create UI posts form fields (name, emails, phones, DOB, address) instead of `fetchPersons` + client score.
- Shared JS helpers for reason labels and strong/possible sections.
- Strong (email/phone) matches are ranked above name-only hits; phone/email scoring uses normalizers so format variants boost the score.
- Docs updated for create/edit parity.
- Cleanup: removed `fetchPersons` console.log and legacy `_client_match` fallback.

## How To Test This?
1. Automated: `php artisan test --filter=PersonSuggestion` — **18 passed**.
2. Manual create lead: Mark / Bulthuis / `+31611251149` → match appears.
3. Manual edit lead (no linked persons): confirm existing auto-suggest still works.

## Documentation
- [x] Docs updated in-repo (`leads.adoc`, `contact-matcher.adoc`, lead-aanmaken manual).

## Branch Selection
- Target Branch: `development`

## Tailwind Reordering
N/A (Blade/PHP/docs; no new Tailwind class sets).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ad751c6-774d-4768-8024-a79dfb254bf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad751c6-774d-4768-8024-a79dfb254bf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

