### PR TITLE
fix(uitests): align lead create person suggestion with suggest API

### DIFF
--- a/UiTests/Features/LeadCreation.feature
+++ b/UiTests/Features/LeadCreation.feature
@@ -13,7 +13,7 @@ Feature: Lead aanmaken
 
     Scenario: Aanmaken van lead met een person te kiezen in stap 1
         Given I open the lead create page
-        When I select the first person suggestion for query "test"
+        When I select the first person suggestion for first name "CI Test" and last name "PersonOne"
         And I go to step 2
         And I fill the required lead fields
         And I save the lead

--- a/UiTests/Steps/LeadCreationSteps.cs
+++ b/UiTests/Steps/LeadCreationSteps.cs
@@ -33,20 +33,28 @@ namespace UiTests.Steps
             await Assertions.Expect(_driver.Page.GetByText("Lead gegevens", new() { Exact = true })).ToBeVisibleAsync();
         }
 
-        [When(@"I select the first person suggestion for query ""(.*)""")]
-        public async Task WhenISelectFirstPersonForQuery(string query)
+        [When(@"I select the first person suggestion for first name ""(.*)"" and last name ""(.*)""")]
+        public async Task WhenISelectFirstPersonSuggestionForFirstAndLastName(string firstNameValue, string lastNameValue)
         {
-            // New flow: trigger suggestions by filling a field and blurring
+            // Person suggestions on create use PersonSuggestionService and need last name
+            // (and/or email/phone). Filling only first name yields no matches.
             var firstName = _driver.Page.Locator("input[name=first_name]");
+            var lastName = _driver.Page.Locator("input[name=last_name]");
+
             if (await firstName.CountAsync() > 0)
             {
-                await firstName.FillAsync(query);
-                await firstName.BlurAsync();
+                await firstName.FillAsync(firstNameValue);
             }
 
-            // Wait for right-hand suggestions panel
+            if (await lastName.CountAsync() > 0)
+            {
+                await lastName.FillAsync(lastNameValue);
+                await lastName.BlurAsync();
+            }
+
+            // Wait for right-hand suggestions panel (debounce 300ms + suggest API)
             var suggestionsHeader = _driver.Page.GetByText("Mogelijke matches gevonden").First;
-            await suggestionsHeader.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+            await suggestionsHeader.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 30000 });
 
             // Click first Koppelen
             var firstLinkButton = _driver.Page.Locator("button:has-text('Koppelen')").First;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
,

## Description
Na de unify van create/edit person suggestions faalde de UI-test `Aanmaken van lead met een person te kiezen in stap 1`: die vulde alleen `first_name` met `"test"`, terwijl `PersonSuggestionService` last name / email / phone nodig heeft.

De scenario-step vult nu voornaam **CI Test** en achternaam **PersonOne** (zelfde data als `I ensure two test persons exist`) en triggert suggesties via blur op achternaam.

## How To Test This?
1. Run UI test feature `Lead aanmaken` / scenario met person kiezen.
2. Of handmatig: create lead → vul CI Test + PersonOne → panel “Mogelijke matches gevonden” → Koppelen.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- Target Branch: `development`

## Tailwind Reordering
N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ad751c6-774d-4768-8024-a79dfb254bf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad751c6-774d-4768-8024-a79dfb254bf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

